### PR TITLE
Reactor local time

### DIFF
--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -2421,7 +2421,7 @@ void terminate_execution() {
         size_t bytes_to_write = 1 + sizeof(tag_t);
         unsigned char buffer[bytes_to_write];
         buffer[0] = MSG_TYPE_RESIGN;
-        tag_t tag = lf_tag();
+        tag_t tag = lf_tag(NULL);
         encode_tag(&(buffer[1]), tag);
         // Trace the event when tracing is enabled
         tracepoint_federate_to_RTI(send_RESIGN, _lf_my_fed_id, &tag);

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -381,7 +381,7 @@ int send_timed_message(interval_t additional_delay,
 
     // Apply the additional delay to the current tag and use that as the intended
     // tag of the outgoing message
-    tag_t current_message_intended_tag = _lf_delay_tag(lf_tag(NULL),
+    tag_t current_message_intended_tag = lf_delay_tag(lf_tag(NULL),
                                                     additional_delay);
 
     // Next 8 + 4 will be the tag (timestamp, microstep)
@@ -1512,7 +1512,7 @@ void send_port_absent_to_federate(interval_t additional_delay,
 
     // Apply the additional delay to the current tag and use that as the intended
     // tag of the outgoing message
-    tag_t current_message_intended_tag = _lf_delay_tag(lf_tag(NULL),
+    tag_t current_message_intended_tag = lf_delay_tag(lf_tag(NULL),
                                                     additional_delay);
 
     LF_PRINT_LOG("Sending port "

--- a/core/modal_models/modes.c
+++ b/core/modal_models/modes.c
@@ -416,7 +416,7 @@ void _lf_process_mode_changes(
                         } else if (state->next_mode != state->current_mode && event->trigger != NULL) { // History transition to a different mode
                             // Remaining time that the event would have been waiting before mode was left
                             instant_t local_remaining_delay = event->time - (state->next_mode->deactivation_time != 0 ? state->next_mode->deactivation_time : lf_time_start());
-                            tag_t current_logical_tag = lf_tag();
+                            tag_t current_logical_tag = lf_tag(NULL);
 
                             // Reschedule event with original local delay
                             LF_PRINT_DEBUG("Modes: Re-enqueuing event with a suspended delay of " PRINTF_TIME
@@ -461,7 +461,7 @@ void _lf_process_mode_changes(
                 // Apply transition effect
                 if (state->next_mode != NULL) {
                     // Save time when mode was left to handle suspended events in the future
-                    state->current_mode->deactivation_time = lf_time_logical();
+                    state->current_mode->deactivation_time = lf_time_logical(NULL);
 
                     // Apply transition
                     state->current_mode = state->next_mode;

--- a/core/modal_models/modes.c
+++ b/core/modal_models/modes.c
@@ -530,7 +530,7 @@ void _lf_process_mode_changes(
         if (_lf_mode_triggered_reactions_request) {
             // Insert a dummy event in the event queue for the next microstep to make
             // sure startup/reset reactions (if any) are triggered as soon as possible.
-            pqueue_insert(event_q, _lf_create_dummy_events(NULL, lf_tag().time, NULL, 1));
+            pqueue_insert(event_q, _lf_create_dummy_events(NULL, lf_tag(NULL).time, NULL, 1));
         }
     }
 }

--- a/core/reactor.c
+++ b/core/reactor.c
@@ -302,9 +302,6 @@ int next(void) {
 
 /**
  * Stop execution at the conclusion of the next microstep.
- * FIXME: If this is called from a LET reaction we will either:
- * A) requrest a stop tag "in the past" if we are using reactors local tag
- * B) request stop sometime "in the futre" if we use global tag <- This is what we are doing now
  */
 void lf_request_stop() {
 	tag_t new_stop_tag;

--- a/core/reactor.c
+++ b/core/reactor.c
@@ -249,7 +249,7 @@ int next(void) {
         next_tag.time = event->time;
         // Deduce the microstep
         if (next_tag.time == current_tag.time) {
-            next_tag.microstep = lf_tag().microstep + 1;
+            next_tag.microstep = current_tag.microstep + 1;
         } else {
             next_tag.microstep = 0;
         }
@@ -302,6 +302,9 @@ int next(void) {
 
 /**
  * Stop execution at the conclusion of the next microstep.
+ * FIXME: If this is called from a LET reaction we will either:
+ * A) requrest a stop tag "in the past" if we are using reactors local tag
+ * B) request stop sometime "in the futre" if we use global tag <- This is what we are doing now
  */
 void lf_request_stop() {
 	tag_t new_stop_tag;

--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -444,8 +444,7 @@ void _lf_pop_events() {
         // If the trigger is a periodic timer, create a new event for its next execution.
         if (event->trigger->is_timer && event->trigger->period > 0LL) {
             // Reschedule the trigger.
-            tag_t next_tag = {current_tag.time + event->trigger->period, 0UL};
-            _lf_schedule_at_tag(event->trigger, next_tag, NULL);
+            _lf_schedule(event->trigger, event->trigger->period, NULL);
         }
 
         // Copy the token pointer into the trigger struct so that the

--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -662,7 +662,7 @@ int _lf_schedule_at_tag(trigger_t* trigger, tag_t tag, lf_token_t* token) {
 
     // Do not schedule events if the tag is after the stop tag
     if (_lf_is_tag_after_stop_tag(tag)) {
-         LF_PRINT_DEBUG("_lf_schedule_at_tag: event time is past the timeout. Discarding event.");
+         lf_print_warning("_lf_schedule_at_tag: event time is past the timeout. Discarding event.");
         _lf_done_using(token);
         return -1;
     }

--- a/core/tag.c
+++ b/core/tag.c
@@ -15,7 +15,10 @@
 #include "tag.h"
 #include "util.h"
 #include "platform.h"
+#include "reactor.h"
 #include "util.h"
+#include "lf_types.h"
+
 
 /**
  * An enum for specifying the desired tag when calling "lf_time"
@@ -148,8 +151,14 @@ instant_t _lf_time(_lf_time_type type) {
 
 ////////////////  Functions declared in tag.h
 
-tag_t lf_tag() {
-    return current_tag;
+tag_t lf_tag(void* self) {
+    if (self == NULL) {
+        return current_tag;
+    } else if (((self_base_t *) self)->executing_reaction) {
+        return ((self_base_t *) self)->current_tag;
+    } else {
+        return current_tag;
+    }
 }
 
 int lf_tag_compare(tag_t tag1, tag_t tag2) {
@@ -186,12 +195,16 @@ tag_t lf_delay_tag(tag_t tag, interval_t interval) {
     return result;
 }
 
-instant_t lf_time_logical(void) {
-    return _lf_time(LF_LOGICAL);
+instant_t lf_time_logical(void *self) {
+    if (self) return ((self_base_t *) self)->current_tag.time;
+    else return _lf_time(LF_LOGICAL);
 }
 
-interval_t lf_time_logical_elapsed(void) {
-    return _lf_time(LF_ELAPSED_LOGICAL);
+/**
+ * Return the elapsed logical time in nanoseconds since the start of execution.
+ */
+interval_t lf_time_logical_elapsed(void *self) {
+    return lf_time_logical(self) - start_time;
 }
 
 instant_t lf_time_physical(void) {

--- a/core/tag.c
+++ b/core/tag.c
@@ -152,9 +152,7 @@ instant_t _lf_time(_lf_time_type type) {
 ////////////////  Functions declared in tag.h
 
 tag_t lf_tag(void* self) {
-    if (self == NULL) {
-        return current_tag;
-    } else if (((self_base_t *) self)->executing_reaction) {
+    if (self != NULL && ((self_base_t *) self)->executing_reaction != NULL) {
         return ((self_base_t *) self)->current_tag;
     } else {
         return current_tag;

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -141,6 +141,7 @@ void _lf_increment_global_tag_barrier_already_locked(tag_t future_tag) {
         lf_print_warning("Attempting to raise a barrier after the stop tag.");
         future_tag = stop_tag;
     }
+    tag_t current_tag = lf_tag(NULL);
     // Check to see if future_tag is actually in the future.
     if (lf_tag_compare(future_tag, current_tag) > 0) {
         // Future tag is actually in the future.
@@ -464,7 +465,7 @@ tag_t get_next_event_tag() {
         if (next_tag.time == current_tag.time) {
         	LF_PRINT_DEBUG("Earliest event matches current time. Incrementing microstep. Event is dummy: %d.",
         			event->is_dummy);
-            next_tag.microstep =  lf_tag().microstep + 1;
+            next_tag.microstep =  lf_tag(NULL).microstep + 1;
         } else {
             next_tag.microstep = 0;
         }

--- a/core/trace.c
+++ b/core/trace.c
@@ -294,14 +294,7 @@ void tracepoint(
     int i = _lf_trace_buffer_size[index];
     // Write to memory buffer.
     // Get the correct time of the event
-    tag_t tag;
-    if (trigger) {
-        self_base_t* reactor = (self_base_t *) trigger->reactions[0]->self;
-        tag = lf_tag(reactor);
-    } else {
-        tag = lf_tag(pointer);
-    }
-
+    
     _lf_trace_buffer[index][i].event_type = event_type;
     _lf_trace_buffer[index][i].pointer = pointer;
     _lf_trace_buffer[index][i].src_id = src_id;

--- a/core/trace.c
+++ b/core/trace.c
@@ -293,6 +293,15 @@ void tracepoint(
     // The above flush_trace resets the write pointer.
     int i = _lf_trace_buffer_size[index];
     // Write to memory buffer.
+    // Get the correct time of the event
+    tag_t tag;
+    if (trigger) {
+        self_base_t* reactor = (self_base_t *) trigger->reactions[0]->self;
+        tag = lf_tag(reactor);
+    } else {
+        tag = lf_tag(pointer);
+    }
+
     _lf_trace_buffer[index][i].event_type = event_type;
     _lf_trace_buffer[index][i].pointer = pointer;
     _lf_trace_buffer[index][i].src_id = src_id;
@@ -301,8 +310,8 @@ void tracepoint(
         _lf_trace_buffer[index][i].logical_time = tag->time;
         _lf_trace_buffer[index][i].microstep = tag->microstep;
     } else {
-        _lf_trace_buffer[index][i].logical_time = lf_time_logical();
-        _lf_trace_buffer[index][i].microstep = lf_tag().microstep;
+        _lf_trace_buffer[index][i].logical_time = lf_time_logical(pointer);
+        _lf_trace_buffer[index][i].microstep = lf_tag(pointer).microstep;
     }
     _lf_trace_buffer[index][i].trigger = trigger;
     _lf_trace_buffer[index][i].extra_delay = extra_delay;

--- a/include/api/api.h
+++ b/include/api/api.h
@@ -185,6 +185,6 @@ int lf_tag_compare(tag_t tag1, tag_t tag2);
 /**
  * Return the current tag, a logical time, microstep pair.
  */
-tag_t lf_tag();
+tag_t lf_tag(void * self);
 
 #endif // API_H

--- a/include/api/api.h
+++ b/include/api/api.h
@@ -183,8 +183,11 @@ bool lf_check_deadline(void* self, bool invoke_deadline_handler);
 int lf_tag_compare(tag_t tag1, tag_t tag2);
 
 /**
- * Return the current tag, a logical time, microstep pair.
+ * Return the current tag of a reactor. If NULL is passed to this function it
+ * will return the "global tag" of the runtime.  
+ * @param self A pointer to the self-struct of the reactor. 
+ * @return the current tag 
  */
-tag_t lf_tag(void * self);
+tag_t lf_tag(void* self);
 
 #endif // API_H

--- a/include/api/set.h
+++ b/include/api/set.h
@@ -211,3 +211,14 @@ do { \
 #endif // MODAL_REACTORS
 
 #endif // CTARGET_SET
+
+// For simplicity and backward compatability, dont require the self-pointer when calling the timing API.
+// Since this is always done from the context of a reaction `self` is in scope and is a pointer to the self-struct
+#define lf_tag() lf_tag(self)
+#define get_current_tag() get_current_tag(self)
+#define get_microstep() get_microstep(self)
+
+#define lf_time_logical() lf_time_logical(self)
+#define lf_time_logical_elapsed() lf_time_logical_elapsed(self)
+#define get_elapsed_logical_time() get_elapsed_logical_time(self)
+#define get_logical_time() get_logical_time(self)

--- a/include/api/set_undef.h
+++ b/include/api/set_undef.h
@@ -112,4 +112,12 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #undef SET_MODE
 #endif
 
+#undef lf_time_logical 
+#undef lf_time_logical_elapsed 
+#undef get_logical_time
+#undef get_elapsed_logical_time
+
+#undef lf_tag
+#undef get_current_tag
+#undef get_microstep
 #endif // CTARGET_SET

--- a/include/core/lf_types.h
+++ b/include/core/lf_types.h
@@ -240,6 +240,7 @@ struct trigger_t {
                               //   downstream messages have been produced for the same port for the same logical time.
     reactor_mode_t* mode;     // The enclosing mode of this reaction (if exists).
                               // If enclosed in multiple, this will point to the innermost mode.
+    void* parent;             // Pointer to reactor which contains the trigger
 #ifdef FEDERATED
     tag_t last_known_status_tag;        // Last known status of the port, either via a timed message, a port absent, or a
                                         // TAG from the RTI.
@@ -278,6 +279,7 @@ typedef struct allocation_record_t {
 typedef struct self_base_t {
 	struct allocation_record_t *allocations;
 	struct reaction_t *executing_reaction;   // The currently executing reaction of the reactor.
+    tag_t current_tag;                       // The current tag the reactor is executing at (used for e.g. LET scheduling)
 #ifdef MODAL_REACTORS
     reactor_mode_state_t _lf__mode_state;    // The current mode (for modal models).
 #endif

--- a/include/core/tag.h
+++ b/include/core/tag.h
@@ -77,7 +77,7 @@ typedef struct {
 /**
  * Return the current tag, a logical time, microstep pair.
  */
-tag_t lf_tag();
+tag_t lf_tag(void* self);
 
 /**
  * Compare two tags. Return -1 if the first is less than
@@ -116,14 +116,14 @@ tag_t lf_delay_tag(tag_t tag, interval_t interval);
  *
  * @return A time instant.
  */
-instant_t lf_time_logical(void);
+instant_t lf_time_logical(void* self);
 
 /**
  * Return the elapsed logical time in nanoseconds
  * since the start of execution.
  * @return A time interval.
  */
-interval_t lf_time_logical_elapsed(void);
+interval_t lf_time_logical_elapsed(void *self);
 
 /**
  * Return the current physical time in nanoseconds.

--- a/lib/schedule.c
+++ b/lib/schedule.c
@@ -191,7 +191,7 @@ trigger_handle_t lf_schedule_value(void* action, interval_t extra_delay, void* v
  */
 bool lf_check_deadline(void* self, bool invoke_deadline_handler) {
     reaction_t* reaction = ((self_base_t*)self)->executing_reaction;
-    if (lf_time_physical() > lf_time_logical() + reaction->deadline) {
+    if (lf_time_physical() > lf_time_logical(self) + reaction->deadline) {
         if (invoke_deadline_handler) {
             reaction->deadline_violation_handler(self);
         }

--- a/lingua-franca-ref.txt
+++ b/lingua-franca-ref.txt
@@ -1,1 +1,1 @@
-master
+reactor-local-time


### PR DESCRIPTION
This PR makes the logical tag a reactor-level variable (not system-level). This means each reactor can be at different tags. This is needed for LET scheduling and static scheduling.

The changes are mainly:
- Update API with a pointer to the a `self_base_t` for the timing functions. `lf_tag()` and `lf_time_logical`.
- Ensure backwards compatibility with macros 
- Update any calls to: `lf_tag` and `lf_time_logical` throughout the runtime. Either they must be passed a pointer to the reactor from which they are invoked. Or passed NULL to get the system-level logical time