### PR TITLE
Update the documentation of vector_at.

### DIFF
--- a/core/utils/vector.c
+++ b/core/utils/vector.c
@@ -90,6 +90,33 @@ void* vector_pop(vector_t* v) {
 }
 
 /**
+ * @brief Return a pointer of the vector element at 'idx'.
+ * 
+ * @param v Any vector.
+ * @param idx The index in the vector.
+ * 
+ * @return NULL on error. A valid pointer to the element at 'idx' otherwise.
+ */
+void** vector_at(vector_t* v, size_t idx) {
+    void** vector_position = v->start + idx;
+    if ((vector_position + 1) > v->next) {
+        v->next = vector_position + 1;
+    }
+    if (v->next >= v->end) {
+        v->votes_required++;
+        size_t new_size = (v->end - v->start) * SCALE_FACTOR;
+        // Find a size that includes idx
+        while (new_size <= idx) {
+            new_size *= SCALE_FACTOR;
+        }
+        vector_resize(v, new_size);
+    }
+    // Note: Can't re-use vector_position because v->start can move after
+    // resizing.
+    return v->start + idx;
+}
+
+/**
  * @brief Return the size of the vector.
  * 
  * @param v Any vector

--- a/core/utils/vector.c
+++ b/core/utils/vector.c
@@ -90,12 +90,17 @@ void* vector_pop(vector_t* v) {
 }
 
 /**
- * @brief Return a pointer of the vector element at 'idx'.
+ * Return a pointer to where the vector element at 'idx' is stored.
+ * This can be used to set the value of the element or to read it.
+ * If the index is past the end of the vector, then the vector
+ * is automatically expanded and filled with NULL pointers as needed.
+ * If no element at `idx` has been previously set, then the value
+ * pointed to by the returned pointer will be NULL.
  * 
- * @param v Any vector.
- * @param idx The index in the vector.
+ * @param v The vector.
+ * @param idx The index into the vector.
  * 
- * @return NULL on error. A valid pointer to the element at 'idx' otherwise.
+ * @return A pointer to the element at 'idx', which is itself a pointer.
  */
 void** vector_at(vector_t* v, size_t idx) {
     void** vector_position = v->start + idx;

--- a/core/utils/vector.c
+++ b/core/utils/vector.c
@@ -90,33 +90,6 @@ void* vector_pop(vector_t* v) {
 }
 
 /**
- * @brief Return a pointer of the vector element at 'idx'.
- * 
- * @param v Any vector.
- * @param idx The index in the vector.
- * 
- * @return NULL on error. A valid pointer to the element at 'idx' otherwise.
- */
-void** vector_at(vector_t* v, size_t idx) {
-    void** vector_position = v->start + idx;
-    if ((vector_position + 1) > v->next) {
-        v->next = vector_position + 1;
-    }
-    if (v->next >= v->end) {
-        v->votes_required++;
-        size_t new_size = (v->end - v->start) * SCALE_FACTOR;
-        // Find a size that includes idx
-        while (new_size <= idx) {
-            new_size *= SCALE_FACTOR;
-        }
-        vector_resize(v, new_size);
-    }
-    // Note: Can't re-use vector_position because v->start can move after
-    // resizing.
-    return v->start + idx;
-}
-
-/**
  * @brief Return the size of the vector.
  * 
  * @param v Any vector

--- a/core/utils/vector.h
+++ b/core/utils/vector.h
@@ -60,6 +60,16 @@ void vector_pushall(vector_t* v, void** array, size_t size);
 void* vector_pop(vector_t* v);
 
 /**
+ * @brief Return a pointer that is contained in the vector at 'idx'.
+ * 
+ * @param v Any vector.
+ * @param idx The index in the vector.
+ * 
+ * @return NULL on error. A valid pointer to the element at 'idx' otherwise.
+ */
+void** vector_at(vector_t* v, size_t idx);
+
+/**
  * @brief Return the size of the vector.
  * 
  * @param v Any vector

--- a/core/utils/vector.h
+++ b/core/utils/vector.h
@@ -60,16 +60,6 @@ void vector_pushall(vector_t* v, void** array, size_t size);
 void* vector_pop(vector_t* v);
 
 /**
- * @brief Return a pointer that is contained in the vector at 'idx'.
- * 
- * @param v Any vector.
- * @param idx The index in the vector.
- * 
- * @return NULL on error. A valid pointer to the element at 'idx' otherwise.
- */
-void** vector_at(vector_t* v, size_t idx);
-
-/**
  * @brief Return the size of the vector.
  * 
  * @param v Any vector

--- a/core/utils/vector.h
+++ b/core/utils/vector.h
@@ -60,12 +60,17 @@ void vector_pushall(vector_t* v, void** array, size_t size);
 void* vector_pop(vector_t* v);
 
 /**
- * @brief Return a pointer that is contained in the vector at 'idx'.
+ * Return a pointer to where the vector element at 'idx' is stored.
+ * This can be used to set the value of the element or to read it.
+ * If the index is past the end of the vector, then the vector
+ * is automatically expanded and filled with NULL pointers as needed.
+ * If no element at `idx` has been previously set, then the value
+ * pointed to by the returned pointer will be NULL.
  * 
- * @param v Any vector.
- * @param idx The index in the vector.
+ * @param v The vector.
+ * @param idx The index into the vector.
  * 
- * @return NULL on error. A valid pointer to the element at 'idx' otherwise.
+ * @return A pointer to the element at 'idx', which is itself a pointer.
  */
 void** vector_at(vector_t* v, size_t idx);
 


### PR DESCRIPTION
Fixes #92.

~~I understand that this is not exactly what was originally suggested, and I'm happy to go back and _actually_ fix the problem.~~

~~However, this procedure was not being used anywhere, and it does not seem strictly necessary because you can always just break the abstraction barrier (which is pretty thin anyway) and reach directly into the `vector_t` struct (although I understand that `vector_at` was originally intended to implement some more complicated logic).~~