### PR TITLE
Token payload freed with after delay

### DIFF
--- a/include/core/lf_types.h
+++ b/include/core/lf_types.h
@@ -183,7 +183,7 @@ typedef struct token_present_t {
     lf_token_t** token;
     port_status_t* status; // FIXME: This structure is used to present the status of tokens
                            // for both ports and actions.
-    bool reset_is_present; // True to set is_present to false after calling done_using().
+    bool reset_is_present; // True to set is_present to false after calling _lf_done_using().
 } token_present_t;
 
 /**


### PR DESCRIPTION
This PR fixes a logic error where the payload of a token was not being freed when the token itself was not freed. A token is not freed if it is the "template" token for a port or action because it contains type information for that port or action and it will be reused in future events for that port or action. However, the payload, the value field, should be freed when it is no longer needed. This was not being done. This bug was probably introduced with the Python target, where payloads never get freed because the payload is a Python target and Python handles garbage collection.