### PR TITLE
Destructors c

### DIFF
--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -2209,6 +2209,10 @@ void terminate_execution() {
     free(_fed.inbound_socket_listeners);
     free(federation_metadata.rti_host);
     free(federation_metadata.rti_user);
+    _lf_free_all_reactors();
+    free(_lf_tokens_with_ref_count);
+    free(_lf_is_present_fields);
+    free(_lf_is_present_fields_abbreviated);
 }
 
 /** 

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -2209,10 +2209,6 @@ void terminate_execution() {
     free(_fed.inbound_socket_listeners);
     free(federation_metadata.rti_host);
     free(federation_metadata.rti_user);
-    _lf_free_all_reactors();
-    free(_lf_tokens_with_ref_count);
-    free(_lf_is_present_fields);
-    free(_lf_is_present_fields_abbreviated);
 }
 
 /** 

--- a/core/reactor.h
+++ b/core/reactor.h
@@ -548,6 +548,30 @@ struct trigger_t {
                                         // Note: The physical_time_of_arrival is only passed down one level of the hierarchy. Default: NEVER.
 #endif
 };
+
+/**
+ * An allocation record that is used by a destructor for a reactor
+ * to free memory that has been dynamically allocated for the particular
+ * instance of the reactor.  This will be an element of linked list.
+ */
+typedef struct allocation_record_t {
+	void* allocated;
+	allocation_record_t *next;
+} allocation_record_t;
+
+/**
+ * The first element of every self struct defined in generated code
+ * will be a pointer to an allocation record, which is either NULL
+ * or the head of a NULL-terminated linked list of allocation records.
+ * Casting the self struct to this type enables access to this list
+ * by the function {@link free_reactor(self_t)}. To allocate memory
+ * for the reactor that will be freed by that function, allocate the
+ * memory using {@link _lf_allocate(size_t,size_t,self_t)}.
+ */
+typedef struct self_base_t {
+	allocation_record_t *allocations;
+};
+
 //  ======== Function Declarations ========  //
 
 /**

--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -176,6 +176,7 @@ void set_federation_id(char* fid);
  */
 void* _lf_allocate(size_t count, size_t size, struct self_base_t *self) {
 	void *mem = calloc(count, size);
+    if (mem == NULL) error_print_and_exit("Out of memory!");
 	struct allocation_record_t* head = self->allocations;
 	struct allocation_record_t* record = (allocation_record_t*)calloc(1, sizeof(allocation_record_t));
 	self->allocations = record;
@@ -199,8 +200,10 @@ struct allocation_record_t *_lf_reactors_to_free = NULL;
  */
 void* _lf_new_reactor(size_t size) {
 	void* result = calloc(1, size);
+    if (result == NULL) error_print_and_exit("Out of memory!");
 	struct allocation_record_t* head = _lf_reactors_to_free;
 	struct allocation_record_t* record = (allocation_record_t*)calloc(1, sizeof(allocation_record_t));
+    if (record == NULL) error_print_and_exit("Out of memory!");
 	_lf_reactors_to_free = record;
 	record->allocated = result;
 	record->next = head;
@@ -814,6 +817,7 @@ event_t* _lf_get_new_event() {
     event_t* e = (event_t*)pqueue_pop(recycle_q);
     if (e == NULL) {
         e = (event_t*)calloc(1, sizeof(struct event_t));
+        if (e == NULL) error_print_and_exit("Out of memory!");
 #ifdef FEDERATED_DECENTRALIZED
         e->intended_tag = (tag_t) { .time = NEVER, .microstep = 0u};
 #endif
@@ -1994,4 +1998,8 @@ void termination() {
             printf("---- Elapsed physical time (in nsec): %s\n", time_buffer);
         }
     }
+    _lf_free_all_reactors();
+    free(_lf_tokens_with_ref_count);
+    free(_lf_is_present_fields);
+    free(_lf_is_present_fields_abbreviated);
 }


### PR DESCRIPTION
This PR provides generic allocate and free functions so that generated C programs now demonstrably free all allocated memory.  This should be systematically tested with `leaks`. I have checked a few tests only, and they all show no leaks.