### PR TITLE
Fix problem with threaded Zephyr and overflow handling in QEMU emulation

### DIFF
--- a/core/platform/lf_zephyr_support.c
+++ b/core/platform/lf_zephyr_support.c
@@ -144,7 +144,9 @@ void lf_initialize_clock() {
 // Zephyrs Counter API
 
 /**
- * Return the current time in nanoseconds
+ * Return the current time in nanoseconds. It gets the current value
+ * of the hi-res counter device and also keeps track of overflows
+ * to deliver a monotonically increasing clock.
  */
 int lf_clock_gettime(instant_t* t) {
     uint32_t now_cycles;
@@ -154,8 +156,6 @@ int lf_clock_gettime(instant_t* t) {
     res = counter_get_value(_lf_counter_dev, &now_cycles);
     now_nsec = counter_ticks_to_us(_lf_counter_dev, now_cycles)*1000ULL;
     *t = now_nsec + _lf_timer_last_epoch_nsec;
-    now_cycles = k_cycle_get_32();
-    *t = (SECOND(1)/CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC)*now_cycles;
     return 0;
 }
 

--- a/core/platform/lf_zephyr_support.c
+++ b/core/platform/lf_zephyr_support.c
@@ -350,7 +350,7 @@ int lf_notify_of_event() {
 // FIXME: What is an appropriate thread prio?
 #define _LF_THREAD_PRIORITY 5
 
-// If NUMBER_OF_WORKERS is not specified, or specified to 0. Then we default to 1
+// If NUMBER_OF_WORKERS is not specified, or set to 0, then we default to 1.
 #if !defined(NUMBER_OF_WORKERS) || NUMBER_OF_WORKERS==0
 #undef NUMBER_OF_WORKERS
 #define NUMBER_OF_WORKERS 1

--- a/core/platform/lf_zephyr_support.c
+++ b/core/platform/lf_zephyr_support.c
@@ -45,6 +45,9 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // Combine 2 32-bit words to a 64-bit word
 #define COMBINE_HI_LO(hi,lo) ((((uint64_t) hi) << 32) | ((uint64_t) lo))
 
+// Keep track of overflows to keep clocks monotonic
+static int64_t _lf_timer_epoch_duration_nsec;
+static volatile int64_t _lf_timer_last_epoch_nsec = 0;
 
 #if defined(LF_ZEPHYR_CLOCK_HI_RES)
 // Create semaphore for async wakeup from physical action
@@ -55,13 +58,11 @@ const struct device *const _lf_counter_dev = DEVICE_DT_GET(LF_TIMER);
 static volatile bool _lf_alarm_fired;
 static uint32_t _lf_timer_freq;
 
-static int64_t _lf_timer_epoch_duration_usec;
-static volatile int64_t _lf_timer_last_epoch_nsec = 0;
 
 
 // Timer overflow callback
 static void  _lf_timer_overflow_callback(const struct device *dev, void *user_data) {
-        _lf_timer_last_epoch_nsec += _lf_timer_epoch_duration_usec*1000LL;
+        _lf_timer_last_epoch_nsec += _lf_timer_epoch_duration_nsec;
 }
 
 
@@ -109,7 +110,7 @@ void lf_initialize_clock() {
 
     // Calculate the duration of an epoch
     counter_max_ticks = counter_get_max_top_value(_lf_counter_dev);
-    _lf_timer_epoch_duration_usec = counter_ticks_to_us(_lf_counter_dev, counter_max_ticks);
+    _lf_timer_epoch_duration_nsec = counter_ticks_to_us(_lf_counter_dev, counter_max_ticks) * 1000LL;
     
     // Set the max_top value to be the maximum
     counter_max_ticks = counter_get_max_top_value(_lf_counter_dev);
@@ -135,6 +136,9 @@ void lf_initialize_clock() {
     #else
     LF_PRINT_LOG("Using Low resolution zephyr kernel clock");
     LF_PRINT_LOG("Kernel Clock has frequency of %u Hz\n", CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC);
+    _lf_timer_last_epoch_nsec = 0;
+    // Compute the duration of an 
+    _lf_timer_epoch_duration_nsec = ((1LL << 32) * SECONDS(1))/CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC;
     #endif
 }   
 
@@ -222,11 +226,19 @@ int lf_sleep_until_locked(instant_t wakeup) {
     }
 }
 #else
-// Clock and sleep implementation for LO_RES clock
-
+// Clock and sleep implementation for LO_RES clock. Handle wraps
+//  by checking if two consecutive reads are monotonic
+static uint32_t last_read_cycles=0;
 int lf_clock_gettime(instant_t* t) {
     uint32_t now_cycles = k_cycle_get_32();
-    *t = (SECOND(1)/CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC)*now_cycles;
+
+    if (now_cycles < last_read_cycles) {
+        _lf_timer_last_epoch_nsec += _lf_timer_epoch_duration_nsec;
+    }
+
+    *t = (SECOND(1)/CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC)*now_cycles + _lf_timer_last_epoch_nsec;
+
+    last_read_cycles = now_cycles;
     return 0;
 }
 

--- a/core/platform/lf_zephyr_support.c
+++ b/core/platform/lf_zephyr_support.c
@@ -343,7 +343,7 @@ int lf_notify_of_event() {
 
 
 #ifdef LF_THREADED
-#warning "Threaded support on Zephyr is still experimental"
+#error "Threaded support on Zephyr is not supported"
 
 // FIXME: What is an appropriate stack size?
 #define _LF_STACK_SIZE 1024
@@ -381,7 +381,10 @@ int lf_available_cores() {
  * getting passed arguments. The new handle is stored in thread_id.
  *
  * @return 0 on success, platform-specific error number otherwise.
- *
+ * FIXME: As this function is currently part of the user-facing API, 
+ *  it should not care about the number of workers specified.
+ *  If we want static allocation of workers, as implemented now,
+ *  it must be removed from the API.
  */
 int lf_thread_create(lf_thread_t* thread, void *(*lf_thread) (void *), void* arguments) {
     // Use static id to map each created thread to a 

--- a/core/platform/lf_zephyr_support.c
+++ b/core/platform/lf_zephyr_support.c
@@ -337,6 +337,13 @@ int lf_notify_of_event() {
 #define _LF_STACK_SIZE 1024
 // FIXME: What is an appropriate thread prio?
 #define _LF_THREAD_PRIORITY 5
+
+// If NUMBER_OF_WORKERS is not specified, or specified to 0. Then we default to 1
+#if !defined(NUMBER_OF_WORKERS) || NUMBER_OF_WORKERS==0
+#undef NUMBER_OF_WORKERS
+#define NUMBER_OF_WORKERS 1
+#endif
+
 static K_THREAD_STACK_ARRAY_DEFINE(stacks, NUMBER_OF_WORKERS, _LF_STACK_SIZE);
 static struct k_thread threads[NUMBER_OF_WORKERS];
 
@@ -367,7 +374,8 @@ int lf_available_cores() {
 int lf_thread_create(lf_thread_t* thread, void *(*lf_thread) (void *), void* arguments) {
     // Use static id to map each created thread to a 
     static int tid = 0;
-    
+
+    // Make sure we dont try to create too many threads
     if (tid > (NUMBER_OF_WORKERS-1)) {
         return -1;
     }

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -1031,7 +1031,9 @@ void start_threads() {
     LF_PRINT_LOG("Starting %u worker threads.", _lf_number_of_workers);
     _lf_thread_ids = (lf_thread_t*)malloc(_lf_number_of_workers * sizeof(lf_thread_t));
     for (unsigned int i = 0; i < _lf_number_of_workers; i++) {
-        lf_thread_create(&_lf_thread_ids[i], worker, NULL);
+        if (lf_thread_create(&_lf_thread_ids[i], worker, NULL) != 0) {
+            lf_print_error_and_exit("Could not start thread-%u", i);
+        }
     }
 }
 

--- a/core/threaded/scheduler_adaptive.c
+++ b/core/threaded/scheduler_adaptive.c
@@ -27,6 +27,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * This is a non-priority-driven scheduler. See scheduler.h for documentation.
  * @author{Peter Donovan <peterdonovan@berkeley.edu>}
  */
+#include "lf_types.h"
 #if defined SCHEDULER && SCHEDULER == ADAPTIVE
 #ifndef NUMBER_OF_WORKERS
 #define NUMBER_OF_WORKERS 1


### PR DESCRIPTION
This PR addresses various bugs that I discovered when debugging the QEMU emulation of the threaded runtime.
1. When number of workers were not specified the system could not create any workers through `lf_thread_create`. Fixed by turning off threading support until we know whether `lf_thread_create` should be a user-facing API.
2. In the threaded runtime, the adaptive scheduler was still used because it was missing a `#inlude "lf_types.h"` at the top.
3. Some left-over debug-code was using the low-res timer also in the `lf_clockgettime` implementetion for the hi-res timer.
4. The implementation of `lf_clock_gettime` for the low-res timer (which is what is used by QEMU), did not handle overflows which caused the emulation to stop after some 