### PR TITLE
Add checks for `token->ok_to_free` before freeing the token's value

### DIFF
--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -378,9 +378,9 @@ token_freed _lf_done_using(lf_token_t* token) {
     if (token->ref_count == 0) {
         if (token->value != NULL) {
             // Count frees to issue a warning if this is never freed.
-            // Do not free the value field if it is garbage collected.
+            // Do not free the value field if it is garbage collected and token's ok_to_free field is not "token_and_value".
             _lf_count_payload_allocations--;
-            if(OK_TO_FREE != token_only) {
+            if(OK_TO_FREE != token_only && token->ok_to_free == token_and_value) {
                 DEBUG_PRINT("_lf_done_using: Freeing allocated memory for payload (token value): %p", token->value);
                 free(token->value);
             }


### PR DESCRIPTION
Soroush and I noticed that `token->ok_to_free` field is not checked before freeing the token's value (currently, token's value is always freed).

We ran into this issue because we used `shared_ptr` as the type of an action. Shared pointers are freed automatically, but our runtime also tries to free it at the start of the next time step. This creates a double free issue and causes a segfault. 

For now, we manually set `token->ok_to_free` to be `token_only` for the shared pointer physical action.
In the future, we could pattern match the type of actions and set `token->ok_to_free` to `token_only` automatically in `initialize_trigger_objects`. 