### PR TITLE
Support Modal Reactors with LET

### DIFF
--- a/core/modal_models/modes.c
+++ b/core/modal_models/modes.c
@@ -34,8 +34,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * @author{Alexander Schulz-Rosengarten <als@informatik.uni-kiel.de>}
  * @author{Soroush Bateni <soroush@utdallas.edu}
- * FIXME: Before performing any mode transitions the reactor-local mutex must be acquired.
- *  this will make sure that we dont do any mode transition while executing a LET reaction
+ * @author{Erling R. Jellum <erling.r.jellum@ntnu.no}
  */
 #ifdef MODAL_REACTORS
 

--- a/core/modal_models/modes.c
+++ b/core/modal_models/modes.c
@@ -591,7 +591,7 @@ int _lf_mode_collect_transitioning_reactors(reactor_mode_state_t **states, int s
                 // See if its parent has done any volunteered mode transition
                  for (int i = 0; i< num_transitioning_reactors; i++) {
                     // Start search from the end. Look for a reactor pointer equal to self pointer of parent
-                    if (vector_at(return_vec, num_transitioning_reactors-1-i) == (void *) state->parent_mode->state->self) {
+                    if ( ((self_base_t *) vector_at(return_vec, num_transitioning_reactors-1-i)) == state->parent_mode->state->self) {
                         vector_push(return_vec, state->self);
                         num_transitioning_reactors++;
                         break;

--- a/core/modal_models/modes.c
+++ b/core/modal_models/modes.c
@@ -370,15 +370,6 @@ void _lf_process_mode_changes(
             // Handle effect of entering next mode
             if (state->next_mode != NULL) {
                 LF_PRINT_DEBUG("Modes: Transition to %s.", state->next_mode->name);
-                // Grab Reactor mutex if it is present. This enables LET scheduling
-                // FIXME: Verify that there is no race condition. Can a worker advance time BEFORE the LET
-                //  worker has grabbed the mutex? 
-                if (state->self->has_mutex) {
-                    LF_PRINT_DEBUG("Modes: Acquire mutex of reactor");
-                    lf_mutex_lock(&state->self->mutex);
-                    LF_PRINT_DEBUG("Modes: Mutex acquired of reactor");
-                }
-
                 transition = true;
 
                 if (state->mode_change == reset_transition) {
@@ -451,11 +442,6 @@ void _lf_process_mode_changes(
                     }
                 }
 
-                // Unlock mutex after mode transition has been completed. 
-                if (state->self->has_mutex) {
-                    LF_PRINT_DEBUG("Modes: release mutex of reactor");
-                    lf_mutex_unlock(&state->self->mutex);
-                }
             }
         }
     }

--- a/core/modal_models/modes.c
+++ b/core/modal_models/modes.c
@@ -559,8 +559,8 @@ void _lf_terminate_modal_reactors() {
 }
 
 /**
- * @brief This function accepts an array of ALL the mode_states and adds a reactor ptr into return_vec 
- *  for all reactors that will perform a transition at the current tag.
+ * @brief This function accepts an array of ALL the modes ordered from top-level and ending with leaf modes, 
+ *  and adds a reactor ptr into return_vec for all reactors that will perform a transition at the current tag.
  * 
  *  A mode performs a transition if either:
  *  1) next_mode is set or
@@ -570,8 +570,7 @@ void _lf_terminate_modal_reactors() {
  *  1) Check if reactor has next_mode set. If so, add to return_vec 
  *  2) If not, check if its parent has already been added to return_vec. If so, add it
  *  
- *  This assumes that the `states` argument is an array ordered hierarchically. It does a bunch of searching through
- *  the return_vec, but this might be OK.   
+ *  This assumes that the `states` argument is an array ordered from top-level mode to leaf mode
  * 
  * @param states 
  * @param states_size 

--- a/core/modal_models/modes.c
+++ b/core/modal_models/modes.c
@@ -559,7 +559,7 @@ void _lf_terminate_modal_reactors() {
 }
 
 /**
- * @brief This function accepts an array of ALL the mode_states and should add a reactor ptr into return_vec 
+ * @brief This function accepts an array of ALL the mode_states and adds a reactor ptr into return_vec 
  *  for all reactors that will perform a transition at the current tag.
  * 
  *  A mode performs a transition if either:

--- a/core/modal_models/modes.c
+++ b/core/modal_models/modes.c
@@ -560,7 +560,7 @@ void _lf_terminate_modal_reactors() {
 
 /**
  * @brief This function accepts an array of ALL the mode_states and should add a reactor ptr into return_vec 
- *  for all reactors that will do a transition
+ *  for all reactors that will perform a transition at the current tag.
  * 
  *  A mode performs a transition if either:
  *  1) next_mode is set or

--- a/core/modal_models/modes.c
+++ b/core/modal_models/modes.c
@@ -562,7 +562,7 @@ void _lf_terminate_modal_reactors() {
  * 
  * @param states An array of modes.
  * @param states_size The size of the array of modes.
- * @param return_vec A pointer to a vector_t into which to push the result.
+ * @param return_vec A pointer to a an allocated `vector_t` type. void* used to avoid exposing type to user-code
  * @return int The number of items pushed into the vector.
  */
 int _lf_mode_collect_transitioning_reactors(reactor_mode_state_t **states, int states_size, void * _return_vec) {

--- a/core/modal_models/modes.c
+++ b/core/modal_models/modes.c
@@ -564,7 +564,7 @@ void _lf_terminate_modal_reactors() {
  * 
  *  A mode performs a transition if either:
  *  1) next_mode is set or
- *  2) parent has next_mode set
+ *  2) any parent has next_mode set.
  * 
  *  A preliminary implementation is simple:
  *  1) Check if reactor has next_mode set. If so, add to return_vec 

--- a/core/modal_models/modes.c
+++ b/core/modal_models/modes.c
@@ -441,7 +441,6 @@ void _lf_process_mode_changes(
                         suspended_event = suspended_event->next;
                     }
                 }
