### PR TITLE
Fix set executing_reaction in self struct

### DIFF
--- a/core/reactor.c
+++ b/core/reactor.c
@@ -227,9 +227,7 @@ int _lf_do_step(void) {
         
         if (!violation) {
             // Invoke the reaction function.
-            tracepoint_reaction_starts(reaction, 0); // 0 indicates unthreaded.
-            reaction->function(reaction->self);
-            tracepoint_reaction_ends(reaction, 0);
+            _lf_invoke_reaction(reaction, 0);   // 0 indicates unthreaded.
 
             // If the reaction produced outputs, put the resulting triggered
             // reactions into the queue.

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -973,9 +973,7 @@ void _lf_worker_invoke_reaction(int worker_number, reaction_t* reaction) {
             reaction->name,
             current_tag.time - start_time,
             current_tag.microstep);
-    tracepoint_reaction_starts(reaction, worker_number);
-    reaction->function(reaction->self);
-    tracepoint_reaction_ends(reaction, worker_number);
+    _lf_invoke_reaction(reaction, worker_number);
 
     // If the reaction produced outputs, put the resulting triggered
     // reactions into the queue or execute them immediately.


### PR DESCRIPTION
Correctly set `self->executing_reaction` before invoking a reaction and reset it after