### PR TITLE
Fix compile error when unthreded execution and tracing are both enabl…

### DIFF
--- a/core/trace.c
+++ b/core/trace.c
@@ -356,6 +356,14 @@ void start_trace(char* filename) {
 
     lf_thread_create(&_lf_flush_trace_thread, flush_trace, NULL);
 
+#ifdef LF_UNTHREADED 
+    // FIXME: If LF_UNTHREADED is defined, then no thread will be create to 
+    //        flush the file (instruction above).
+    //        A sequential mechanism is needed for emptying the buffer into the
+    //        file when needed.
+    ; // WIP
+#endif // LF_UNTHREADED
+
     LF_PRINT_DEBUG("Started tracing.");
 }
 

--- a/include/core/platform.h
+++ b/include/core/platform.h
@@ -79,8 +79,16 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #error "Platform not supported"
 #endif
 
-#if !defined(LF_THREADED) && !defined(_LF_TRACE)
-    typedef void lf_mutex_t;
+#if defined(LF_UNTHREADED) 
+    #if defined(LF_TRACE)
+        typedef void *lf_mutex_t;
+        typedef void *lf_cond_t;
+        typedef void *lf_thread_t;
+    #else // !defined(_LF_TRACE) ???
+        // FIXME: Not sure if _LF_TRACE is needed anymore, as it is commented 
+        // out in trace.c. In both case, shouldn't it lf_mutex_t be void*?
+        typedef void lf_mutex_t;
+    #endif
 #endif
 
 #define LF_TIMEOUT _LF_TIMEOUT
@@ -333,5 +341,20 @@ extern int lf_sleep_until_locked(instant_t wakeup_time);
  * @deprecated version of "lf_sleep"
  */
 DEPRECATED(extern int lf_nanosleep(interval_t sleep_duration));
+
+// empty definition in case we have LF_UNTHREADED and LF_TRACE
+#if (defined LF_UNTHREADED && defined LF_TRACE)
+#define lf_available_cores(...);
+#define lf_thread_create(...);
+#define lf_thread_join(...);
+#define lf_mutex_init(...);
+#define lf_mutex_lock(...);
+#define lf_mutex_unlock(...);
+#define lf_cond_init(...);
+#define lf_cond_broadcast(...);
+#define lf_cond_signal(...);
+#define lf_cond_wait(...);
+#define lf_cond_timedwait(...);
+#endif // LF_UNTHREADED && LF_TRACE
 
 #endif // PLATFORM_H


### PR DESCRIPTION
This PR fixes the compile error due to tracing in an unthreaded execution. 
Currently, the .lft file is generated, but w/o contents.
Writing to the trace file is WIP. 