### PR TITLE
Hashmap

### DIFF
--- a/core/utils/hashmap.c
+++ b/core/utils/hashmap.c
@@ -3,12 +3,13 @@
  * @brief Defines a generic, non-resizing hashmap data type.
  *
  * Hashmaps are defined by redefining K, V, HASH_OF, and HASHMAP, and including this file. A default
- * hashmap type is defined in hashmap.h. See hashmap.h a
+ * hashmap type is defined in hashmap.h. See hashmap.h for an example of a hashmap declaration.
  * - K and V must be the types of keys and values of the hashmap, respectively.
  * - HASH_OF must be the hash of a key.
- * - HASHMAP must be a function-like macro that prefixes tokens with the name of the hashmap.
- *   For example, the hashmap data type is named HASHMAP(t) so that it is "t" prefixed with the
- *   name of the hashmap, and the function names associated with the data type are similar.
+ * - HASHMAP must be a function-like macro that prefixes tokens with the name of the hashmap. For
+ *   example, the name of the hashmap data type is given by evaluation of the macro HASHMAP(t) so
+ *   that it is "t" prefixed with the name of the hashmap. The function names associated with the
+ *   data type are similar.
  */
 
 #ifndef K

--- a/core/utils/hashmap.c
+++ b/core/utils/hashmap.c
@@ -1,11 +1,14 @@
 /**
  * @author Peter Donovan (peterdonovan@berkeley.edu)
  * @brief Defines a generic, non-resizing hashmap data type.
- * 
- * Hashmaps are defined by redefining K, V, HASH_OF, and HASHMAP and including this file.
- * HASHMAP must be a function-like macro that prefixes tokens with the name of the hashmap.
- * For example, the hashmap data type is named HASHMAP(t) so that it is "t" prefixed with
- * the name of the hashmap, and the function names associated with the data type are similar.
+ *
+ * Hashmaps are defined by redefining K, V, HASH_OF, and HASHMAP, and including this file. A default
+ * hashmap type is defined in hashmap.h. See hashmap.h a
+ * - K and V must be the types of keys and values of the hashmap, respectively.
+ * - HASH_OF must be the hash of a key.
+ * - HASHMAP must be a function-like macro that prefixes tokens with the name of the hashmap.
+ *   For example, the hashmap data type is named HASHMAP(t) so that it is "t" prefixed with the
+ *   name of the hashmap, and the function names associated with the data type are similar.
  */
 
 #ifndef K
