### PR TITLE
Relative paths lf_types.h

### DIFF
--- a/include/core/lf_types.h
+++ b/include/core/lf_types.h
@@ -38,8 +38,8 @@
 
 #include <stdbool.h>
 
-#include "modes.h" // Modal model support
-#include "pqueue.h"
+#include "modal_models/modes.h" // Modal model support
+#include "utils/pqueue.h"
 #include "platform.h"
 #include "tag.h"
 


### PR DESCRIPTION
changed the modes.h header path to avoid conflict