### PR TITLE
Update `ci.yml` to point to master branch in LF repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       cmake-args: '-DNUMBER_OF_WORKERS=4'
 
   fetch-lf:
-    uses: lf-lang/lingua-franca/.github/workflows/extract-ref.yml@more-lf-prefix
+    uses: lf-lang/lingua-franca/.github/workflows/extract-ref.yml@master
     with:
       file: 'lingua-franca-ref.txt'
   


### PR DESCRIPTION
`more-lf-prefix` branch has been deleted in the main repo.