### PR TITLE
Added lf_wait_for_event()

### DIFF
--- a/core/platform/lf_arduino_support.c
+++ b/core/platform/lf_arduino_support.c
@@ -175,6 +175,14 @@ int lf_notify_of_event() {
    return 0;
 }
 
+int lf_wait_for_event(interval_t timeout) {
+    int result = lf_sleep(timeout);
+    if (result) {
+        return LF_TIMEOUT;
+    }
+    return 0;
+}
+
 #else
 #warning "Threaded support on Arduino is still experimental"
 #include "ConditionWrapper.h"

--- a/core/platform/lf_nrf52_support.c
+++ b/core/platform/lf_nrf52_support.c
@@ -292,4 +292,12 @@ int lf_notify_of_event() {
     _lf_async_event = true;
     return 0;
 }
+
+int lf_wait_for_event(interval_t timeout) {
+    int result = lf_sleep_until_locked(lf_time_physical() + timeout);
+    if (result) {
+        return LF_TIMEOUT;
+    }
+    return 0;
+}
 #endif

--- a/core/platform/lf_os_single_threaded_support.c
+++ b/core/platform/lf_os_single_threaded_support.c
@@ -34,6 +34,10 @@ int lf_notify_of_event() {
     return 0;
 }
 
+int lf_wait_for_event(interval_t timeout) {
+    return 0;
+}
+
 int lf_ack_events() {
     return 0;
 }

--- a/core/platform/lf_zephyr_support.c
+++ b/core/platform/lf_zephyr_support.c
@@ -344,6 +344,18 @@ int lf_notify_of_event() {
    return 0;
 }
 
+int lf_wait_for_event(instant_t timeout) {
+    lf_critical_section_exit();
+    instant_t wait_until_time = lf_time_physical() + timeout;
+    // Busy wait.
+    while(!_lf_async_event && lf_time_physical() < wait_until_time) {}
+    if (_lf_async_event) {
+        _lf_async_event = false;
+        return 0;
+    }
+    return LF_TIMEOUT;
+}
+
 #endif
 
 

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -1179,6 +1179,10 @@ int lf_notify_of_event() {
     return lf_cond_broadcast(&event_q_changed);
 }
 
+int lf_wait_for_event(instant_t timeout) {
+    return lf_cond_timedwait(&event_q_changed, lf_time_physical() + timeout);
+}
+
 /**
  * @brief Enter critical section by locking the global mutex.
  */

--- a/include/core/platform.h
+++ b/include/core/platform.h
@@ -125,6 +125,14 @@ extern int lf_critical_section_exit();
  */
 extern int lf_notify_of_event();
 
+/**
+ * @brief Wait for an event notification.
+ * The caller should call lf_critical_section_enter() before calling this function.
+ * @param timeout Maximum time to wait.
+ * @return 0 if event occurred and LF_TIMEOUT if timeout occurred.
+ */
+extern int lf_wait_for_event(interval_t timeout);
+
 // For platforms with threading support, the following functions
 // abstract the API so that the LF runtime remains portable.
 #if defined LF_THREADED || defined _LF_TRACE


### PR DESCRIPTION
In the platform.h definitions, we have `lf_critical_section_enter()`, `lf_critical_section_exit()`, and `lf_notify_of_event`. But missing from this is `lf_wait_for_event()`.  This PR adds that function, including implementations for Zephyr, Arduino, and nrf52, although I'm not entirely sure those implementations are correct.

In lingua-franca, there is a corresponding branch `wait-for-event` that adds two tests, `test/C/src/WaitForEvent.lf` and `test/C/src/WaitForEvent.lf2`.  I've verified that these tests work for threaded and unthreaded runtimes.

The reason for adding this is that we can make tracing work for all platforms if we add this function, I think.