### PR TITLE
Optimized ports reset

### DIFF
--- a/core/platform.h
+++ b/core/platform.h
@@ -177,9 +177,15 @@ extern int lf_cond_timedwait(lf_cond_t* cond, lf_mutex_t* mutex, instant_t absol
  */
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
 // Assume that an integer is 32 bits.
-#define lf_atomic_fetch_add(x, addend) InterlockedExchangeAdd(x, addend)
+#define lf_atomic_fetch_add(ptr, value) \
+do { \
+    InterlockedExchangeAdd(ptr, value); \
+} while(0)
 #elif defined(__GNUC__) || defined(__clang__)
-#define lf_atomic_fetch_add(x, addend) __sync_fetch_and_add(x, addend)
+#define lf_atomic_fetch_add(ptr, value) \
+do { \
+    __sync_fetch_and_add(ptr, value); \
+} while(0)
 #else
 #error "Compiler not supported"
 #endif

--- a/core/platform.h
+++ b/core/platform.h
@@ -175,17 +175,11 @@ extern int lf_cond_timedwait(lf_cond_t* cond, lf_mutex_t* mutex, instant_t absol
  * @param addend the value to be added to x.
  * @return the original value of x, from before addend was added.
  */
-int lf_atomic_fetch_add(int* x, int addend);
-
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
-int lf_atomic_fetch_add(int* x, int addend) {
-    // Assume that an integer is 32 bits.
-    return InterlockedExchangeAdd(x, addend);
-}
+// Assume that an integer is 32 bits.
+#define lf_atomic_fetch_add(x, addend) InterlockedExchangeAdd(x, addend)
 #elif defined(__GNUC__) || defined(__clang__)
-int lf_atomic_fetch_add(int* x, int addend) {
-    return __sync_fetch_and_add(x, addend);
-}
+#define lf_atomic_fetch_add(x, addend) __sync_fetch_and_add(x, addend)
 #else
 #error "Compiler not supported"
 #endif

--- a/core/platform.h
+++ b/core/platform.h
@@ -177,15 +177,9 @@ extern int lf_cond_timedwait(lf_cond_t* cond, lf_mutex_t* mutex, instant_t absol
  */
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
 // Assume that an integer is 32 bits.
-#define lf_atomic_fetch_add(ptr, value) \
-do { \
-    InterlockedExchangeAdd(ptr, value); \
-} while(0)
+#define lf_atomic_fetch_add(ptr, value) InterlockedExchangeAdd(ptr, value)
 #elif defined(__GNUC__) || defined(__clang__)
-#define lf_atomic_fetch_add(ptr, value) \
-do { \
-    __sync_fetch_and_add(ptr, value); \
-} while(0)
+#define lf_atomic_fetch_add(ptr, value) __sync_fetch_and_add(ptr, value)
 #else
 #error "Compiler not supported"
 #endif

--- a/core/platform.h
+++ b/core/platform.h
@@ -170,10 +170,10 @@ extern int lf_cond_wait(lf_cond_t* cond, lf_mutex_t* mutex);
 extern int lf_cond_timedwait(lf_cond_t* cond, lf_mutex_t* mutex, instant_t absolute_time_ns);
 
 /*
- * Atomically add addend to x and return the original value held by x.
- * @param x the value to be accessed.
- * @param addend the value to be added to x.
- * @return the original value of x, from before addend was added.
+ * Atomically increment the variable that ptr points to by the given value, and return the original value of the variable.
+ * @param ptr A pointer to a variable. The value of this variable will be replaced with the result of the operation.
+ * @param value The value to be added to the variable pointed to by the ptr parameter.
+ * @return The original value of the variable that ptr points to (i.e., from before the application of this operation).
  */
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
 // Assume that an integer is 32 bits.

--- a/core/platform.h
+++ b/core/platform.h
@@ -169,6 +169,27 @@ extern int lf_cond_wait(lf_cond_t* cond, lf_mutex_t* mutex);
  */
 extern int lf_cond_timedwait(lf_cond_t* cond, lf_mutex_t* mutex, instant_t absolute_time_ns);
 
+/*
+ * Atomically add addend to x and return the original value held by x.
+ * @param x the value to be accessed.
+ * @param addend the value to be added to x.
+ * @return the original value of x, from before addend was added.
+ */
+int lf_atomic_fetch_add(int* x, int addend);
+
+#if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
+int lf_atomic_fetch_add(int* x, int addend) {
+    // Assume that an integer is 32 bits.
+    return InterlockedExchangeAdd(x, addend);
+}
+#elif defined(__GNUC__) || defined(__clang__)
+int lf_atomic_fetch_add(int* x, int addend) {
+    return __sync_fetch_and_add(x, addend);
+}
+#else
+#error "Compiler not supported"
+#endif
+
 #endif
 
 /**

--- a/core/reactor.c
+++ b/core/reactor.c
@@ -92,6 +92,22 @@ trigger_handle_t _lf_schedule_copy(void* action, interval_t offset, void* value,
     return schedule_token(action, offset, token);
 }
 
+/*
+ * Mark the given is_present field as true. This is_present field
+ * will later be cleaned up by _lf_start_time_step.
+ * This assumes that the mutex is not held.
+ * @param is_present_field A pointer to the is_present field that
+ * must be set.
+ */
+void _lf_set_present(bool* is_present_field) {
+    if (_lf_is_present_fields_abbreviated_size < _lf_is_present_fields_size) {
+        _lf_is_present_fields_abbreviated[_lf_is_present_fields_abbreviated_size]
+            = is_present_field;
+    }
+    _lf_is_present_fields_abbreviated_size++;
+    *is_present_field = true;
+}
+
 /**
  * Advance logical time to the lesser of the specified time or the
  * timeout time, if a timeout time has been given. If the -fast command-line option

--- a/core/reactor.c
+++ b/core/reactor.c
@@ -92,7 +92,7 @@ trigger_handle_t _lf_schedule_copy(void* action, interval_t offset, void* value,
     return schedule_token(action, offset, token);
 }
 
-/*
+/**
  * Mark the given is_present field as true. This is_present field
  * will later be cleaned up by _lf_start_time_step.
  * This assumes that the mutex is not held.

--- a/core/reactor.h
+++ b/core/reactor.h
@@ -84,6 +84,8 @@
 // problems with if ... else statements that do not use braces around the
 // two branches.
 
+void _lf_set_present(bool* is_present_field);
+
 /**
  * Set the specified output (or input of a contained reactor)
  * to the specified value.

--- a/core/reactor.h
+++ b/core/reactor.h
@@ -101,7 +101,7 @@
 #define _LF_SET(out, val) \
 do { \
     out->value = val; \
-    out->is_present = true; \
+    _lf_set_present(&out->is_present); \
 } while(0)
 
 /**
@@ -120,7 +120,7 @@ do { \
 #ifndef __cplusplus
 #define _LF_SET_ARRAY(out, val, element_size, length) \
 do { \
-    out->is_present = true; \
+    _lf_set_present(&out->is_present); \
     lf_token_t* token = _lf_initialize_token_with_value(out->token, val, length); \
     token->ref_count = out->num_destinations; \
     out->token = token; \
@@ -129,7 +129,7 @@ do { \
 #else
 #define _LF_SET_ARRAY(out, val, element_size, length) \
 do { \
-    out->is_present = true; \
+    _lf_set_present(&out->is_present); \
     lf_token_t* token = _lf_initialize_token_with_value(out->token, val, length); \
     token->ref_count = out->num_destinations; \
     out->token = token; \
@@ -154,7 +154,7 @@ do { \
 #ifndef __cplusplus
 #define _LF_SET_NEW(out) \
 do { \
-    out->is_present = true; \
+    _lf_set_present(&out->is_present); \
     lf_token_t* token = _lf_set_new_array_impl(out->token, 1, out->num_destinations); \
     out->value = token->value; \
     out->token = token; \
@@ -162,7 +162,7 @@ do { \
 #else
 #define _LF_SET_NEW(out) \
 do { \
-    out->is_present = true; \
+    _lf_set_present(&out->is_present); \
     lf_token_t* token = _lf_set_new_array_impl(out->token, 1, out->num_destinations); \
     out->value = static_cast<decltype(out->value)>(token->value); \
     out->token = token; \
@@ -185,7 +185,7 @@ do { \
 #ifndef __cplusplus
 #define _LF_SET_NEW_ARRAY(out, len) \
 do { \
-    out->is_present = true; \
+    _lf_set_present(&out->is_present); \
     lf_token_t* token = _lf_set_new_array_impl(out->token, len, out->num_destinations); \
     out->value = token->value; \
     out->token = token; \
@@ -194,7 +194,7 @@ do { \
 #else
 #define _LF_SET_NEW_ARRAY(out, len) \
 do { \
-    out->is_present = true; \
+    _lf_set_present(&out->is_present); \
     lf_token_t* token = _lf_set_new_array_impl(out->token, len, out->num_destinations); \
     out->value = static_cast<decltype(out->value)>(token->value); \
     out->token = token; \
@@ -212,7 +212,7 @@ do { \
  */
 #define _LF_SET_PRESENT(out) \
 do { \
-    out->is_present = true; \
+    _lf_set_present(&out->is_present); \
 } while(0)
 
 /**
@@ -227,21 +227,19 @@ do { \
 #ifndef __cplusplus
 #define _LF_SET_TOKEN(out, newtoken) \
 do { \
-    out->is_present = true; \
+    _lf_set_present(&out->is_present); \
     out->value = newtoken->value; \
     out->token = newtoken; \
     newtoken->ref_count += out->num_destinations; \
-    out->is_present = true; \
     out->length = newtoken->length; \
 } while(0)
 #else
 #define _LF_SET_TOKEN(out, newtoken) \
 do { \
-    out->is_present = true; \
+    _lf_set_present(&out->is_present); \
     out->value = static_cast<decltype(out->value)>(newtoken->value); \
     out->token = newtoken; \
     newtoken->ref_count += out->num_destinations; \
-    out->is_present = true; \
     out->length = newtoken->length; \
 } while(0)
 #endif

--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -440,21 +440,6 @@ void _lf_start_time_step() {
     _lf_is_present_fields_abbreviated_size = 0;
 }
 
-/*
- * Mark the given is_present field as true. This is_present field
- * will later be cleaned up by _lf_start_time_step.
- * @param is_present_field A pointer to the is_present field that
- * must be set.
- */
-void _lf_set_present(bool* is_present_field) {
-    if (_lf_is_present_fields_abbreviated_size < _lf_is_present_fields_size) {
-        _lf_is_present_fields_abbreviated[_lf_is_present_fields_abbreviated_size]
-            = is_present_field;
-    }
-    _lf_is_present_fields_abbreviated_size++;
-    *is_present_field = true;
-}
-
 /**
  * Create a new lf_token_t struct and initialize it for assignment to a trigger.
  * The value pointer will be NULL and the length will be 0.

--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -428,6 +428,8 @@ void _lf_start_time_step() {
         // indicates that it has never been set.
         *_lf_intended_tag_fields[i] = (tag_t) {NEVER, 0};
     }
+#endif
+#ifdef FEDERATED
     // Reset absent fields on network ports because
     // their status is unknown
     reset_status_fields_on_input_port_triggers();

--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -85,12 +85,15 @@ bool keepalive_specified = false;
 bool** _lf_is_present_fields = NULL;
 int _lf_is_present_fields_size = 0;
 
-// Define an array of pointers to those particular _is_present fields
-// that need to be reinitialized at the start of the next time step.
-// NOTE: If the same fields are repeatedly set to present at the same
-// time step, then it is possible that _lf_is_present_fields_abbreviated
-// will run out of space, in which case it is necessary to fall back to
-// _lf_is_present_fields to determine which fields to reset.
+// Define an array of pointers to the _is_present fields
+// that have been set to true during the execution of a tag
+// so that at the conclusion of the tag, these fields can be reset to
+// false. Usually, this list will have fewer records than will
+// _lf_is_present_fields, allowing for some time to be saved.
+// However, it is possible for it to have more records if some ports
+// are set multiple times at the same tag. In such cases, we fall back
+// to resetting all is_present fields at the start of the next time
+// step.
 bool** _lf_is_present_fields_abbreviated = NULL;
 int _lf_is_present_fields_abbreviated_size = 0;
 

--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -421,13 +421,13 @@ void _lf_start_time_step() {
     }
     for(int i = 0; i < size; i++) {
         *is_present_fields[i] = false;
+    }
 #ifdef FEDERATED_DECENTRALIZED
+    for (int i = 0; i < _lf_is_present_fields_size; i++) {
         // FIXME: For now, an intended tag of (NEVER, 0)
         // indicates that it has never been set.
-        *is_present_fields[i] = (tag_t) {NEVER, 0};
-#endif
+        *_lf_intended_tag_fields[i] = (tag_t) {NEVER, 0};
     }
-#ifdef FEDERATED
     // Reset absent fields on network ports because
     // their status is unknown
     reset_status_fields_on_input_port_triggers();

--- a/core/reactor_threaded.c
+++ b/core/reactor_threaded.c
@@ -359,6 +359,24 @@ trigger_handle_t _lf_schedule_value(void* action, interval_t extra_delay, void* 
     return return_value;
 }
 
+/*
+ * Mark the given is_present field as true. This is_present field
+ * will later be cleaned up by _lf_start_time_step.
+ * This assumes that the mutex is not held.
+ * @param is_present_field A pointer to the is_present field that
+ * must be set.
+ */
+void _lf_set_present(bool* is_present_field) {
+    lf_mutex_lock(&mutex);
+    if (_lf_is_present_fields_abbreviated_size < _lf_is_present_fields_size) {
+        _lf_is_present_fields_abbreviated[_lf_is_present_fields_abbreviated_size]
+            = is_present_field;
+    }
+    _lf_is_present_fields_abbreviated_size++;
+    lf_mutex_unlock(&mutex);
+    *is_present_field = true;
+}
+
 /** 
  * Placeholder for code-generated function that will, in a federated
  * execution, be used to coordinate the advancement of tag. It will notify

--- a/core/reactor_threaded.c
+++ b/core/reactor_threaded.c
@@ -367,13 +367,10 @@ trigger_handle_t _lf_schedule_value(void* action, interval_t extra_delay, void* 
  * must be set.
  */
 void _lf_set_present(bool* is_present_field) {
-    lf_mutex_lock(&mutex);
-    if (_lf_is_present_fields_abbreviated_size < _lf_is_present_fields_size) {
-        _lf_is_present_fields_abbreviated[_lf_is_present_fields_abbreviated_size]
-            = is_present_field;
+    int ipfas = lf_atomic_fetch_add(&_lf_is_present_fields_abbreviated_size, 1);
+    if (ipfas < _lf_is_present_fields_size) {
+        _lf_is_present_fields_abbreviated[ipfas] = is_present_field;
     }
-    _lf_is_present_fields_abbreviated_size++;
-    lf_mutex_unlock(&mutex);
     *is_present_field = true;
 }
 


### PR DESCRIPTION
This is an optimization that only is beneficial when the set of all `is_present` values that need to be reset at the start of the next tag is sparse (i.e., mostly `false`).

Discussion is in [the PR at the main repository](https://github.com/lf-lang/lingua-franca/pull/736).