### PR TITLE
Avoid searching reaction queue.

### DIFF
--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -1221,9 +1221,10 @@ void enqueue_network_input_control_reactions(pqueue_t *reaction_q) {
         // Reaction 0 should always be the network input control reaction
         if (get_current_port_status(i) == unknown) {
             reaction_t *reaction = _fed.triggers_for_network_input_control_reactions[i]->reactions[0];
-            if (pqueue_find_equal_same_priority(reaction_q, reaction) == NULL) {
+            if (reaction->status = inactive) {
                 reaction->is_a_control_reaction = true;
                 DEBUG_PRINT("Inserting network input control reaction on reaction queue.");
+                reaction->status = queued;
                 pqueue_insert(reaction_q, reaction);
                 mark_control_reaction_waiting(i, true);
             }
@@ -1244,9 +1245,10 @@ void enqueue_network_output_control_reactions(pqueue_t* reaction_q){
     }
     for (int i = 0; i < _fed.trigger_for_network_output_control_reactions->number_of_reactions; i++) {
         reaction_t* reaction = _fed.trigger_for_network_output_control_reactions->reactions[i];
-        if (pqueue_find_equal_same_priority(reaction_q, reaction) == NULL) {
+        if (reaction->status == inactive) {
             reaction->is_a_control_reaction = true;
             DEBUG_PRINT("Inserting network output control reaction on reaction queue.");
+            reaction->status = queued;
             pqueue_insert(reaction_q, reaction);
         }
     }

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -1221,7 +1221,7 @@ void enqueue_network_input_control_reactions(pqueue_t *reaction_q) {
         // Reaction 0 should always be the network input control reaction
         if (get_current_port_status(i) == unknown) {
             reaction_t *reaction = _fed.triggers_for_network_input_control_reactions[i]->reactions[0];
-            if (reaction->status = inactive) {
+            if (reaction->status == inactive) {
                 reaction->is_a_control_reaction = true;
                 DEBUG_PRINT("Inserting network input control reaction on reaction queue.");
                 reaction->status = queued;

--- a/core/reactor.c
+++ b/core/reactor.c
@@ -133,9 +133,10 @@ void print_snapshot() {
  */
 void _lf_enqueue_reaction(reaction_t* reaction) {
     // Do not enqueue this reaction twice.
-    if (pqueue_find_equal_same_priority(reaction_q, reaction) == NULL) {
+    if (reaction->status == inactive) {
         DEBUG_PRINT("Enqueing downstream reaction %s, which has level %lld.",
         		reaction->name, reaction->index & 0xffffLL);
+        reaction->status = queued;
         pqueue_insert(reaction_q, reaction);
     }
 }
@@ -151,6 +152,7 @@ int _lf_do_step() {
     while(pqueue_size(reaction_q) > 0) {
         // print_snapshot();
         reaction_t* reaction = (reaction_t*)pqueue_pop(reaction_q);
+        reaction->status = running;
         
         LOG_PRINT("Invoking reaction %s at elapsed logical tag (%lld, %d).",
         		reaction->name,
@@ -198,6 +200,9 @@ int _lf_do_step() {
             // reactions into the queue.
             schedule_output_reactions(reaction, 0);
         }
+        // There cannot be any subsequent events that trigger this reaction at the
+        //  current tag, so it is safe to conclude that it is now inactive.
+        reaction->status = inactive;
     }
     
     // No more reactions should be blocked at this point.

--- a/core/reactor.h
+++ b/core/reactor.h
@@ -331,6 +331,20 @@ typedef enum {no=0, token_and_value, token_only} ok_to_free_t;
 typedef enum {absent = false, present = true, unknown} port_status_t;
 
 /**
+ * Status of a given reaction at a given logical time.
+ *
+ * If a reaction is 'inactive', it is neither running nor queued.
+ * If a reaction is 'queued', it is going to be executed at the current logical time,
+ * but it has not started running yet.
+ * If a reaction is 'running', its body is being executed.
+ *
+ * @note inactive must equal zero because it should be possible to allocate a reaction
+ *  with default values using calloc.
+ * FIXME: The running state does not seem to be read.
+ */
+typedef enum {inactive = 0, queued, running} reaction_status_t;
+
+/**
  * The flag OK_TO_FREE is used to indicate whether
  * the void* in toke_t should be freed or not.
  */ 
@@ -451,7 +465,7 @@ struct reaction_t {
     bool** output_produced;   // Array of pointers to booleans indicating whether outputs were produced. COMMON.
     int* triggered_sizes;     // Pointer to array of ints with number of triggers per output. INSTANCE.
     trigger_t ***triggers;    // Array of pointers to arrays of pointers to triggers triggered by each output. INSTANCE.
-    bool running;             // Indicator that this reaction has already started executing. RUNTIME.
+    reaction_status_t status; // Indicator of whether the reaction is inactive, queued, or running. RUNTIME.
     interval_t deadline;      // Deadline relative to the time stamp for invocation of the reaction. INSTANCE.
     bool is_STP_violated;     // Indicator of STP violation in one of the input triggers to this reaction. default = false.
                               // Value of True indicates to the runtime that this reaction contains trigger(s)

--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -559,7 +559,7 @@ void _lf_pop_events() {
         for (int i = 0; i < event->trigger->number_of_reactions; i++) {
             reaction_t *reaction = event->trigger->reactions[i];
             // Do not enqueue this reaction twice.
-            if (pqueue_find_equal_same_priority(reaction_q, reaction) == NULL) {
+            if (reaction->status == inactive) {
 #ifdef FEDERATED_DECENTRALIZED
                 // In federated execution, an intended tag that is not (NEVER, 0)
                 // indicates that this particular event is triggered by a network message.
@@ -583,6 +583,7 @@ void _lf_pop_events() {
                 }
 #endif
                 DEBUG_PRINT("Enqueing reaction %s.", reaction->name);
+                reaction->status = queued;
                 pqueue_insert(reaction_q, reaction);
             } else {
                 DEBUG_PRINT("Reaction is already on the reaction_q: %s", reaction->name);
@@ -1295,8 +1296,9 @@ trigger_handle_t _lf_insert_reactions_for_trigger(trigger_t* trigger, lf_token_t
     for (int i = 0; i < trigger->number_of_reactions; i++) {
         reaction_t* reaction = trigger->reactions[i];
         // Do not enqueue this reaction twice.
-        if (pqueue_find_equal_same_priority(reaction_q, reaction) == NULL) {
+        if (reaction->status == inactive) {
             reaction->is_STP_violated = is_STP_violated;
+            reaction->status = queued;
             pqueue_insert(reaction_q, reaction);
             LOG_PRINT("Enqueued reaction %s at time %lld.", reaction->name, get_logical_time());
         }

--- a/core/reactor_threaded.c
+++ b/core/reactor_threaded.c
@@ -863,20 +863,20 @@ bool _lf_advancing_time = false;
  */
 void _lf_enqueue_reaction(reaction_t* reaction) {
     // Do not enqueue this reaction twice.
+    // Acquire the mutex lock.
+    lf_mutex_lock(&mutex);
     if (reaction != NULL && reaction->status == inactive) {
         DEBUG_PRINT("Enqueing downstream reaction %s, which has level %lld.",
         		reaction->name, reaction->index & 0xffffLL);
         reaction->status = queued;
-        // Acquire the mutex lock.
-        lf_mutex_lock(&mutex);
         pqueue_insert(reaction_q, reaction);
-        lf_mutex_unlock(&mutex);
         // NOTE: We could notify another thread so it can execute this reaction.
         // However, this notification is expensive!
         // It is now handled by schedule_output_reactions() in reactor_common,
         // which calls the _lf_notify_workers() function defined below.
         // lf_cond_signal(&reaction_q_changed);
     }
+    lf_mutex_unlock(&mutex);
 }
 
 /**


### PR DESCRIPTION
The changes in this branch allow us to avoid having to search for reactions in the reaction queue in order to determine their status.