### PR TITLE
Fix of flaky timedwait on Windows

### DIFF
--- a/core/platform/lf_windows_support.c
+++ b/core/platform/lf_windows_support.c
@@ -223,7 +223,7 @@ int lf_cond_timedwait(_lf_cond_t* cond, _lf_critical_section_t* critical_section
     }
 
     // convert ns to ms and round up to closest full integer
-    DWORD relative_time_ms = relative_time_ns + 999999LL / 1000000LL;
+    DWORD relative_time_ms = (relative_time_ns + 999999LL) / 1000000LL;
 
     int return_value =
      (int)SleepConditionVariableCS(

--- a/core/platform/lf_windows_support.c
+++ b/core/platform/lf_windows_support.c
@@ -216,7 +216,14 @@ int lf_cond_timedwait(_lf_cond_t* cond, _lf_critical_section_t* critical_section
     // Convert the absolute time to a relative time
     instant_t current_time_ns;
     lf_clock_gettime(&current_time_ns);
-    DWORD relative_time_ms = (absolute_time_ns - current_time_ns)/1000000LL;
+    DWORD relative_time_ns = (absolute_time_ns - current_time_ns);
+    if (relative_time_ns <= 0){
+      // physical time has already catched up sufficiently and we do not need to wait anymore
+      return 0;
+    }
+
+    // convert ns to ms and round up to closest full integer
+    DWORD relative_time_ms = relative_time_ns + 999999LL / 1000000LL;
 
     int return_value =
      (int)SleepConditionVariableCS(

--- a/core/platform/lf_windows_support.c
+++ b/core/platform/lf_windows_support.c
@@ -205,11 +205,11 @@ int lf_cond_wait(_lf_cond_t* cond, _lf_critical_section_t* critical_section) {
      }
 }
 
-/** 
+/**
  * Block current thread on the condition variable until condition variable
  * pointed by "cond" is signaled or time pointed by "absolute_time_ns" in
  * nanoseconds is reached.
- * 
+ *
  * @return 0 on success and LF_TIMEOUT on timeout, 1 otherwise.
  */
 int lf_cond_timedwait(_lf_cond_t* cond, _lf_critical_section_t* critical_section, instant_t absolute_time_ns) {
@@ -217,8 +217,8 @@ int lf_cond_timedwait(_lf_cond_t* cond, _lf_critical_section_t* critical_section
     instant_t current_time_ns;
     lf_clock_gettime(&current_time_ns);
     DWORD relative_time_ns = (absolute_time_ns - current_time_ns);
-    if (relative_time_ns <= 0){
-      // physical time has already catched up sufficiently and we do not need to wait anymore
+    if (relative_time_ns <= 0) {
+      // physical time has already caught up sufficiently and we do not need to wait anymore
       return 0;
     }
 
@@ -227,24 +227,20 @@ int lf_cond_timedwait(_lf_cond_t* cond, _lf_critical_section_t* critical_section
 
     int return_value =
      (int)SleepConditionVariableCS(
-         (PCONDITION_VARIABLE)cond, 
-         (PCRITICAL_SECTION)critical_section, 
+         (PCONDITION_VARIABLE)cond,
+         (PCRITICAL_SECTION)critical_section,
          relative_time_ms
      );
-     switch (return_value) {
-        case 0:
-            // Error
-            if (GetLastError() == ERROR_TIMEOUT) {
-                return _LF_TIMEOUT;
-            }
-            return 1;
-            break;
-        
-        default:
-            // Success
-            return 0;
-            break;
-     }
+    if (return_value == 0) {
+      // Error
+      if (GetLastError() == ERROR_TIMEOUT) {
+        return _LF_TIMEOUT;
+      }
+      return 1;
+    }
+
+    // Success
+    return 0;
 }
 
 

--- a/core/platform/lf_windows_support.c
+++ b/core/platform/lf_windows_support.c
@@ -216,7 +216,7 @@ int lf_cond_timedwait(_lf_cond_t* cond, _lf_critical_section_t* critical_section
     // Convert the absolute time to a relative time
     instant_t current_time_ns;
     lf_clock_gettime(&current_time_ns);
-    DWORD relative_time_ns = (absolute_time_ns - current_time_ns);
+    interval_t relative_time_ns = (absolute_time_ns - current_time_ns);
     if (relative_time_ns <= 0) {
       // physical time has already caught up sufficiently and we do not need to wait anymore
       return 0;


### PR DESCRIPTION
The Windows implementation of `lf_timed_wait` calculates the difference between the timepoint to wait until and the current physical time. In some seldom cases, the current physical time could already be larger then the specified timepoint. This will lead to a negative delay passed to `SleepConditionVariableCS`. While the documentation does not specify this precisely, experimentation showed that negative delays are interpreted as infinite delays and hence the program would block forever.

This fix makes two changes. First, it checks for negative delays and returns without waiting if the delay is less or equal to zero. Second, the number of milliseconds to wait for is rounded up in order to prevent unnecessary busy waiting when the call to `SleepConditionVariableCS` returns early.