### PR TITLE
Surround MAX and MIN defs with ifndef to prevent annoying warnings

### DIFF
--- a/core/reactor.h
+++ b/core/reactor.h
@@ -294,10 +294,14 @@ do { \
 #define LEVEL(index) (index & 0xffffLL)
 
 /** Utility for finding the maximum of two values. */
+#ifndef MAX
 #define MAX(X, Y) (((X) > (Y)) ? (X) : (Y))
+#endif
 
 /** Utility for finding the minimum of two values. */
+#ifndef MIN
 #define MIN(X, Y) (((X) < (Y)) ? (X) : (Y))
+#endif
 
 /**
  * Macro for determining whether two reactions are in the

--- a/core/utils/util.c
+++ b/core/utils/util.c
@@ -71,6 +71,10 @@ int get_fed_id() {
 	return _lf_my_fed_id;
 }
 
+// GCC gives very annoying warnings here.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsuggest-attribute=format"
+
 /**
  * Internal implementation of the next few reporting functions.
  */
@@ -120,6 +124,8 @@ void _lf_message_print(
 		free(message);
 	}
 }
+
+#pragma GCC diagnostic pop
 
 /**
  * Report an informational message on stdout with

--- a/core/utils/util.c
+++ b/core/utils/util.c
@@ -71,10 +71,6 @@ int get_fed_id() {
 	return _lf_my_fed_id;
 }
 
-// GCC gives very annoying warnings here.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wsuggest-attribute=format"
-
 /**
  * Internal implementation of the next few reporting functions.
  */
@@ -124,8 +120,6 @@ void _lf_message_print(
 		free(message);
 	}
 }
-
-#pragma GCC diagnostic pop
 
 /**
  * Report an informational message on stdout with


### PR DESCRIPTION
I frequently get very annoying warnings because reactor.h defines MAX and MIN macros (which appear to be nowhere used).  Someone wanted them there, so I suggest we keep them, but surround them with ifndef.  That is what this PR does.