### PR TITLE
Add new tracepoint for deadline misses

### DIFF
--- a/core/reactor.c
+++ b/core/reactor.c
@@ -169,6 +169,7 @@ int _lf_do_step(void) {
             // Handle the local deadline first.
             if (reaction->deadline == 0 || physical_time > current_tag.time + reaction->deadline) {
                 LF_PRINT_LOG("Deadline violation. Invoking deadline handler.");
+                tracepoint_reaction_deadline_missed(reaction, 0);
                 // Deadline violation has occurred.
                 violation = true;
                 // Invoke the local handler, if there is one.

--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -1463,6 +1463,7 @@ void schedule_output_reactions(reaction_t* reaction, int worker) {
             // Check for deadline violation.
             if (downstream_to_execute_now->deadline == 0 || physical_time > current_tag.time + downstream_to_execute_now->deadline) {
                 // Deadline violation has occurred.
+                tracepoint_reaction_deadline_missed(downstream_to_execute_now, worker);
                 violation = true;
                 // Invoke the local handler, if there is one.
                 reaction_function_t handler = downstream_to_execute_now->deadline_violation_handler;

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -816,6 +816,7 @@ bool _lf_worker_handle_deadline_violation_for_reaction(int worker_number, reacti
         // Check for deadline violation.
         if (reaction->deadline == 0 || physical_time > current_tag.time + reaction->deadline) {
             // Deadline violation has occurred.
+            tracepoint_reaction_deadline_missed(reaction, worker_number);
             violation_occurred = true;
             // Invoke the local handler, if there is one.
             reaction_function_t handler = reaction->deadline_violation_handler;

--- a/core/trace.c
+++ b/core/trace.c
@@ -516,6 +516,15 @@ void tracepoint_scheduler_advancing_time_ends() {
 }
 
 /**
+ * Trace the occurrence of a deadline miss.
+ * @param reaction Pointer to the reaction_t struct for the reaction.
+ * @param worker The thread number of the worker thread or 0 for unthreaded execution.
+ */
+void tracepoint_reaction_deadline_missed(reaction_t *reaction, int worker) {
+    tracepoint(reaction_deadline_missed, reaction->self, reaction->number, worker, NULL, NULL, 0);
+}
+
+/**
  * Flush any buffered trace records to the trace file and
  * close the file.
  */

--- a/include/core/trace.h
+++ b/include/core/trace.h
@@ -64,7 +64,7 @@ typedef enum {
     worker_wait_starts,
     worker_wait_ends,
     scheduler_advancing_time_starts,
-    scheduler_advancing_time_ends,
+    scheduler_advancing_time_ends
 } trace_event_t;
 
 #ifdef LF_TRACE

--- a/include/core/trace.h
+++ b/include/core/trace.h
@@ -57,13 +57,14 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 typedef enum {
     reaction_starts,
     reaction_ends,
+    reaction_deadline_missed,
     schedule_called,
     user_event,
     user_value,
     worker_wait_starts,
     worker_wait_ends,
     scheduler_advancing_time_starts,
-    scheduler_advancing_time_ends
+    scheduler_advancing_time_ends,
 } trace_event_t;
 
 #ifdef LF_TRACE
@@ -74,6 +75,7 @@ typedef enum {
 static const char* trace_event_names[] = {
         "Reaction starts",
         "Reaction ends",
+        "Reaction deadline missed",
         "Schedule called",
         "User-defined event",
         "User-defined valued event",
@@ -235,6 +237,15 @@ void tracepoint_scheduler_advancing_time_starts();
  */
 void tracepoint_scheduler_advancing_time_ends();
 
+
+/**
+ * Trace the occurence of a deadline miss.
+ * @param reaction Pointer to the reaction_t struct for the reaction.
+ * @param worker The thread number of the worker thread or 0 for unthreaded execution.
+ */
+void tracepoint_reaction_deadline_missed(reaction_t *reaction, int worker);
+
+
 void stop_trace(void);
 
 #else
@@ -252,6 +263,7 @@ void stop_trace(void);
 #define tracepoint_worker_wait_ends(...)
 #define tracepoint_scheduler_advancing_time_starts(...);
 #define tracepoint_scheduler_advancing_time_ends(...);
+#define tracepoint_reaction_deadline_missed(...);
 
 #define start_trace(...)
 #define stop_trace(...)


### PR DESCRIPTION
Solves #168 By doing the following:
1. Introducing a new tracepoint called `reaction_deadline_missed`.
2. Adding a tracepoint in reactor.c reactor_common.c and reactor_threaded.c when a deadline violation is detected.

We do NOT trace it in the `lf_check_deadline` API function, even though it can trigger the execution of the deadline handler. This is because, semantically, it is not a deadline miss if it expires during reaction execution.