### PR TITLE
avoid duplicate tokens in token recycle bin

### DIFF
--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -389,10 +389,19 @@ static token_freed _lf_free_token(lf_token_t* token) {
     if (token->ok_to_free) {
         // Need to free the lf_token_t struct also.
         if (_lf_token_recycling_bin_size < _LF_TOKEN_RECYCLING_BIN_SIZE_LIMIT) {
-            // Recycle instead of freeing.
-            token->next_free = _lf_token_recycling_bin;
-            _lf_token_recycling_bin = token;
-            _lf_token_recycling_bin_size++;
+            // find if token is already there in recycle bin
+            lf_token_t* token_itr = _lf_token_recycling_bin;
+            while ((token_itr != NULL) && (token_itr != token)) {
+                token_itr = token_itr->next_free;
+            }
+
+            // recycle in case of token not found in the list
+            if (token_itr == NULL) {
+                // Recycle instead of freeing.
+                token->next_free = _lf_token_recycling_bin;
+                _lf_token_recycling_bin = token;
+                _lf_token_recycling_bin_size++;
+            }
         } else {
             // Recycling bin is full.
             free(token);


### PR DESCRIPTION
This issue was reproduced when using pointers to struct for input and output of reactions. After a short run (when size of recycle bin overflows by duplicate entries into recycle bin) occurs a double delete.

Trigger still holds the pointer to token so the actual issue of double delete would still be there. Complete fix of this problem needs a thorough review of token usage, and I would try to create a PR with changes in the future.

Currently this fix would do some good for shorter programs that don't overflow recycle bin, or we could increase the recycle bin limit as a workaround in that case.