@@ -49,13 +52,16 @@ typedef struct HASHMAP(t) {
  */
 HASHMAP(t)* HASHMAP(new)(size_t capacity, K nothing);
 
-/**
- * @brief Free the given hashmap.
- */
+/** @brief Free all memory used by the given hashmap. */
 void HASHMAP(free)(HASHMAP(t)* hashmap);
 
+/** @brief Associate a value with the given key. */
 void HASHMAP(put)(HASHMAP(t)* hashmap, K key, V value);
 
+/**
+ * @brief Get the value associated with the given key.
+ * Precondition: The key must be present in the map.
+ */
 V HASHMAP(get)(HASHMAP(t)* hashmap, K key);
 
 /////////////////////////// Private helpers ///////////////////////////
@@ -102,7 +108,8 @@ HASHMAP(t)* HASHMAP(new)(size_t capacity, K nothing) {
     ret->entries = entries;
     ret->capacity = capacity;
     ret->num_entries = 0;
-    // A second nothing will be required if removal is to be supported.
+    // A second nothing may be required if removal is to be supported and we want to make removal
+    // a constant-time operation.
     ret->nothing = nothing;
     return ret;
 }

--- a/core/utils/hashmap.c
+++ b/core/utils/hashmap.c
@@ -1,0 +1,127 @@
+/**
+ * @author Peter Donovan (peterdonovan@berkeley.edu)
+ * @brief Defines a generic, non-resizing hashmap data type.
+ * 
+ * Hashmaps are defined by redefining K, V, HASH_OF, and HASHMAP and including this file.
+ * HASHMAP must be a function-like macro that prefixes tokens with the name of the hashmap.
+ * For example, the hashmap data type is named HASHMAP(t) so that it is "t" prefixed with
+ * the name of the hashmap, and the function names associated with the data type are similar.
+ */
+
+#ifndef K
+#define K void*
+#endif
+#ifndef V
+#define V void*
+#endif
+#ifndef HASH_OF
+#define HASH_OF(key) (size_t) key
+#endif
+#ifndef HASHMAP
+#define HASHMAP(token) hashmap ## _ ## token
+#endif
+
+#include <stddef.h>
+#include <assert.h>
+#include <stdbool.h>
+
+////////////////////////// Type definitions ///////////////////////////
+
+typedef struct HASHMAP(entry_t) {
+    K key;
+    V value;
+} HASHMAP(entry_t);
+
+typedef struct HASHMAP(t) {
+    HASHMAP(entry_t)* entries;
+    size_t capacity;
+    size_t num_entries;
+    K nothing;
+} HASHMAP(t);
+
+//////////////////////// Function declarations ////////////////////////
+
+/**
+ * @brief Construct a new hashmap object.
+ * @param capacity A number that is much larger than the maximum number of items that this
+ * hashmap will contain. Insufficient surplus capacity will cause poor performance.
+ * @param nothing A key that is guaranteed never to be used.
+ */
+HASHMAP(t)* HASHMAP(new)(size_t capacity, K nothing);
+
+/**
+ * @brief Free the given hashmap.
+ */
+void HASHMAP(free)(HASHMAP(t)* hashmap);
+
+void HASHMAP(put)(HASHMAP(t)* hashmap, K key, V value);
+
+V HASHMAP(get)(HASHMAP(t)* hashmap, K key);
+
+/////////////////////////// Private helpers ///////////////////////////
+
+static HASHMAP(entry_t)* HASHMAP(get_ideal_address)(HASHMAP(t)* hashmap, K key) {
+    HASHMAP(entry_t)* address = hashmap->entries + (HASH_OF(key) % hashmap->capacity);
+    assert(address >= hashmap->entries);
+    assert(address < hashmap->entries + hashmap->capacity);
+    return address;
+}
+
+/**
+ * @brief Return the actual address of the hashmap entry corresponding to `key`, or the address of
+ * the closest empty entry if no such entry exists.
+ * @param key The key from which to begin a search.
+ * @param desired The key that the desired returnable entry should have.
+ */
+static HASHMAP(entry_t)* HASHMAP(get_actual_address)(HASHMAP(t)* hashmap, K key) {
+    HASHMAP(entry_t)* address = HASHMAP(get_ideal_address)(hashmap, key);
+    HASHMAP(entry_t)* upper_limit = hashmap->entries + hashmap->capacity;
+    while ((address->key != hashmap->nothing) & (address->key != key)) address++;
+    if (address == upper_limit) {
+        address = hashmap->entries;
+        while ((address->key != hashmap->nothing) & (address->key != key)) address++;
+        if (address == upper_limit) return NULL;
+    }
+    assert(address->key == key || address->key == hashmap->nothing);
+    return address;
+}
+
+//////////////////////// Function definitions /////////////////////////
+
+HASHMAP(t)* HASHMAP(new)(size_t capacity, K nothing) {
+    HASHMAP(entry_t)* entries = (HASHMAP(entry_t)*) malloc(
+        (capacity + 1) * sizeof(HASHMAP(entry_t))
+    );
+    if (!entries) exit(1);
+    HASHMAP(t)* ret = (HASHMAP(t)*) malloc(sizeof(HASHMAP(t)));
+    if (!ret) exit(1);
+    // The entry at the end is used as a boundary. It will never again be written to.
+    for (size_t i = 0; i < capacity + 1; i++) {
+        entries[i].key = nothing;
+    }
+    ret->entries = entries;
+    ret->capacity = capacity;
+    ret->num_entries = 0;
+    // A second nothing will be required if removal is to be supported.
+    ret->nothing = nothing;
+    return ret;
+}
+
+void HASHMAP(free)(HASHMAP(t)* hashmap) {
+    free(hashmap->entries);
+    free(hashmap);
+}
+
+void HASHMAP(put)(HASHMAP(t)* hashmap, K key, V value) {
+    assert(key != hashmap->nothing);
+    assert(key >= 0);
+    HASHMAP(entry_t)* write_to = HASHMAP(get_actual_address)(hashmap, key);
+    write_to->key = key;
+    write_to->value = value;
+}
+
+V HASHMAP(get)(HASHMAP(t)* hashmap, K key) {
+    assert(key != hashmap->nothing);
+    HASHMAP(entry_t)* read_from = HASHMAP(get_actual_address)(hashmap, key);
+    return read_from->value; // Crash the program if the key cannot be found
+}

--- a/core/utils/hashmap.h
+++ b/core/utils/hashmap.h
@@ -1,7 +1,10 @@
 /**
  * @author Peter Donovan (peterdonovan@berkeley.edu)
- * @brief Defines a default hashmap type.
+ * @brief Defines a hashmap type that maps void pointers to integers.
+ *
+ * See hashmap.c for documentation on how to declare other hashmap types.
  */
+
 #define HASHMAP(token) hashmap_object2int ## _ ## token
 #define K void*
 #define V int

--- a/core/utils/hashmap.h
+++ b/core/utils/hashmap.h
@@ -1,0 +1,10 @@
+
+#define HASHMAP(token) hashmap_object2int ## _ ## token
+#define K void*
+#define V int
+#define HASH_OF(key) (size_t) key
+#include "hashmap.c"
+#undef HASHMAP
+#undef K
+#undef V
+#undef HASH_OF

--- a/core/utils/hashmap.h
+++ b/core/utils/hashmap.h
@@ -1,4 +1,7 @@
-
+/**
+ * @author Peter Donovan (peterdonovan@berkeley.edu)
+ * @brief Defines a default hashmap type.
+ */
 #define HASHMAP(token) hashmap_object2int ## _ ## token
 #define K void*
 #define V int

--- a/test/general/utils/hashmap_test.c
+++ b/test/general/utils/hashmap_test.c
@@ -15,7 +15,8 @@ static hashmap_object2int_entry_t mock[CAPACITY];
 static size_t mock_size = 0;
 
 void test_put(hashmap_object2int_t* h) {
-    void* key = (void*) rand();
+    void* key = NULL;
+    while (!key) key = (void*) (rand() % CAPACITY);
     int value = rand();
     hashmap_object2int_entry_t entry = (hashmap_object2int_entry_t) { .key = key, .value = value };
     hashmap_object2int_put(h, entry.key, entry.value);
@@ -48,7 +49,7 @@ void test_get(hashmap_object2int_t* h) {
 
 /**
  * @brief Run a randomly selected test on `h`.
- * 
+ *
  * @param h A hashmap.
  * @param distribution The desired probability distribution with
  * which each of two actions are performed, expressed as percents.
@@ -65,8 +66,6 @@ void run_test(hashmap_object2int_t* h, int* distribution) {
 }
 
 int main() {
-    // FIXME: This test is not robust! It does not rigorously test edge cases involving multiple
-    // uses of the same key.
     srand(RANDOM_SEED);
     for (int i = 0; i < N; i++) {
         int perturbed[2];

--- a/test/general/utils/hashmap_test.c
+++ b/test/general/utils/hashmap_test.c
@@ -1,0 +1,87 @@
+
+#include <stdlib.h>
+#include <stdio.h>
+#include "core/utils/hashmap.h"
+#include "rand_utils.h"
+#include "core/utils/util.h"
+
+#define CAPACITY 100
+#define N 5000
+#define RANDOM_SEED 1830
+
+static int distribution[2] = {50, 50};
+
+static hashmap_object2int_entry_t mock[CAPACITY];
+static size_t mock_size = 0;
+
+void test_put(hashmap_object2int_t* h) {
+    void* key = (void*) rand();
+    int value = rand();
+    hashmap_object2int_entry_t entry = (hashmap_object2int_entry_t) { .key = key, .value = value };
+    hashmap_object2int_put(h, entry.key, entry.value);
+    // printf("Putting (%p, %d).\n", entry.key, entry.value);
+    mock[mock_size++] = entry;
+}
+
+void test_get(hashmap_object2int_t* h) {
+    if (!mock_size) return;
+    size_t r = rand() % mock_size;
+    hashmap_object2int_entry_t desired = mock[r];
+    int found = hashmap_object2int_get(h, desired.key);
+    // printf("Getting (%p, %d) from %d.\n", desired.key, desired.value, r);
+    if (desired.value != found) {
+        // It is possible that two distinct values were associated with the same key. Search the
+        // "mock" array to check if this is the case.
+        for (size_t i = mock_size - 1; i >= 0; i--) {
+            if (mock[i].key == desired.key) {
+                if (mock[i].value == found) return; // Everything is OK.
+                break;
+            }
+        }
+        error_print_and_exit(
+            "Expected %d but got %d when getting from a hashmap.\n",
+            desired.value,
+            found
+        );
+    }
+}
+
+/**
+ * @brief Run a randomly selected test on `h`.
+ * 
+ * @param h A hashmap.
+ * @param distribution The desired probability distribution with
+ * which each of two actions are performed, expressed as percents.
+ */
+void run_test(hashmap_object2int_t* h, int* distribution) {
+    int result = 1;
+    int r = rand();
+    int choice = (r < 0 ? -r : r) % 100;
+    if ((choice = choice - distribution[0]) < 0) {
+        test_put(h);
+    } else {
+        test_get(h);
+    }
+}
+
+int main() {
+    // FIXME: This test is not robust! It does not rigorously test edge cases involving multiple
+    // uses of the same key.
+    srand(RANDOM_SEED);
+    for (int i = 0; i < N; i++) {
+        int perturbed[2];
+        perturb(distribution, 2, perturbed);
+        DEBUG_PRINT(
+            "Distribution: %d, %d",
+            perturbed[0], perturbed[1]
+        );
+        hashmap_object2int_t* h = hashmap_object2int_new(CAPACITY, NULL);
+        int j = rand() % (CAPACITY / 2);
+        while (j--) {
+            run_test(h, perturbed);
+        }
+        hashmap_object2int_free(h);
+        mock_size = 0;
+    }
+    return 0;
+}


### PR DESCRIPTION
This adds another data structure (a simple lookup table) in case it is useful, e.g. for attaching metadata to reactions or to circumstances that a scheduler might encounter at runtime. It is intended to be simple and fast with not many expensive checks. I decided to submit a PR now because the data structure was already implemented, and it would have languished in the branch it was in.

This implementation uses macros to implement generics. This makes it cumbersome and confusing, but I think this is justified by the resulting code reusability.