### PR TITLE
Documentation and code cleanup

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,5 +1,5 @@
 All files in this repository are copyrighted by their respective authors
-and/or institutions (as identified in each file) and bear a BSD 2-Clause License:
+and/or institutions and bear a BSD 2-Clause License:
 
 Copyright (c) 2021-2023, by the Authors
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,7 @@
-BSD 2-Clause License
+All files in this repository are copyrighted by their respective authors
+and/or institutions (as identified in each file) and bear a BSD 2-Clause License:
 
-Copyright (c) 2021, The Lingua Franca Coordination Language
+Copyright (c) 2021-2023, by the Authors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,7 +2,6 @@ All files in this repository are copyrighted by their respective authors
 and/or institutions (as identified in each file) and bear a BSD 2-Clause License:
 
 Copyright (c) 2021-2023, by the Authors
-All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -4,32 +4,21 @@
 # Reactor-C: A reactor runtime implementation in C
 
 ## Documentation
-To generate and view documentation, follow the following steps:
-- Install `python3`, `pip3` and `doxygen`
-- Install the required Python modules:
-  - `pip3 install sphinx`
-  - `pip3 install sphinx_sitemap`
-  - `pip3 install sphinx-rtd-theme`
-  - `pip3 install breathe`
-  - `pip3 install exhale`
-- Check out this repo and build the docs:
-  - `git clone git@github.com:lf-lang/reactor-c.git`
-  - `cd reactor-c/doc-sphinx`
-  - `make html`
-- Point your browser to the generated HTML page:
-  - `firefox _build/html/index.html`
+To generate and view documentation, see [docs/README.md](docs/README.md).
 
 ## Testing
 The Github Actions tests for this repo will automatically run all the C Lingua Franca tests with each of the available schedulers. The version of the lingua-franca repo that is used to do this is specified by the lingua-franca-ref.txt file in this directory.
 
 To create a new test, write a C program with a file name ending in "test.c"
 in a subdirectory of the `test` directory. That file should contain a main and should return 0 if the test succeeds.
+
 * Tests in the `general` subdirectory will always be run.
 * Tests in the `single-threaded` and `multithreaded` subdirectories will be run
 depending on parameters passed to `cmake`.
 
 To run tests for the single-threaded runtime, execute the following. Note that
 `-U` is required to undefine a name that may be cached from a previous run.
+
 - `cd build`
 - `cmake .. -UNUMBER_OF_WORKERS`
 - `cmake --build .`
@@ -37,6 +26,7 @@ To run tests for the single-threaded runtime, execute the following. Note that
 
 To run tests for the multithreaded runtime, provide a nonzero number of workers
 when invoking `cmake`. For example:
+
 - `cmake .. -DNUMBER_OF_WORKERS=2`
 
 To define/undefine other preprocessor definitions such as `LOG_LEVEL`, pass them as

--- a/core/federated/RTI/rti_lib.c
+++ b/core/federated/RTI/rti_lib.c
@@ -49,6 +49,9 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "rti_lib.h"
 #include "string.h"
 
+// Global variables defined in tag.c:
+extern instant_t start_time;
+
 /**
  * The state of this RTI instance.
  */
@@ -278,7 +281,7 @@ tag_t transitive_next_event(federate_t* fed, tag_t candidate, bool visited[]) {
                 &_RTI.federates[fed->upstream[i]], result, visited);
 
         // Add the "after" delay of the connection to the result.
