### PR TITLE
Fix scheduling preprocessing

### DIFF
--- a/core/threaded/scheduler.c
+++ b/core/threaded/scheduler.c
@@ -1,3 +1,5 @@
+#include "lf_types.h"
+
 #if SCHEDULER == ADAPTIVE
 #include "scheduler_adaptive.c"
 

--- a/core/threaded/scheduler_adaptive.c
+++ b/core/threaded/scheduler_adaptive.c
@@ -27,7 +27,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * This is a non-priority-driven scheduler. See scheduler.h for documentation.
  * @author{Peter Donovan <peterdonovan@berkeley.edu>}
  */
-#if defined SCHEDULER && SCHEDULER == adaptive
+#if defined SCHEDULER && SCHEDULER == ADAPTIVE
 #ifndef NUMBER_OF_WORKERS
 #define NUMBER_OF_WORKERS 1
 #endif // NUMBER_OF_WORKERS

--- a/include/core/lf_types.h
+++ b/include/core/lf_types.h
@@ -55,6 +55,20 @@ typedef unsigned short int ushort;
 #endif
 
 /**
+ * Define scheduler types as integers. This way we can conditionally
+ * include/exclude code with the preprocessor with
+ * #if SCHEDULER == ADAPTIVE etc
+ * This means that `lf_types.h` MUST be included before doing any preprocessing
+ * on SCHEDULER compile def.
+ */
+
+#define ADAPTIVE 1
+#define GEDF_NP_CI 2
+#define GEDF_NP 3
+#define LET 4
+#define NP 5
+
+/**
  * Policy for handling scheduled events that violate the specified
  * minimum interarrival time.
  * The default policy is `defer`: adjust the tag to that the minimum


### PR DESCRIPTION
The conditional inclusion of code based on which scheduler was chosen didnt work.
```
#if SCHEDULER == LET
```
Does not work if you do `-DSCHEDULER=LET`. A fix is to define macros for `LET` etc. But this means that the header file with these `#define`s must be included before any use of `#if SCHEDULER == ...`
