### PR TITLE
Continuations

### DIFF
--- a/core/utils/CMakeLists.txt
+++ b/core/utils/CMakeLists.txt
@@ -1,3 +1,3 @@
-set(GENERAL_SOURCES vector.c pqueue.c util.c)
+set(GENERAL_SOURCES vector.c pqueue.c util.c context_switch.c)
 set(MULTITHREADED_SOURCES semaphore.c)
 add_sources_to_parent(GENERAL_SOURCES MULTITHREADED_SOURCES "")

--- a/core/utils/context_switch.c
+++ b/core/utils/context_switch.c
@@ -1,0 +1,44 @@
+#include <stddef.h>
+#include <stdlib.h>
+#include <setjmp.h>
+
+typedef struct context_t {
+    jmp_buf registers;
+    int n;
+    long *stack;
+} context_t;
+
+static void save_stack(context_t *c, long *top_of_stack, long *bottom_of_stack) {
+    int n = top_of_stack-bottom_of_stack;
+    c->stack = (long *) malloc(n*sizeof(long));
+    c->n = n;
+    for (int i = 0; i < n; i++) {
+        c->stack[i] = top_of_stack[-i];
+    }
+}
+
+context_t* context_save(long* top_of_stack) {
+    context_t* ret = (context_t*) malloc(sizeof(context_t));
+    long bottom_of_stack;
+    if (!setjmp(ret->registers)) {
+        save_stack(ret, top_of_stack, &bottom_of_stack);
+        return ret;
+    } else {
+        return NULL; // setjmp was returned to by a longjmp call
+    }
+}
+
+void context_switch(context_t* c, long* top_of_stack) {
+    long mem_allocated_on_stack[12];
+    long current_bottom_of_stack;
+    if (top_of_stack - &current_bottom_of_stack < c->n) context_switch(c, top_of_stack);
+    for (int i = 0; i < c->n; i++) {
+        top_of_stack[-i] = c->stack[i];
+    }
+    longjmp(c->registers, 1);
+}
+
+void context_free(context_t* ctx) {
+    free(ctx->stack);
+    free(ctx);
+}

--- a/include/api/set.h
+++ b/include/api/set.h
@@ -29,10 +29,10 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Target-specific runtime functions for the C target language.
  * This API layer can be used in conjunction with:
  *     target C;
- * 
- * Note for target language developers. This is one way of developing a target language where 
- * the C core runtime is adopted. This file is a translation layer that implements Lingua Franca 
- * APIs which interact with the internal _lf_SET and _lf_schedule APIs. This file can act as a 
+ *
+ * Note for target language developers. This is one way of developing a target language where
+ * the C core runtime is adopted. This file is a translation layer that implements Lingua Franca
+ * APIs which interact with the internal _lf_SET and _lf_schedule APIs. This file can act as a
  * template for future runtime developement for target languages.
  * For source generation, see xtext/org.icyphy.linguafranca/src/org/icyphy/generator/CCppGenerator.xtend.
  */
@@ -54,20 +54,20 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * to the specified value.
  *
  * If the value argument is a primitive type such as int,
- * double, etc. as well as the built-in types bool and string, 
+ * double, etc. as well as the built-in types bool and string,
  * the value is copied and therefore the variable carrying the
  * value can be subsequently modified without changing the output.
  * This also applies to structs with a type defined by a typedef
  * so that the type designating string does not end in '*'.
- * 
+ *
  * If the value argument is a pointer
  * to memory that the calling reaction has dynamically allocated,
  * the memory will be automatically freed once all downstream
  * reactions no longer need the value.
  * If 'lf_set_destructor' is called on 'out', then that destructor
- * will be used to free 'value'. 
+ * will be used to free 'value'.
  * Otherwise, the default void free(void*) function is used.
- * 
+ *
  * @param out The output port (by name) or input of a contained
  *  reactor in form input_name.port_name.
  * @param value The value to insert into the self struct.
