### PR TITLE
Intended tag printed instead of last-seen tag in debug message

### DIFF
--- a/core/federated/RTI/rti.c
+++ b/core/federated/RTI/rti.c
@@ -889,8 +889,8 @@ void handle_next_event_tag(federate_t* fed) {
 
     tag_t intended_tag = extract_tag(buffer);
     LF_PRINT_LOG("RTI received from federate %d the Next Event Tag (NET) (%ld, %u).",
-        fed->id, fed->next_event.time - start_time,
-        fed->next_event.microstep);
+        fed->id, intended_tag.time - start_time,
+        intended_tag.microstep);
     update_federate_next_event_tag_locked(
         fed->id,
         intended_tag


### PR DESCRIPTION
The log message in [rti.c/#L891](https://github.com/lf-lang/reactor-c/blob/2ec5deff12daf66ce106892083443fc85385d035/core/federated/RTI/rti.c#L891) says that it prints the received next event tag but actually it prints the current next event tag of its federate.