### PR TITLE
Draft: Remove unnecessary LTC messages to optimize the RTI

### DIFF
--- a/core/federated/RTI/rti_lib.c
+++ b/core/federated/RTI/rti_lib.c
@@ -566,7 +566,10 @@ void update_federate_next_event_tag_locked(uint16_t federate_id, tag_t next_even
         next_event_tag = min_in_transit_tag;
     }
 
-    _RTI.federates[federate_id].next_event = next_event_tag;
+    if (lf_tag_compare(_RTI.federates[federate_id].next_event, next_event_tag) != 0) {
+        _RTI.federates[federate_id].next_event = next_event_tag;
+        //FIXME: notify upstream federates
+    }
 
     LF_PRINT_DEBUG(
        "RTI: Updated the recorded next event tag for federate %d to (%ld, %u).",


### PR DESCRIPTION
This draft PR tries to remove unnecessary LTC messages from federates to the RTI.
To do this, the RTI has to forward NET messages to indicate when the LTC message is needed. 

For more information, please see this discussion, [lingua-franca/discussions/1626](https://github.com/lf-lang/lingua-franca/discussions/1626).