### PR TITLE
Disable MBED Support since it is a multithreaded enabled board.

### DIFF
--- a/core/platform/lf_arduino_support.c
+++ b/core/platform/lf_arduino_support.c
@@ -139,7 +139,7 @@ int lf_critical_section_enter() {
         // TODO: Do we need to check whether the interrupts were enabled to
         //  begin with? AFAIK there is no Arduino API for that 
         #if BOARD==MBED
-            core_util_critical_section_enter(); //MBED Boards use an RTOS, so we use a specific call to enter a critical section.
+            //core_util_critical_section_enter(); //MBED Boards use an RTOS, so we use a specific call to enter a critical section.
         #else
             noInterrupts();
         #endif
@@ -163,7 +163,7 @@ int lf_critical_section_exit() {
     }
     if (--_lf_num_nested_critical_sections == 0) {
         #if BOARD==MBED
-            core_util_critical_section_exit(); //MBED Boards use an RTOS, so we use a specific call to exit a critical section.
+            //core_util_critical_section_exit(); //MBED Boards use an RTOS, so we use a specific call to exit a critical section.
         #else
             interrupts();
         #endif

--- a/include/core/platform/lf_arduino_support.h
+++ b/include/core/platform/lf_arduino_support.h
@@ -98,6 +98,10 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 #endif
 
+#if BOARD==MBED
+#error "MBED RTOS-based Arduino Boards are currently unsupported"
+#endif
+
 #define __STDC_FORMAT_MACROS
 #include <inttypes.h>
 


### PR DESCRIPTION
MBED is more complicated than other Arduino boards since it has an onboard RTOS, which forces us to have the multithreaded reactor-c support present due to issues with hanging threads. We disable MBED boards to kickstart Arduino Support and will integrate it back later.