### PR TITLE
Fix definition of LF_TIME_BUFFER_LENGTH

### DIFF
--- a/include/core/platform/lf_nrf52_support.h
+++ b/include/core/platform/lf_nrf52_support.h
@@ -52,23 +52,6 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 typedef void lf_mutex_t;
 typedef void _lf_cond_var_t;
 
-/**
- * For user-friendly reporting of time values, the buffer length required.
- * This is calculated as follows, based on 64-bit time in nanoseconds:
- * Maximum number of weeks is 15,250
- * Maximum number of days is 6
- * Maximum number of hours is 23
- * Maximum number of minutes is 59
- * Maximum number of seconds is 59
- * Maximum number of nanoseconds is 999,999,999
- * Maximum number of microsteps is 4,294,967,295
- * Total number of characters for the above is 24.
- * Text descriptions and spaces add an additional 55,
- * for a total of 79. One more allows for a null terminator.
- */
-#define LF_TIME_BUFFER_LENGTH 80
-
-
 // The underlying physical clock for Linux
 #define _LF_CLOCK CLOCK_MONOTONIC
 

--- a/include/core/platform/lf_tag_64_32.h
+++ b/include/core/platform/lf_tag_64_32.h
@@ -47,19 +47,3 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // format for printing both time and microstep as follows:
 //     printf("Tag is " PRINTF_TAG "\n", time_value, microstep);
 #define PRINTF_TAG "(" PRINTF_TIME ", " PRINTF_MICROSTEP ")"
-
-/**
- * For user-friendly reporting of time values, the buffer length required.
- * This is calculated as follows, based on 64-bit time in nanoseconds:
- * Maximum number of weeks is 15,250
- * Maximum number of days is 6
- * Maximum number of hours is 23
- * Maximum number of minutes is 59
- * Maximum number of seconds is 59
- * Maximum number of nanoseconds is 999,999,999
- * Maximum number of microsteps is 4,294,967,295
- * Total number of characters for the above is 24.
- * Text descriptions and spaces add an additional 55,
- * for a total of 79. One more allows for a null terminator.
- */
-#define LF_TIME_BUFFER_LENGTH 80

--- a/include/core/tag.h
+++ b/include/core/tag.h
@@ -158,6 +158,22 @@ instant_t lf_time_start(void);
 void lf_set_physical_clock_offset(interval_t offset);
 
 /**
+ * For user-friendly reporting of time values, the buffer length required.
+ * This is calculated as follows, based on 64-bit time in nanoseconds:
+ * Maximum number of weeks is 15,250
+ * Maximum number of days is 6
+ * Maximum number of hours is 23
+ * Maximum number of minutes is 59
+ * Maximum number of seconds is 59
+ * Maximum number of nanoseconds is 999,999,999
+ * Maximum number of microsteps is 4,294,967,295
+ * Total number of characters for the above is 24.
+ * Text descriptions and spaces add an additional 55,
+ * for a total of 79. One more allows for a null terminator.
+ */
+#define LF_TIME_BUFFER_LENGTH 80
+
+/**
  * Store into the specified buffer a string giving a human-readable
  * rendition of the specified time. The buffer must have length at least
  * equal to LF_TIME_BUFFER_LENGTH. The format is:


### PR DESCRIPTION
Moved \#define LF_TIME_BUFFER_LENGTH from platform files to tag.h because platform.h is no longer automatically included and tag.h depends on it.