### PR TITLE
fix port absent

### DIFF
--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -1277,7 +1277,7 @@ void enqueue_network_control_reactions(pqueue_t* reaction_q) {
     enqueue_network_output_control_reactions(reaction_q);
 #ifdef FEDERATED_CENTRALIZED
     // If the granted tag is not provisional, there is no
-    // need for network control reactions
+    // need for network input control reactions
     if (compare_tags(_fed.last_TAG, get_current_tag()) != 0
     		|| _fed.is_last_TAG_provisional == false) {
         return;

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -1274,6 +1274,7 @@ void enqueue_network_output_control_reactions(pqueue_t* reaction_q){
  * Enqueue network control reactions.
  */
 void enqueue_network_control_reactions(pqueue_t* reaction_q) {
+    enqueue_network_output_control_reactions(reaction_q);
 #ifdef FEDERATED_CENTRALIZED
     // If the granted tag is not provisional, there is no
     // need for network control reactions
@@ -1283,7 +1284,6 @@ void enqueue_network_control_reactions(pqueue_t* reaction_q) {
     }
 #endif
     enqueue_network_input_control_reactions(reaction_q);
-    enqueue_network_output_control_reactions(reaction_q);
 }
 
 /**


### PR DESCRIPTION
This PR fixes the bug where a federate in centralized coordination advance time too quickly before the RTI can send a PTAG, which prevents it from sending port absent messages to earlier tags. 