-        upstream_result = _lf_delay_tag(upstream_result, fed->upstream_delay[i]);
+        upstream_result = lf_delay_tag(upstream_result, fed->upstream_delay[i]);
 
         // If the adjusted event time is less than the result so far, update the result.
         if (lf_tag_compare(upstream_result, result) < 0) {
@@ -373,7 +376,7 @@ bool send_advance_grant_if_safe(federate_t* fed) {
         // Ignore this federate if it has resigned.
         if (upstream->state == NOT_CONNECTED) continue;
 
-        tag_t candidate = _lf_delay_tag(upstream->completed, fed->upstream_delay[j]);
+        tag_t candidate = lf_delay_tag(upstream->completed, fed->upstream_delay[j]);
 
         if (lf_tag_compare(candidate, min_upstream_completed) < 0) {
             min_upstream_completed = candidate;
@@ -426,7 +429,7 @@ bool send_advance_grant_if_safe(federate_t* fed) {
         // Adjust by the "after" delay.
         // Note that "no delay" is encoded as NEVER,
         // whereas one microstep delay is encoded as 0LL.
-        tag_t candidate = _lf_delay_tag(upstream_next_event, fed->upstream_delay[j]);
+        tag_t candidate = lf_delay_tag(upstream_next_event, fed->upstream_delay[j]);
 
         if (lf_tag_compare(candidate, t_d) < 0) {
             t_d = candidate;

--- a/core/federated/RTI/rti_lib.c
+++ b/core/federated/RTI/rti_lib.c
@@ -1,33 +1,10 @@
 /**
  * @file
- * @author Edward A. Lee (eal@berkeley.edu)
+ * @author Edward A. Lee
  * @author Soroush Bateni
- *
- * @section LICENSE
-Copyright (c) 2020, The University of California at Berkeley.
-
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice,
-   this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
-THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
-THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
- * @section DESCRIPTION
- * Runtime infrastructure for distributed Lingua Franca programs.
+ * @copyright (c) 2020-2023, The University of California at Berkeley
+ * License in [BSD 2-clause](https://github.com/lf-lang/reactor-c/blob/main/LICENSE.md)
+ * @brief Runtime infrastructure (RTI) for distributed Lingua Franca programs.
  *
  * This implementation creates one thread per federate so as to be able
  * to take advantage of multiple cores. It may be more efficient, however,
@@ -47,7 +24,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #include "rti_lib.h"
-#include "string.h"
+#include <string.h>
 
 // Global variables defined in tag.c:
 extern instant_t start_time;

--- a/core/federated/RTI/rti_lib.h
+++ b/core/federated/RTI/rti_lib.h
@@ -2,34 +2,11 @@
  * @file
  * @author Edward A. Lee (eal@berkeley.edu)
  * @author Soroush Bateni (soroush@utdallas.edu)
+ * @copyright (c) 2020-2023, The University of California at Berkeley
+ * License in [BSD 2-clause](https://github.com/lf-lang/reactor-c/blob/main/LICENSE.md)
+ * @brief Declarations for runtime infrastructure (RTI) for distributed Lingua Franca programs.
  *
- * @section LICENSE
-Copyright (c) 2020, The University of California at Berkeley.
-
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice,
-   this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
-THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
-THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
- * @section DESCRIPTION
- * Header file for the runtime infrastructure for distributed Lingua Franca programs.
- *
-*/
+ */
 
 #ifndef RTI_LIB_H
 #define RTI_LIB_H

--- a/core/federated/clock-sync.c
+++ b/core/federated/clock-sync.c
@@ -44,6 +44,10 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "net_util.h"
 #include "util.h"
 
+// Global variables defined in tag.c:
+extern interval_t _lf_time_physical_clock_offset;
+extern interval_t _lf_time_test_physical_clock_offset;
+
 /**
  * Keep a record of connection statistics
  * and the remote physical clock of the RTI.
@@ -396,12 +400,6 @@ void handle_T4_clock_sync_message(unsigned char* buffer, int socket, instant_t r
         // Note that estimated_clock_error is calculated using lf_time_physical() which includes
         // the _lf_time_physical_clock_offset adjustment.
         adjustment = estimated_clock_error / _LF_CLOCK_SYNC_ATTENUATION;
-
-        // FIXME: Adjust drift.
-        // _lf_global_physical_clock_drift = ((r1 - t1) -
-        //                                    (_lf_rti_socket_stat.local_physical_clock_snapshot_T2 -
-        //                                    _lf_rti_socket_stat.remote_physical_clock_snapshot_T1)) /
-        //                                    (t1 - _lf_rti_socket_stat.remote_physical_clock_snapshot_T1);
     } else {
         // Use of TCP socket means we are in the startup phase, so
         // rather than adjust the clock offset, we simply set it to the

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -66,6 +66,11 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <openssl/hmac.h> // For HMAC-based authentication of federates.
 #endif
 
+// Global variables defined in tag.c:
+extern instant_t _lf_last_reported_unadjusted_physical_time_ns;
+extern tag_t current_tag;
+extern instant_t start_time;
+
 // Error messages.
 char* ERROR_SENDING_HEADER = "ERROR sending header information to federate via RTI";
 char* ERROR_SENDING_MESSAGE = "ERROR sending message to federate via RTI";
@@ -376,7 +381,7 @@ int send_timed_message(interval_t additional_delay,
 
     // Apply the additional delay to the current tag and use that as the intended
     // tag of the outgoing message
-    tag_t current_message_intended_tag = _lf_delay_tag(lf_tag(),
+    tag_t current_message_intended_tag = lf_delay_tag(lf_tag(),
                                                     additional_delay);
 
     // Next 8 + 4 will be the tag (timestamp, microstep)
@@ -1337,7 +1342,7 @@ void update_last_known_status_on_input_port(tag_t tag, int port_id) {
                 if (lf_tag_compare(tag,
                         input_port_action->last_known_status_tag) == 0) {
                     // If the intended tag for an input port is equal to the last known status, we need
-                    // to increment the microstep. This is a direct result of the behavior of the _lf_delay_tag()
+                    // to increment the microstep. This is a direct result of the behavior of the lf_delay_tag()
                     // semantics in tag.h.
                     tag.microstep++;
                 }
@@ -1507,7 +1512,7 @@ void send_port_absent_to_federate(interval_t additional_delay,
 
     // Apply the additional delay to the current tag and use that as the intended
     // tag of the outgoing message
-    tag_t current_message_intended_tag = _lf_delay_tag(lf_tag(),
+    tag_t current_message_intended_tag = lf_delay_tag(lf_tag(),
                                                     additional_delay);
 
     LF_PRINT_LOG("Sending port "

--- a/core/lf_token.c
+++ b/core/lf_token.c
@@ -30,6 +30,12 @@
  * Functions supporting token types.  See lf_token.h for docs.
  */
 
+/**
+ * Counter used to issue a warning if memory is
+ * allocated for message payloads and never freed.
+ */
+static int _lf_count_payload_allocations;
+
 #include <stdbool.h>
 #include <assert.h>
 #include <string.h>  // Defines memcpy

--- a/core/lf_token.c
+++ b/core/lf_token.c
@@ -34,7 +34,7 @@
  * Counter used to issue a warning if memory is
  * allocated for message payloads and never freed.
  */
-static int _lf_count_payload_allocations;
+int _lf_count_payload_allocations;
 
 #include <stdbool.h>
 #include <assert.h>

--- a/core/modal_models/modes.c
+++ b/core/modal_models/modes.c
@@ -530,7 +530,7 @@ void _lf_process_mode_changes(
         if (_lf_mode_triggered_reactions_request) {
             // Insert a dummy event in the event queue for the next microstep to make
             // sure startup/reset reactions (if any) are triggered as soon as possible.
-            pqueue_insert(event_q, _lf_create_dummy_events(NULL, current_tag.time, NULL, 1));
+            pqueue_insert(event_q, _lf_create_dummy_events(NULL, lf_tag().time, NULL, 1));
         }
     }
 }

--- a/core/platform/lf_unix_clock_support.c
+++ b/core/platform/lf_unix_clock_support.c
@@ -7,7 +7,9 @@
 
 /**
  * Offset to _LF_CLOCK that would convert it
- * to epoch time.
+ * to epoch time. This is applied to the physical clock
+ * to get a more meaningful and universal time.
+ *
  * For CLOCK_REALTIME, this offset is always zero.
  * For CLOCK_MONOTONIC, it is the difference between those
  * clocks at the start of the execution.

--- a/core/reactor.c
+++ b/core/reactor.c
@@ -46,6 +46,10 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <signal.h> // To trap ctrl-c and invoke termination().
 #endif
 
+// Global variable defined in tag.c:
+extern tag_t current_tag;
+extern instant_t start_time;
+
 /**
  * @brief Queue of triggered reactions at the current tag.
  *

--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -60,6 +60,9 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 extern tag_t current_tag;
 extern instant_t start_time;
 
+// Global variable defined in lf_token.c:
+extern int _lf_count_payload_allocations;
+
 /**
  * Indicator of whether to wait for physical time to match logical time.
  * By default, execution will wait. The command-line argument -fast will

--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -56,9 +56,9 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "hashset/hashset.h"
 #include "hashset/hashset_itr.h"
 
-////////////////////////////////////////////////////////////
-//// Global variables :(
-
+// Global variable defined in tag.c:
+extern tag_t current_tag;
+extern instant_t start_time;
 
 /**
  * Indicator of whether to wait for physical time to match logical time.
@@ -1237,13 +1237,6 @@ trigger_handle_t _lf_schedule_value(lf_action_base_t* action, interval_t extra_d
     return return_value;
 }
 
-/**
- * Advance from the current tag to the next. If the given next_time is equal to
- * the current time, then increase the microstep. Otherwise, update the current
- * time and set the microstep to zero.
- *
- * @param next_time The time step to advance to.
- */
 void _lf_advance_logical_time(instant_t next_time) {
     // FIXME: The following checks that _lf_advance_logical_time()
     // is being called correctly. Namely, check if logical time
@@ -1293,28 +1286,6 @@ trigger_handle_t _lf_schedule_int(lf_action_base_t* action, interval_t extra_del
     int* container = (int*)malloc(sizeof(int));
     *container = value;
     return _lf_schedule_value(action, extra_delay, container, 1);
-}
-
-/**
- * Check the deadline of the currently executing reaction against the
- * current physical time. If the deadline has passed, invoke the deadline
- * handler (if invoke_deadline_handler parameter is set true) and return true.
- * Otherwise, return false.
- *
- * @param self The self struct of the reactor.
- * @param invoke_deadline_handler When this is set true, also invoke deadline
- *  handler if the deadline has passed.
- * @return True if the specified deadline has passed and false otherwise.
- */
-bool _lf_check_deadline(self_base_t* self, bool invoke_deadline_handler) {
-    reaction_t* reaction = self->executing_reaction;
-    if (lf_time_physical() > lf_time_logical() + reaction->deadline) {
-        if (invoke_deadline_handler) {
-            reaction->deadline_violation_handler(self);
-        }
-        return true;
-    }
-    return false;
 }
 
 /**
@@ -1701,13 +1672,12 @@ void initialize(void) {
     // Initialize the trigger table.
     _lf_initialize_trigger_objects();
 
-    physical_start_time = lf_time_physical();
-    current_tag.time = physical_start_time;
-    start_time = current_tag.time;
+    start_time = lf_time_physical();
+    current_tag.time = start_time;
 
     LF_PRINT_DEBUG("Start time: " PRINTF_TIME "ns", start_time);
 
-    struct timespec physical_time_timespec = {physical_start_time / BILLION, physical_start_time % BILLION};
+    struct timespec physical_time_timespec = {start_time / BILLION, start_time % BILLION};
 
     printf("---- Start execution at time %s---- plus %ld nanoseconds.\n",
             ctime(&physical_time_timespec.tv_sec), physical_time_timespec.tv_nsec);
@@ -1762,9 +1732,9 @@ void termination(void) {
         lf_comma_separated_time(time_buffer, elapsed_time);
         printf("---- Elapsed logical time (in nsec): %s\n", time_buffer);
 
-        // If physical_start_time is 0, then execution didn't get far enough along
+        // If start_time is 0, then execution didn't get far enough along
         // to initialize this.
-        if (physical_start_time > 0LL) {
+        if (start_time > 0LL) {
             lf_comma_separated_time(time_buffer, lf_time_physical_elapsed());
             printf("---- Elapsed physical time (in nsec): %s\n", time_buffer);
         }

--- a/core/tag.c
+++ b/core/tag.c
@@ -3,32 +3,9 @@
  * @author Edward A. Lee
  * @author Soroush Bateni
  * @author Hou Seng (Steven) Wong
- *
- * @section LICENSE
-Copyright (c) 2020, The University of California at Berkeley.
-
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice,
-   this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
-THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
-THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
- * @section DESCRIPTION
- * Implementation file for tag functions for Lingua Franca programs.
+ * @copyright (c) 2020-2023, The University of California at Berkeley
+ * License in [BSD 2-clause](https://github.com/lf-lang/reactor-c/blob/main/LICENSE.md)
+ * @brief Implementation of time and tag functions for Lingua Franca programs.
  */
 
 #include <stdbool.h>
@@ -40,7 +17,23 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "platform.h"
 #include "util.h"
 
-// Global variables :(
+/**
+ * An enum for specifying the desired tag when calling "lf_time"
+ */
+typedef enum _lf_time_type {
+    LF_LOGICAL,
+    LF_PHYSICAL,
+    LF_ELAPSED_LOGICAL,
+    LF_ELAPSED_PHYSICAL,
+    LF_START
+} _lf_time_type;
+
+//////////////// Global variables declared in tag.h:
+
+// Global variables declared in tag.h:
+instant_t start_time = NEVER;
+
+//////////////// Global variables not declared in tag.h (must be declared extern if used elsewhere):
 
 /**
  * Current time in nanoseconds since January 1, 1970
@@ -50,29 +43,11 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 tag_t current_tag = {.time = 0LL, .microstep = 0};
 
 /**
- * Physical time at the start of the execution.
- * This should only ever be accessed while holding the mutex lock.
- */
-instant_t physical_start_time = NEVER;
-
-/**
- * Logical time at the start of execution.
- * This should only ever be accessed while holding the mutex lock.
- */
-instant_t start_time = NEVER;
-
-/**
  * Global physical clock offset.
  * Initially set according to the RTI's clock in federated
  * programs.
  */
 interval_t _lf_time_physical_clock_offset = 0LL;
-
-/**
- * A measure of calculating the drift between the federate's
- * clock and the RTI's clock
- */
-interval_t _lf_global_physical_clock_drift = 0LL;
 
 /**
  * A test offset that is applied to the clock.
@@ -99,72 +74,7 @@ instant_t _lf_last_reported_physical_time_ns = 0LL;
  */
 instant_t _lf_last_reported_unadjusted_physical_time_ns = NEVER;
 
-/**
- * Return the current tag, a logical time, microstep pair.
- */
-tag_t lf_tag() {
-    return current_tag;
-}
-
-/**
- * Compare two tags. Return -1 if the first is less than
- * the second, 0 if they are equal, and +1 if the first is
- * greater than the second. A tag is greater than another if
- * its time is greater or if its time is equal and its microstep
- * is greater.
- * @param tag1
- * @param tag2
- * @return -1, 0, or 1 depending on the relation.
- */
-int lf_tag_compare(tag_t tag1, tag_t tag2) {
-    if (tag1.time < tag2.time) {
-        return -1;
-    } else if (tag1.time > tag2.time) {
-        return 1;
-    } else if (tag1.microstep < tag2.microstep) {
-        return -1;
-    } else if (tag1.microstep > tag2.microstep) {
-        return 1;
-    } else {
-        return 0;
-    }
-}
-
-/**
- * Delay a tag by the specified time interval to realize the "after" keyword.
- * If either the time interval or the time field of the tag is NEVER,
- * return the unmodified tag.
- * If the time interval is 0LL, add one to the microstep, leave
- * the time field alone, and return the result.
- * Otherwise, add the interval to the time field of the tag and reset
- * the microstep to 0.
- * If the sum overflows, saturate the time value at FOREVER.
- *
- * Note that normally it makes no sense to call this with a negative
- * interval (except NEVER), but this is not checked.
- *
- * @param tag The tag to increment.
- * @param interval The time interval.
- */
-tag_t _lf_delay_tag(tag_t tag, interval_t interval) {
-    if (tag.time == NEVER || interval == NEVER) return tag;
-    tag_t result = tag;
-    if (interval == 0LL) {
-        // Note that unsigned variables will wrap on overflow.
-        // This is probably the only reasonable thing to do with overflowing
-        // microsteps.
-        result.microstep++;
-    } else {
-        // Note that overflow in C is undefined for signed variables.
-        if (FOREVER - interval < result.time) {
-            result.time = FOREVER;
-        } else {
-            result.time += interval;
-        }
-        result.microstep = 0;
-    }
-    return result;
-}
+////////////////  Functions not declared in tag.h (local use only)
 
 /**
  * Return the current physical time in nanoseconds since January 1, 1970,
@@ -185,15 +95,6 @@ instant_t _lf_physical_time() {
     // Apply the test offset
     adjusted_clock_ns += _lf_time_test_physical_clock_offset;
 
-    // if (_lf_global_physical_clock_drift != 0LL
-    //         && _lf_last_clock_sync_instant != 0LL) {
-    //     // Apply the calculated drift, if appropriate
-    //     interval_t drift = (adjusted_clock_ns - _lf_last_clock_sync_instant) *
-    //                        _lf_global_physical_clock_drift;
-    //     adjusted_clock_ns += drift;
-    //     LF_PRINT_DEBUG("Physical time adjusted for clock drift by " PRINTF_TIME ".", drift);
-    // }
-
     // Check if the clock has progressed since the last reported value
     // This ensures that the clock is monotonic
     if (adjusted_clock_ns > _lf_last_reported_physical_time_ns) {
@@ -209,7 +110,6 @@ instant_t _lf_physical_time() {
 
     return _lf_last_reported_physical_time_ns;
 }
-
 
 /**
  * Get the time specified by "type".
@@ -238,7 +138,7 @@ instant_t _lf_time(_lf_time_type type) {
     case LF_ELAPSED_LOGICAL:
         return current_tag.time - start_time;
     case LF_ELAPSED_PHYSICAL:
-        return _lf_physical_time() - physical_start_time;
+        return _lf_physical_time() - start_time;
     case LF_START:
         return start_time;
     default:
@@ -246,75 +146,70 @@ instant_t _lf_time(_lf_time_type type) {
     }
 }
 
-/**
- * Return the current logical time in nanoseconds since January 1, 1970.
- */
+////////////////  Functions declared in tag.h
+
+tag_t lf_tag() {
+    return current_tag;
+}
+
+int lf_tag_compare(tag_t tag1, tag_t tag2) {
+    if (tag1.time < tag2.time) {
+        return -1;
+    } else if (tag1.time > tag2.time) {
+        return 1;
+    } else if (tag1.microstep < tag2.microstep) {
+        return -1;
+    } else if (tag1.microstep > tag2.microstep) {
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
+tag_t lf_delay_tag(tag_t tag, interval_t interval) {
+    if (tag.time == NEVER || interval == NEVER) return tag;
+    tag_t result = tag;
+    if (interval == 0LL) {
+        // Note that unsigned variables will wrap on overflow.
+        // This is probably the only reasonable thing to do with overflowing
+        // microsteps.
+        result.microstep++;
+    } else {
+        // Note that overflow in C is undefined for signed variables.
+        if (FOREVER - interval < result.time) {
+            result.time = FOREVER;
+        } else {
+            result.time += interval;
+        }
+        result.microstep = 0;
+    }
+    return result;
+}
+
 instant_t lf_time_logical(void) {
     return _lf_time(LF_LOGICAL);
 }
 
-/**
- * Return the elapsed logical time in nanoseconds since the start of execution.
- */
 interval_t lf_time_logical_elapsed(void) {
     return _lf_time(LF_ELAPSED_LOGICAL);
 }
 
-
-/**
- * Return the current physical time in nanoseconds since January 1, 1970,
- * adjusted by the global physical time offset.
- */
 instant_t lf_time_physical(void) {
     return _lf_time(LF_PHYSICAL);
 }
 
-/**
- * Return the elapsed physical time in nanoseconds.
- * This is the time returned by lf_time_physical() minus the
- * physical start time as measured by lf_time_physical() when
- * the program was started.
- */
 instant_t lf_time_physical_elapsed(void) {
     return _lf_time(LF_ELAPSED_PHYSICAL);
 }
 
-
-/**
- * Return the physical time of the start of execution in nanoseconds. *
- * On many platforms, this is the number of nanoseconds
- * since January 1, 1970, but it is actually platform dependent. *
- * @return A time instant.
- */
 instant_t lf_time_start(void) {
     return _lf_time(LF_START);
 }
 
-/**
- * Set a fixed offset to the physical clock.
- * After calling this, the value returned by lf_time_physical()
- * and get_elpased_physical_time() will have this specified offset
- * added to what it would have returned before the call.
- */
 void lf_set_physical_clock_offset(interval_t offset) {
     _lf_time_test_physical_clock_offset += offset;
 }
 
-/**
- * Store into the specified buffer a string giving a human-readable
- * rendition of the specified time. The buffer must have length at least
- * equal to LF_TIME_BUFFER_LENGTH. The format is:
- * ```
- *    x weeks, x days, x hours, x minutes, x seconds, x unit
- * ```
- * where each `x` is a string of numbers with commas inserted if needed
- * every three numbers and `unit` is nanoseconds, microseconds, or
- * milliseconds.
- * @param buffer The buffer into which to write the string, having a length of
- * at least 58 characters.
- * @param time The time to write.
- * @return The number of characters written (not counting the null terminator).
- */
 size_t lf_readable_time(char* buffer, instant_t time) {
     char* original_buffer = buffer;
     bool lead = false; // Set to true when first clause has been printed.
@@ -397,17 +292,6 @@ size_t lf_readable_time(char* buffer, instant_t time) {
     return (buffer - original_buffer);
 }
 
-/**
- * Print a non-negative time value in nanoseconds with commas separating thousands
- * into the specified buffer. Ideally, this would use the locale to
- * use periods if appropriate, but I haven't found a sufficiently portable
- * way to do that.
- * @param buffer A buffer long enough to contain a 27-character string like
- * "-9,223,372,036,854,775,807".
- * @param time A time value.
- * @return The number of characters written into the buffer (not including
- *  the null terminator).
- */
 size_t lf_comma_separated_time(char* buffer, instant_t time) {
     size_t result = 0; // The number of characters printed.
     // If the number is zero, print it and return.
@@ -449,24 +333,3 @@ size_t lf_comma_separated_time(char* buffer, instant_t time) {
     }
     return result;
 }
-
-/**
- * For C++ compatibility, take a volatile tag_t and return a non-volatile
- * variant.
- */
-#ifdef __cplusplus
-tag_t _lf_convert_volatile_tag_to_nonvolatile(tag_t volatile const& vtag) {
-    tag_t non_volatile_tag;
-    non_volatile_tag.time = vtag.time;
-    non_volatile_tag.microstep = vtag.microstep;
-    return non_volatile_tag;
-}
-#else
-/**
- * @note This is an undefined behavior in C and should
- *  be used with utmost caution. See Section 6.7.2 of the C99 standard.
- */
-tag_t _lf_convert_volatile_tag_to_nonvolatile(tag_t volatile vtag) {
-    return vtag;
-}
-#endif

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -46,10 +46,14 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "scheduler.h"
 #include "tag.h"
 
+// Global variables defined in tag.c:
+extern instant_t _lf_last_reported_unadjusted_physical_time_ns;
+extern tag_t current_tag;
+extern instant_t start_time;
+
 /**
  * Global mutex and condition variable.
 */
-
 lf_mutex_t mutex;
 lf_cond_t event_q_changed;
 
@@ -137,7 +141,6 @@ void _lf_increment_global_tag_barrier_already_locked(tag_t future_tag) {
         lf_print_warning("Attempting to raise a barrier after the stop tag.");
         future_tag = stop_tag;
     }
-    tag_t current_tag = lf_tag();
     // Check to see if future_tag is actually in the future.
     if (lf_tag_compare(future_tag, current_tag) > 0) {
         // Future tag is actually in the future.
@@ -758,11 +761,6 @@ void _lf_initialize_start_tag() {
     LF_PRINT_DEBUG("Done waiting for start time " PRINTF_TIME ".", start_time);
     LF_PRINT_DEBUG("Physical time is ahead of current time by " PRINTF_TIME ". This should be small.",
             lf_time_physical() - start_time);
-
-    // Reinitialize the physical start time to match the start_time.
-    // Otherwise, reports of lf_time_physical() are not very meaningful
-    // w.r.t. logical time.
-    physical_start_time = start_time;
 
     // Each federate executes the start tag (which is the current
     // tag). Inform the RTI of this if needed.

--- a/core/threaded/scheduler_sync_tag_advance.c
+++ b/core/threaded/scheduler_sync_tag_advance.c
@@ -39,7 +39,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "trace.h"
 #include "util.h"
 
-/////////////////// External Variables /////////////////////////
+// Global variable defined in tag.c:
 extern tag_t current_tag;
 extern tag_t stop_tag;
 

--- a/core/utils/pqueue_support.h
+++ b/core/utils/pqueue_support.h
@@ -24,15 +24,9 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /**
  * @file pqueue_support.h
- * 
- * @author{Edward A. Lee <eal@berkeley.edu>}
- * @author{Marten Lohstroh <marten@berkeley.edu>}
- * 
+ * @author Edward A. Lee
+ * @author Marten Lohstroh
  * @brief Header-only support functions for pqueue.
- * @version 0.1
- * @date 2021-12-04
- * 
- * @copyright Copyright (c) 2022, The University of California at Berkeley. 
  */
 
 #ifndef PQUEUE_SUPPORT_H

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -2276,7 +2276,7 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED             += DOXYGEN_SHOULD_SKIP_THIS
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -1596,7 +1596,7 @@ DISABLE_INDEX          = NO
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-GENERATE_TREEVIEW      = NO
+GENERATE_TREEVIEW      = YES
 
 # When both GENERATE_TREEVIEW and DISABLE_INDEX are set to YES, then the
 # FULL_SIDEBAR option determines if the side bar is limited to only the treeview

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -44,7 +44,7 @@ PROJECT_NUMBER         =
 # for a project that appears at the top of each page and should give viewer a
 # quick idea about the purpose of the project. Keep the description short.
 
-PROJECT_BRIEF          =
+PROJECT_BRIEF          = "C Runtime for Lingua Franca"
 
 # With the PROJECT_LOGO tag one can specify a logo or an icon that is included
 # in the documentation. The maximum height of the logo should not exceed 55
@@ -68,7 +68,7 @@ OUTPUT_DIRECTORY       = _build
 # performance problems for the file system.
 # The default value is: NO.
 
-CREATE_SUBDIRS         = NO
+CREATE_SUBDIRS         = YES
 
 # If the ALLOW_UNICODE_NAMES tag is set to YES, doxygen will allow non-ASCII
 # characters to appear in the names of generated files. If set to NO, non-ASCII
@@ -197,7 +197,7 @@ JAVADOC_AUTOBRIEF      = NO
 # interpreted by doxygen.
 # The default value is: NO.
 
-JAVADOC_BANNER         = NO
+JAVADOC_BANNER         = YES
 
 # If the QT_AUTOBRIEF tag is set to YES then doxygen will interpret the first
 # line (until the first dot) of a Qt-style comment as the brief description. If
@@ -231,7 +231,7 @@ PYTHON_DOCSTRING       = YES
 # documentation from any documented member that it re-implements.
 # The default value is: YES.
 
-INHERIT_DOCS           = NO
+INHERIT_DOCS           = YES
 
 # If the SEPARATE_MEMBER_PAGES tag is set to YES then doxygen will produce a new
 # page for each member. If set to NO, the documentation of a member will be part

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -26,3 +26,4 @@ clean: Makefile
 doxygen: Makefile
 	doxygen Doxyfile.in
 
+all: doxygen

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,29 @@
+[![CI](https://github.com/lf-lang/reactor-c/actions/workflows/ci.yml/badge.svg)](https://github.com/lf-lang/reactor-c/actions/workflows/ci.yml)
+[![API docs](https://github.com/lf-lang/reactor-c/actions/workflows/api-docs.yml/badge.svg)](https://github.com/lf-lang/reactor-c/actions/workflows/api-docs.yml)
+
+# Reactor-C Documentation
+
+## Documentation
+
+### Prerequisites
+
+- Install `python3`, `pip3` and `doxygen`
+- Install the required Python modules:
+  - `pip3 install sphinx`
+  - `pip3 install sphinx_sitemap`
+  - `pip3 install sphinx-rtd-theme`
+  - `pip3 install breathe`
+  - `pip3 install exhale`
+
+### Build Documentation Files
+
+- Check out this repo and build the docs:
+  - `git clone git@github.com:lf-lang/reactor-c.git`
+  - `cd reactor-c/docs`
+  - `make html`
+
+### View Documentation Files
+
+- Point your browser to the generated HTML page:
+  - `firefox _build/html/index.html`
+

--- a/include/api/api.h
+++ b/include/api/api.h
@@ -1,7 +1,7 @@
 /**
  * @file
- * @author Edward A. Lee (eal@berkeley.edu)
- * @author Hou Seng (Steven) Wong (housengw@berkeley.edu)
+ * @author Edward A. Lee
+ * @author Hou Seng (Steven) Wong
  *
  * @section LICENSE
 Copyright (c) 2020, The University of California at Berkeley.

--- a/include/core/lf_token.h
+++ b/include/core/lf_token.h
@@ -180,12 +180,6 @@ extern lf_token_t* _lf_tokens_allocated_in_reactions;
 
 /**
  * Counter used to issue a warning if memory is
- * allocated for message payloads and never freed.
- */
-static int _lf_count_payload_allocations;
-
-/**
- * Counter used to issue a warning if memory is
  * allocated for tokens and never freed. Note that
  * every trigger will have one token allocated for
  * it. That token is not counted because it is not

--- a/include/core/platform/lf_unix_clock_support.h
+++ b/include/core/platform/lf_unix_clock_support.h
@@ -3,7 +3,6 @@
 
 #include "lf_types.h"
 
-extern interval_t _lf_time_epoch_offset;
 extern instant_t convert_timespec_to_ns(struct timespec tp);
 struct timespec convert_ns_to_timespec(instant_t t);
 void calculate_epoch_offset(void);

--- a/include/core/reactor.h
+++ b/include/core/reactor.h
@@ -530,18 +530,5 @@ trigger_handle_t _lf_schedule_copy(lf_action_base_t* action, interval_t offset, 
  */
 void _lf_fd_send_stop_request_to_rti(void);
 
-/**
- * Check the deadline of the currently executing reaction against the
- * current physical time. If the deadline has passed, invoke the deadline
- * handler (if invoke_deadline_handler parameter is set true) and return true.
- * Otherwise, return false.
- *
- * @param self The self struct of the reactor.
- * @param invoke_deadline_handler When this is set true, also invoke deadline
- *  handler if the deadline has passed.
- * @return True if the specified deadline has passed and false otherwise.
- */
-bool _lf_check_deadline(self_base_t* self, bool invoke_deadline_handler);
-
 #endif /* REACTOR_H */
 /** @} */

--- a/include/core/reactor_common.h
+++ b/include/core/reactor_common.h
@@ -46,8 +46,6 @@ parse_rti_code_t parse_rti_addr(const char* rti_addr);
 void set_federation_id(const char* fid);
 #endif
 
-void* _lf_allocate(size_t count, size_t size, struct allocation_record_t** head);
-
 extern struct allocation_record_t* _lf_reactors_to_free;
 void* _lf_new_reactor(size_t size);
 void _lf_free(struct allocation_record_t** head);
@@ -74,9 +72,16 @@ event_t* _lf_create_dummy_events(
 int _lf_schedule_at_tag(trigger_t* trigger, tag_t tag, lf_token_t* token);
 trigger_handle_t _lf_schedule(trigger_t* trigger, interval_t extra_delay, lf_token_t* token);
 trigger_handle_t _lf_insert_reactions_for_trigger(trigger_t* trigger, lf_token_t* token);
+
+/**
+ * Advance from the current tag to the next. If the given next_time is equal to
+ * the current time, then increase the microstep. Otherwise, update the current
+ * time and set the microstep to zero.
+ * @param next_time The time step to advance to.
+ */
 void _lf_advance_logical_time(instant_t next_time);
+
 trigger_handle_t _lf_schedule_int(lf_action_base_t* action, interval_t extra_delay, int value);
-bool _lf_check_deadline(self_base_t* self, bool invoke_deadline_handler);
 void _lf_invoke_reaction(reaction_t* reaction, int worker);
 void schedule_output_reactions(reaction_t* reaction, int worker);
 int process_args(int argc, const char* argv[]);

--- a/include/core/tag.h
+++ b/include/core/tag.h
@@ -3,8 +3,8 @@
  * @author Edward A. Lee
  * @author Soroush Bateni
  * @author Hou Seng (Steven) Wong
- * @copyright (c) 2020-2023, The University of California at Berkeley
- * License in [BSD 2-clause](https://github.com/lf-lang/reactor-c/blob/main/LICENSE.md)
+ * @copyright (c) 2020-2023, The University of California at Berkeley.
+ * License: <a href="https://github.com/lf-lang/reactor-c/blob/main/LICENSE.md">BSD 2-clause</a>
  * @brief Time and tag definitions and functions for Lingua Franca
  */
 
@@ -71,12 +71,6 @@ typedef struct {
     instant_t time;
     microstep_t microstep;
 } tag_t;
-
-/**
- * A tag interval indicates the
- * pairwise difference of two tags.
- */
-typedef tag_t tag_interval_t;
 
 ////////////////  Functions
 

--- a/include/core/tag.h
+++ b/include/core/tag.h
@@ -3,32 +3,9 @@
  * @author Edward A. Lee
  * @author Soroush Bateni
  * @author Hou Seng (Steven) Wong
- *
- * @section LICENSE
-Copyright (c) 2020, The University of California at Berkeley.
-
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice,
-   this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL
-THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
-THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
- * @section DESCRIPTION
- * Header file for tag functions for Lingua Franca programs.
+ * @copyright (c) 2020-2023, The University of California at Berkeley
+ * License in [BSD 2-clause](https://github.com/lf-lang/reactor-c/blob/main/LICENSE.md)
+ * @brief Time and tag definitions and functions for Lingua Franca
  */
 
 #ifndef TAG_H
@@ -69,6 +46,8 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stddef.h>
 #include <limits.h>
 
+////////////////  Type definitions
+
 /**
  * Time instant. Both physical and logical times are represented
  * using this typedef.
@@ -86,32 +65,6 @@ typedef int64_t interval_t;
 typedef uint32_t microstep_t;
 
 /**
- * Global physical clock offset.
- * Initially set according to the RTI's clock in federated
- * programs.
- */
-extern interval_t _lf_time_physical_clock_offset;
-
-/**
- * A test offset that is applied to the clock.
- * The clock synchronization algorithm must correct for this offset.
- * This offset is especially useful to test clock synchronization on the
- * same machine.
- */
-extern interval_t _lf_time_test_physical_clock_offset;
-
-/**
- * Offset to _LF_CLOCK that would convert it
- * to epoch time. This is applied to the physical clock
- * to get a more meaningful and universal time.
- *
- * For CLOCK_REALTIME, this offset is always zero.
- * For CLOCK_MONOTONIC, it is the difference between those
- * clocks at the start of the execution.
- */
-extern interval_t _lf_time_epoch_offset;
-
-/**
  * A tag is a time, microstep pair.
  */
 typedef struct {
@@ -124,6 +77,8 @@ typedef struct {
  * pairwise difference of two tags.
  */
 typedef tag_t tag_interval_t;
+
+////////////////  Functions
 
 /**
  * Return the current tag, a logical time, microstep pair.
@@ -142,23 +97,23 @@ tag_t lf_tag();
  */
 int lf_tag_compare(tag_t tag1, tag_t tag2);
 
-tag_t _lf_delay_tag(tag_t tag, interval_t interval);
-
-instant_t _lf_physical_time();
-
 /**
- * An enum for specifying the desired tag when calling "lf_time"
+ * Delay a tag by the specified time interval to realize the "after" keyword.
+ * If either the time interval or the time field of the tag is NEVER,
+ * return the unmodified tag.
+ * If the time interval is 0LL, add one to the microstep, leave
+ * the time field alone, and return the result.
+ * Otherwise, add the interval to the time field of the tag and reset
+ * the microstep to 0.
+ * If the sum overflows, saturate the time value at FOREVER.
+ *
+ * Note that normally it makes no sense to call this with a negative
+ * interval (except NEVER), but this is not checked.
+ *
+ * @param tag The tag to increment.
+ * @param interval The time interval.
  */
-typedef enum _lf_time_type {
-    LF_LOGICAL,
-    LF_PHYSICAL,
-    LF_ELAPSED_LOGICAL,
-    LF_ELAPSED_PHYSICAL,
-    LF_START
-} _lf_time_type;
-
-instant_t _lf_time(_lf_time_type type);
-
+tag_t lf_delay_tag(tag_t tag, interval_t interval);
 
 /**
  * Return the current logical time in nanoseconds.
@@ -169,14 +124,12 @@ instant_t _lf_time(_lf_time_type type);
  */
 instant_t lf_time_logical(void);
 
-
 /**
  * Return the elapsed logical time in nanoseconds
  * since the start of execution.
  * @return A time interval.
  */
 interval_t lf_time_logical_elapsed(void);
-
 
 /**
  * Return the current physical time in nanoseconds.
@@ -185,7 +138,6 @@ interval_t lf_time_logical_elapsed(void);
  * @return A time instant.
  */
 instant_t lf_time_physical(void);
-
 
 /**
  * Return the elapsed physical time in nanoseconds.
@@ -237,37 +189,5 @@ size_t lf_readable_time(char* buffer, instant_t time);
  * @return The number of characters written (not counting the null terminator).
  */
 size_t lf_comma_separated_time(char* buffer, instant_t time);
-
-/**
- * Set a fixed offset to the physical clock.
- * After calling this, the value returned by lf_time_physical()
- * and get_elpased_physical_time() will have this specified offset
- * added to what it would have returned before the call.
- */
-void lf_set_physical_clock_offset(interval_t offset);
-
-/**
- * For C++ compatibility, take a volatile tag_t and return a non-volatile
- * variant.
- */
-#ifdef __cplusplus
-tag_t _lf_convert_volatile_tag_to_nonvolatile(tag_t volatile const& vtag);
-#else
-/**
- * @note This is an undefined behavior in C and should
- *  be used with utmost caution. See Section 6.7.2 of the C99 standard.
- */
-tag_t _lf_convert_volatile_tag_to_nonvolatile(tag_t volatile vtag);
-#endif
-
-// Global variables :(
-extern tag_t current_tag;
-extern instant_t physical_start_time;
-extern instant_t start_time;
-extern interval_t _lf_time_physical_clock_offset;
-extern interval_t _lf_global_physical_clock_drift;
-extern interval_t _lf_time_test_physical_clock_offset;
-extern instant_t _lf_last_reported_physical_time_ns;
-extern instant_t _lf_last_reported_unadjusted_physical_time_ns;
 
 #endif // TAG_H

--- a/include/core/threaded/scheduler_sync_tag_advance.h
+++ b/include/core/threaded/scheduler_sync_tag_advance.h
@@ -30,10 +30,6 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "tag.h"
 
-/////////////////// External Variables /////////////////////////
-extern tag_t current_tag;
-extern tag_t stop_tag;
-
 /////////////////// External Functions /////////////////////////
 void _lf_next_locked();
 /**

--- a/include/core/threaded/worker_assignments.h
+++ b/include/core/threaded/worker_assignments.h
@@ -65,8 +65,10 @@ static size_t num_workers;
 
 #include "data_collection.h"
 
+#if !defined(DOXYGEN_SHOULD_SKIP_THIS)
 static void worker_states_lock(size_t worker);
 static void worker_states_unlock(size_t worker);
+#endif // DOXYGEN_SHOULD_SKIP_THIS
 
 /**
  * @brief Set the level to be executed now. This function assumes that concurrent calls to it are

--- a/lib/schedule.c
+++ b/lib/schedule.c
@@ -190,5 +190,12 @@ trigger_handle_t lf_schedule_value(void* action, interval_t extra_delay, void* v
  * @return True if the specified deadline has passed and false otherwise.
  */
 bool lf_check_deadline(void* self, bool invoke_deadline_handler) {
-	return _lf_check_deadline((self_base_t*)self, invoke_deadline_handler);
+    reaction_t* reaction = ((self_base_t*)self)->executing_reaction;
+    if (lf_time_physical() > lf_time_logical() + reaction->deadline) {
+        if (invoke_deadline_handler) {
+            reaction->deadline_violation_handler(self);
+        }
+        return true;
+    }
+    return false;
 }

--- a/lingua-franca-ref.txt
+++ b/lingua-franca-ref.txt
@@ -1,1 +1,1 @@
-bodyless-reactions
+docs


### PR DESCRIPTION
This is a starting point to clean up the APIs and their docs for user-facing APIs. It includes a number of code organization changes, including removing variables and functions from user scope. PR [#1696](https://github.com/lf-lang/lingua-franca/pull/1696) should be merged first, or else some tests will fail.

This first step focuses mainly on tag.h and tag.c.  The generated doxygen docs are much better, now suitable for pointing users to them.  This PR is already big enough that I think we should merge this incrementally.  I.e., merge this now, then continue by picking the next part of the API, such as target.h, to work on.