### PR TITLE
Added const to function signatures to suppress warnings.

### DIFF
--- a/core/tag.c
+++ b/core/tag.c
@@ -329,7 +329,7 @@ size_t lf_readable_time(char* buffer, instant_t time) {
 			sprintf(buffer, ", ");
 			buffer += 2;
 		}
-		char* units = "nanoseconds";
+		const char* units = "nanoseconds";
 		if (time % MSEC(1) == (instant_t) 0) {
 			units = "milliseconds";
 			time = time % MSEC(1);

--- a/core/utils/util.c
+++ b/core/utils/util.c
@@ -75,7 +75,7 @@ int get_fed_id() {
  * Internal implementation of the next few reporting functions.
  */
 void _lf_message_print(
-		int is_error, char* prefix, char* format, va_list args, int log_level
+		int is_error, const char* prefix, const char* format, va_list args, int log_level
 ) {
 	// The logging level may be set either by a LOG_LEVEL #define
 	// (which is code generated based on the logging target property)
@@ -129,7 +129,7 @@ void _lf_message_print(
  * where n is the federate ID.
  * The arguments are just like printf().
  */
-void info_print(char* format, ...) {
+void info_print(const char* format, ...) {
     va_list args;
     va_start (args, format);
     _lf_message_print(0, "", format, args, LOG_LEVEL_INFO);
@@ -144,7 +144,7 @@ void info_print(char* format, ...) {
  * where n is the federate ID.
  * The arguments are just like printf().
  */
-void log_print(char* format, ...) {
+void log_print(const char* format, ...) {
     va_list args;
     va_start (args, format);
     _lf_message_print(0, "LOG: ", format, args, LOG_LEVEL_LOG);
@@ -159,7 +159,7 @@ void log_print(char* format, ...) {
  * where n is the federate ID.
  * The arguments are just like printf().
  */
-void debug_print(char* format, ...) {
+void debug_print(const char* format, ...) {
     va_list args;
     va_start (args, format);
     _lf_message_print(0, "DEBUG: ", format, args, LOG_LEVEL_DEBUG);
@@ -170,7 +170,7 @@ void debug_print(char* format, ...) {
  * Report an error with the prefix "ERROR: " and a newline appended
  * at the end.  The arguments are just like printf().
  */
-void error_print(char* format, ...) {
+void error_print(const char* format, ...) {
     va_list args;
     va_start (args, format);
     _lf_message_print(1, "ERROR: ", format, args, LOG_LEVEL_ERROR);
@@ -181,7 +181,7 @@ void error_print(char* format, ...) {
  * Report a warning with the prefix "WARNING: " and a newline appended
  * at the end.  The arguments are just like printf().
  */
-void warning_print(char* format, ...) {
+void warning_print(const char* format, ...) {
     va_list args;
     va_start (args, format);
     _lf_message_print(1, "WARNING: ", format, args, LOG_LEVEL_WARNING);
@@ -193,7 +193,7 @@ void warning_print(char* format, ...) {
  * at the end, then exit with the failure code EXIT_FAILURE.
  * The arguments are just like printf().
  */
-void error_print_and_exit(char* format, ...) {
+void error_print_and_exit(const char* format, ...) {
     va_list args;
     va_start (args, format);
     _lf_message_print(1, "FATAL ERROR: ", format, args, LOG_LEVEL_ERROR);

--- a/core/utils/util.h
+++ b/core/utils/util.h
@@ -98,7 +98,7 @@ int get_fed_id(void);
  * where n is the federate ID.
  * The arguments are just like printf().
  */
-void info_print(char* format, ...);
+void info_print(const char* format, ...);
 
 /**
  * Report an log message on stdout with the prefix
@@ -108,7 +108,7 @@ void info_print(char* format, ...);
  * where n is the federate ID.
  * The arguments are just like printf().
  */
-void log_print(char* format, ...);
+void log_print(const char* format, ...);
 
 /**
  * A macro used to print useful logging information. It can be enabled
@@ -140,7 +140,7 @@ void log_print(char* format, ...);
  * where n is the federate ID.
  * The arguments are just like printf().
  */
-void debug_print(char* format, ...);
+void debug_print(const char* format, ...);
 
 /**
  * A macro used to print useful debug information. It can be enabled
@@ -168,26 +168,26 @@ void debug_print(char* format, ...);
  * specified message as a prefix, then exit with error code 1.
  * @param msg The prefix to the message.
  */
-void error(char *msg);
+void error(const char *msg);
 
 /**
  * Report an error with the prefix "ERROR: " and a newline appended
  * at the end.  The arguments are just like printf().
  */
-void error_print(char* format, ...);
+void error_print(const char* format, ...);
 
 /**
  * Report a warning with the prefix "WARNING: " and a newline appended
  * at the end.  The arguments are just like printf().
  */
-void warning_print(char* format, ...);
+void warning_print(const char* format, ...);
 
 /**
  * Report an error with the prefix "ERROR: " and a newline appended
  * at the end, then exit with the failure code EXIT_FAILURE.
  * The arguments are just like printf().
  */
-void error_print_and_exit(char* format, ...);
+void error_print_and_exit(const char* format, ...);
 
 /**
  * Message print function type. The arguments passed to one of
@@ -195,7 +195,7 @@ void error_print_and_exit(char* format, ...);
  * by a printf-style argument list collected into a va_list
  * (variable argument list).
  */
-typedef void(print_message_function_t)(char*, va_list);
+typedef void(print_message_function_t)(const char*, va_list);
 
 /**
  * Register a function to display messages. After calling this,

--- a/util/sensor_simulator.c
+++ b/util/sensor_simulator.c
@@ -224,7 +224,7 @@ void _lf_sensor_post_message(enum _lf_sensor_message_type type, char* body) {
  * Function to register to handle printing of messages in util.h/c.
  * This acquires the mutex lock.
  */
-void _lf_print_message_function(char* format, va_list args) {
+void _lf_print_message_function(const char* format, va_list args) {
 	if (_lf_sensor.log_file != NULL) {
 		// Write to a log file in addition to the window.
 		vfprintf(_lf_sensor.log_file, format, args);


### PR DESCRIPTION
Picky compilers issue a warning when a function `foo(char* s)` is called with a constant string, `foo("constant string");`
This PR adds `const` to a few function signatures to prevent this warning.