@@ -172,24 +172,26 @@ do { \
  * Set the destructor used to free "token->value" set on "out".
  * That memory will be automatically freed once all downstream
  * reactions no longer need the value.
- * 
+ *
  * @param out The output port (by name) or input of a contained
  *            reactor in form input_name.port_name.
  * @param dtor A pointer to a void function that takes a pointer argument
- *             or NULL to use the default void free(void*) function. 
+ *             or NULL to use the default void free(void*) function.
  */
 #define lf_set_destructor(out, dtor) _LF_SET_DESTRUCTOR(out, dtor)
 
 /**
  * Set the destructor used to copy construct "token->value" received
  * by "in" if "in" is mutable.
- * 
+ *
  * @param out The output port (by name) or input of a contained
  *            reactor in form input_name.port_name.
  * @param cpy_ctor A pointer to a void* function that takes a pointer argument
  *                 or NULL to use the memcpy operator.
  */
 #define lf_set_copy_constructor(out, cpy_ctor) _LF_SET_COPY_CONSTRUCTOR(out, cpy_ctor)
+
+#define lf_call(req, argument, res) _LF_CALL(req, argument, res)
 
 //////////////////////////////////////////////////////////////
 /////////////  SET_MODE Function (to switch a mode)

--- a/include/api/set_undef.h
+++ b/include/api/set_undef.h
@@ -99,6 +99,8 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #undef lf_set_copy_constructor
 
+#undef lf_call
+
 //////////////////////////////////////////////////////////////
 /////////////  SET_MODE Function (to switch a mode)
 

--- a/include/core/lf_types.h
+++ b/include/core/lf_types.h
@@ -44,6 +44,7 @@
 #include "tag.h"
 
 #define lf_request(type) lf_request_ ## type ## _t
+
 #define LF_DECLARE_REQUEST(type) typedef struct lf_request(type) {             \
     context_t* ctx;                                                            \
     int value;                                                                 \

--- a/include/core/lf_types.h
+++ b/include/core/lf_types.h
@@ -43,6 +43,12 @@
 #include "platform.h"
 #include "tag.h"
 
+#define lf_request(type) lf_request_ ## type ## _t
+#define LF_DECLARE_REQUEST(type) typedef struct lf_request(type) {             \
+    context_t* ctx;                                                            \
+    int value;                                                                 \
+} lf_request(type);
+
 /**
  * ushort type. Redefine here for portability if sys/types.h is not included.
  * @see sys/types.h

--- a/include/core/reactor.h
+++ b/include/core/reactor.h
@@ -290,6 +290,19 @@ do { \
     out->copy_constructor = cpy_ctor; \
 } while(0)
 
+// FIXME: REPLACE lf_request_int_t WITH GENERIC
+#define _LF_CALL(req, argument, res)                                           \
+do {                                                                           \
+    context_t* ctx = context_save(top_of_stack);                               \
+    if (ctx != NULL) {                                                         \
+        lf_set(req, ((lf_request_int_t) { .ctx=ctx, .value=argument }));       \
+        return;                                                                \
+    } else if (res->is_present) {                                              \
+        /* Crash if the response does not have a valid context attached */     \
+        context_free(res->value.ctx);                                          \
+    }                                                                          \
+} while(0)
+
 /**
  * Macro for extracting the deadline from the index of a reaction.
  * The reaction queue is sorted according to this index, and the

--- a/include/core/utils/context_switch.h
+++ b/include/core/utils/context_switch.h
@@ -1,0 +1,4 @@
+typedef struct context_t context_t;
+context_t* context_save(long* top_of_stack);
+void context_switch(context_t* c, long* top_of_stack);
+void context_free(context_t* c);


### PR DESCRIPTION
Requirements:
- [x] Continue a reaction where it left off when it is re-triggered in a later tag.
- [ ] Add a mechanism to send multiple requests in the same tag, and only (spiritually) "block" on the response ports when a response is needed (like futures)
- [ ] Create a test in which a caller reaction processes a response and produces a new request in the same tag.
- [ ] Create a test in which a caller reaction processes multiple different responses in the same tag
- [ ] Create a test in which a request is distributed by an intermediate handler to several workers, which each send back partial responses that are merged and send back to the caller
- [ ] Create a test in which a caller reaction receives and successfully processes several responses at the same tag.
- [ ] Create a test in which a caller reaction sends multiple requests and receives them out of order. (This is only possible with the "futures" construct.)
- [ ] Implement a few examples using continuations to show that they make code more readable (and more like programming in a conventional GPL)
- [ ] Do not have a memory leak when no request comes back. (**What should be the mechanism for this?**)
- [ ] Provide a way to introspect into pending requests, e.g. so that decisions can be made according to their number. (**What other data needs to be exposed?**)
- [ ] Provide a way to modify pending requests? (**If you wish to have this amount of power, why not use LF's lower-level primitives? Is it a matter of convenient programming (which this proposal can solve), or of reliable program analysis (which this proposal does not solve at all)?**)

Low-level control over pending requests will probably require another level of indirection. Probably we will need to attach a hashmap to the self struct of the requestor reactor from request IDs to request metadata, or something like that.

Questions:
- Should we allow a reaction to receive a response in the same tag as when it produces the request? I doubt that we can do this in general without introducing a mechanism that is equivalent to microsteps. The handling of a request can, in general, require an iteration through the entire reaction graph. Why would we implement a mechanism that allows arbitrarily many iterations through the reaction graph when we already have a mechanism to do that in zero time (microsteps)? The underlying issue I have that causes me to raise this point is that I do not understand what actual "consistency" is lost by using multiple microsteps versus multiple levels; this lack of understanding has come up before in our discussion of what exactly would be lost if we forbade federated execution with zero-delay cycles between federates, and it's important because we claim that it distinguishes us from actor-based models that totally order events that are processed and impose rules wrt how each event can be processed.