### PR TITLE
Attempt to suppress "has no symbols" warnings.

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -14,6 +14,8 @@ list(APPEND INFO_SOURCES ${GENERAL_SOURCES})
 
 # Create the core library
 add_library(core ${GENERAL_SOURCES})
+SET(CMAKE_C_ARCHIVE_FINISH   "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
+SET(CMAKE_CXX_ARCHIVE_FINISH "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
 
 # Add sources for either threaded or unthreaded runtime
 if (DEFINED FEDERATED)


### PR DESCRIPTION
These warnings appear on macOS because we use the preprocessor to conditionally include the contents of entire source files.

Since I do not use macOS it is difficult for me to check whether this solves the problem, but I think it should.