-
             }
         }
     }

--- a/core/modal_models/modes.c
+++ b/core/modal_models/modes.c
@@ -562,7 +562,7 @@ void _lf_terminate_modal_reactors() {
  * @brief This function accepts an array of ALL the mode_states and should add a reactor ptr into return_vec 
  *  for all reactors that will do a transition
  * 
- *  A mode does a transition of either:
+ *  A mode performs a transition if either:
  *  1) next_mode is set or
  *  2) parent has next_mode set
  * 

--- a/core/modal_models/modes.h
+++ b/core/modal_models/modes.h
@@ -76,6 +76,19 @@ do { \
 
 
 ////////////////////////////////////////////////////////////
+//// Type definitions for modal infrastructure.
+
+/** Typedef for reactor_mode_t struct, used for representing a mode. */
+typedef struct reactor_mode_t reactor_mode_t;
+/** Typedef for reactor_mode_state_t struct, used for storing modal state of reactor and/or its relation to enclosing modes. */
+typedef struct reactor_mode_state_t reactor_mode_state_t;
+/** Typedef for mode_state_variable_reset_data_t struct, used for storing data for resetting state variables nested in modes. */
+typedef struct mode_state_variable_reset_data_t mode_state_variable_reset_data_t;
+
+/** Type of the mode change. */
+typedef enum {no_transition, reset_transition, history_transition} lf_mode_change_type_t;
+
+////////////////////////////////////////////////////////////
 //// Forward declaration for generated code.
 
 /**
@@ -93,18 +106,11 @@ void _lf_handle_mode_changes(void);
  */
 void _lf_handle_mode_triggered_reactions(void);
 
-////////////////////////////////////////////////////////////
-//// Type definitions for modal infrastructure.
+/**
+ * Function (to be code generated) to get the reactor_mode_state array and its length
+ */
+int _lf_mode_get_reactor_mode_states(reactor_mode_state_t ***reactor_mode_state);
 
-/** Typedef for reactor_mode_t struct, used for representing a mode. */
-typedef struct reactor_mode_t reactor_mode_t;
-/** Typedef for reactor_mode_state_t struct, used for storing modal state of reactor and/or its relation to enclosing modes. */
-typedef struct reactor_mode_state_t reactor_mode_state_t;
-/** Typedef for mode_state_variable_reset_data_t struct, used for storing data for resetting state variables nested in modes. */
-typedef struct mode_state_variable_reset_data_t mode_state_variable_reset_data_t;
-
-/** Type of the mode change. */
-typedef enum {no_transition, reset_transition, history_transition} lf_mode_change_type_t;
 
 /** A struct to represent a single mode instace in a reactor instance. */
 struct reactor_mode_t {

--- a/core/modal_models/modes.h
+++ b/core/modal_models/modes.h
@@ -38,6 +38,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * @author{Alexander Schulz-Rosengarten <als@informatik.uni-kiel.de>}
  * @author{Soroush Bateni <soroush@utdallas.edu}
+ * @author{Erling R. Jellum <erling.r.jellum@ntnu.no}
  */
 #ifndef MODES_H
 #define MODES_H
@@ -110,7 +111,10 @@ void _lf_handle_mode_changes(void);
 void _lf_handle_mode_triggered_reactions(void);
 
 /**
- * Function (to be code generated) to fill up a vector with the reactors which have mode transitions.
+ * Function (to be code generated) which accepts a pointer to an allocated
+ * vector_t to which it appends all reactors which have requested 
+ * a mode change at the current tag. A void* is used to avoid
+ * adding vector.h to the namespace of the usercode.
  */
 int _lf_mode_get_transitioning_reactors(void * return_vec);
 

--- a/core/modal_models/modes.h
+++ b/core/modal_models/modes.h
@@ -47,6 +47,9 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // Forward declare reactor self-struct from reactor.h
 struct self_base_t;
 
+// Use a vector for collecting transitioning reactors
+#include "utils/vector.h"
+
 ////////////////////////////////////////////////////////////
 //// Macros for setting modes.
 
@@ -107,9 +110,9 @@ void _lf_handle_mode_changes(void);
 void _lf_handle_mode_triggered_reactions(void);
 
 /**
- * Function (to be code generated) to get the reactor_mode_state array and its length
+ * Function (to be code generated) to fill up a vector with the reactors who has mode transitions
  */
-int _lf_mode_get_reactor_mode_states(reactor_mode_state_t ***reactor_mode_state);
+int _lf_mode_get_transitioning_reactors(void * return_vec);
 
 
 /** A struct to represent a single mode instace in a reactor instance. */

--- a/core/modal_models/modes.h
+++ b/core/modal_models/modes.h
@@ -44,6 +44,9 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef MODAL_REACTORS
 
+// Forward declare reactor self-struct from reactor.h
+struct self_base_t;
+
 ////////////////////////////////////////////////////////////
 //// Macros for setting modes.
 
@@ -113,6 +116,7 @@ struct reactor_mode_t {
 
 /** A struct to store state of the modes in a reactor instance and/or its relation to enclosing modes. */
 struct reactor_mode_state_t {
+    struct self_base_t* self;       // Pointer to the self-struct of the reactor containing this mode.
     reactor_mode_t* parent_mode;    // Pointer to the next enclosing mode (if exists).
     reactor_mode_t* initial_mode;   // Pointer to the initial mode.
     reactor_mode_t* current_mode;   // Pointer to the currently active mode (only locally active).

--- a/core/platform.h
+++ b/core/platform.h
@@ -68,10 +68,11 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef NUMBER_OF_WORKERS
 #define LF_TIMEOUT _LF_TIMEOUT
-
 typedef _lf_mutex_t lf_mutex_t;          // Type to hold handle to a mutex
 typedef _lf_cond_t lf_cond_t;            // Type to hold handle to a condition variable
 typedef _lf_thread_t lf_thread_t;        // Type to hold handle to a thread
+#else
+typedef void lf_mutex_t;                 // Define mutex type also in single-threaded to allow mutex type on self struct
 #endif
 
 /**

--- a/core/platform.h
+++ b/core/platform.h
@@ -72,7 +72,7 @@ typedef _lf_mutex_t lf_mutex_t;          // Type to hold handle to a mutex
 typedef _lf_cond_t lf_cond_t;            // Type to hold handle to a condition variable
 typedef _lf_thread_t lf_thread_t;        // Type to hold handle to a thread
 #else
-typedef void lf_mutex_t;                 // Define mutex type also in single-threaded to allow mutex type on self struct
+typedef void* lf_mutex_t;                 // Define mutex type also in single-threaded to allow mutex type on self struct
 #endif
 
 /**

--- a/core/reactor.h
+++ b/core/reactor.h
@@ -640,6 +640,7 @@ typedef struct self_base_t {
     tag_t current_tag;                       // The tag of the most recent reaction invokation
     lf_mutex_t mutex;                       // A local mutex to ensure mutual exclusion of reactions in reactor 
     bool has_mutex;                       // A local mutex to ensure mutual exclusion of reactions in reactor 
+    struct self_base_t *parent;                     // Pointer to parent/containing reactor
 #ifdef MODAL_REACTORS
     reactor_mode_state_t _lf__mode_state;    // The current mode (for modal models).
 #endif

--- a/core/reactor.h
+++ b/core/reactor.h
@@ -638,10 +638,8 @@ typedef struct self_base_t {
 	struct allocation_record_t *allocations;
 	struct reaction_t *executing_reaction;   // The currently executing reaction of the reactor.
     tag_t current_tag;                       // The tag of the most recent reaction invokation
-#ifdef NUMBER_OF_WORKERS
     lf_mutex_t mutex;                       // A local mutex to ensure mutual exclusion of reactions in reactor 
     bool has_mutex;                       // A local mutex to ensure mutual exclusion of reactions in reactor 
-#endif
 #ifdef MODAL_REACTORS
     reactor_mode_state_t _lf__mode_state;    // The current mode (for modal models).
 #endif

--- a/core/reactor.h
+++ b/core/reactor.h
@@ -4,6 +4,7 @@
  * @author Marten Lohstroh (marten@berkeley.edu)
  * @author Chris Gill (cdgill@wustl.edu)
  * @author Mehrdad Niknami (mniknami@berkeley.edu)
+ * @author Erling R. jellum (erling.r.jellum@ntnu.no)
  *
  * @section LICENSE
  * Copyright (c) 2019, The University of California at Berkeley.

--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -1571,7 +1571,7 @@ bool _lf_check_deadline(self_base_t* self, bool invoke_deadline_handler) {
  */
 void _lf_invoke_reaction(reaction_t* reaction, int worker) {
     
-    #ifdef NUMBER_OF_WORKERS
+    #ifdef LF_MULTI_THREADED
     lf_sched_reaction_prologue(reaction, worker);
     #endif
 
@@ -1584,7 +1584,7 @@ void _lf_invoke_reaction(reaction_t* reaction, int worker) {
     tracepoint_reaction_ends(reaction, worker); 
     LF_PRINT_DEBUG("Worker %d Finished Reaction", worker);
     
-    #ifdef NUMBER_OF_WORKERS
+    #ifdef LF_MULTI_THREADED
     lf_sched_reaction_epilogue(reaction, worker);
     #endif
 }

--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -34,6 +34,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *  @author{Mehrdad Niknami <mniknami@berkeley.edu>}
  *  @author{Soroush Bateni <soroush@utdallas.edu}
  *  @author{Alexander Schulz-Rosengarten <als@informatik.uni-kiel.de>}
+ *  @author{Erling Rennemo Jellum <erling.r.jellum0@ntnu.no>}
  */
 
 #include "reactor.h"
@@ -1573,7 +1574,7 @@ void _lf_invoke_reaction(reaction_t* reaction, int worker) {
     
     #ifdef LF_MULTI_THREADED
     lf_sched_reaction_prologue(reaction, worker);
-    #endif        
+    #endif
 
     bool violation = false;
     if (reaction->deadline >= 0LL) {

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -29,6 +29,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *  @author{Edward A. Lee <eal@berkeley.edu>}
  *  @author{Marten Lohstroh <marten@berkeley.edu>}
  *  @author{Soroush Bateni <soroush@utdallas.edu>}
+ *  @author{Soroush Bateni <erling.r.jellum@ntnu.no>}
  */
 
 #ifndef NUMBER_OF_WORKERS

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -1023,7 +1023,9 @@ void _lf_worker_do_work(int worker_number) {
                 current_reaction_to_execute->chain_id,
                 current_reaction_to_execute->deadline);
 
-        bool violation = _lf_worker_handle_violations(
+        // Check for STP violations. Deadline violations checked after acquiring all the
+        //  mutexes.
+        bool violation = _lf_worker_handle_STP_violation_for_reaction(
             worker_number, 
             current_reaction_to_execute
         );

--- a/core/threaded/scheduler_LET.c
+++ b/core/threaded/scheduler_LET.c
@@ -337,7 +337,7 @@ void lf_sched_init(
     }
 
     // Allocate array to hold information about what workers are in the workforce
-    _lf_sched_worker_is_in_workforce = malloc(_lf_number_of_workers * sizeof(bool));
+    _lf_sched_worker_is_in_workforce = (bool *) malloc(_lf_number_of_workers * sizeof(bool));
     for (int i = 0; i< _lf_number_of_workers; i++) {
         _lf_sched_worker_is_in_workforce[i] = true;
     }
@@ -550,7 +550,10 @@ void lf_sched_reaction_epilogue(reaction_t * reaction, int worker_number) {
 
 #ifdef MODAL_REACTORS
 /**
- * @brief 
+ * @brief This function should be invoked by the worker thread about to advance time BEFORE it acquires the global mutex.
+ *  It is only relevant if we have modal reactors. It gathers all the Reactors which are about to perform mode changes, and reactors contained within them,
+ *  and acquires there local mutex to make sure there are no LET reactions currently executing in any of them.
+ *  In the case that there are LET reactions, this will block the advancement of time until the LET reaction completes.
  * 
  */
 static void _lf_sched_mode_change_prologue() {

--- a/core/threaded/scheduler_LET.c
+++ b/core/threaded/scheduler_LET.c
@@ -346,10 +346,7 @@ void lf_sched_init(
     //  due to mode transitions
     reactor_mode_state_t **states;
     int states_size = _lf_mode_get_reactor_mode_states(&states); 
-    local_mutex_was_locked = malloc(states_size * sizeof(bool));
-    for (int i = 0; i<states_size; i++) {
-        local_mutex_was_locked[i] = false;
-    }
+    local_mutex_was_locked = (bool *) calloc(states_size, sizeof(bool));
     #endif
 
     _lf_sched_instance->_lf_sched_executing_reactions = 

--- a/core/threaded/scheduler_LET.c
+++ b/core/threaded/scheduler_LET.c
@@ -29,6 +29,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define NUMBER_OF_WORKERS 1
 #endif  // NUMBER_OF_WORKERS
 
+#ifndef LF_MULTI_THREADED
+#error LET-scheduler was chosen without LF_MULTI_THREADED flag defined
+#endif
+
 #include <assert.h>
 
 #include "../platform.h"

--- a/core/trace.c
+++ b/core/trace.c
@@ -399,7 +399,7 @@ void tracepoint(
         self_base_t* reactor = (self_base_t *) trigger->reactions[0]->self;
         tag = lf_tag(reactor);
     } else {
-        lf_tag(NULL);
+        tag = lf_tag(NULL);
     }
 
     _lf_trace_buffer[index][i].event_type = event_type;


### PR DESCRIPTION
This is a PR into the Draft PR for LET scheduling. It adds support for handling Modal Reactors. 

The challenge stems from the fact that a LET reaction may execute inside a Modal Reactor while another reaction triggers a mode change. Either in the same reactor or a containing reactor. In that case the LET reaction must stall the mode change. This is achieved by having a "local" mutex per reactor with LET reactions which is locked while the reaction is executing. Before a mode change can occur the mutex of the reactor and all contained reactor must be locked, if they are present.

The challenge stems from the fact that **we have to acquire the local mutex before the global mutex** to avoid deadlocks. Unfortunately the functions for doing mode changes in modes.c are called while holding the global mutex. My approach was to add a prologue and epilogue which is executed from `scheduler_LET.c` that locks and unlocks the required local mutexes **before** the global mutex is locked and the worker tries to advance time.

A companion PR for Lingua-Franca is [here](https://github.com/lf-lang/lingua-franca/pull/1427)

@edwardalee and @a-sr I am tagging both of you here. Would be very nice with some feedback on this approach. I don't have the full picture on Modal Reactors and might have missed something