### PR TITLE
Draft: Scheduler api

### DIFF
--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -2421,7 +2421,7 @@ void terminate_execution() {
         size_t bytes_to_write = 1 + sizeof(tag_t);
         unsigned char buffer[bytes_to_write];
         buffer[0] = MSG_TYPE_RESIGN;
-        tag_t tag = lf_tag();
+        tag_t tag = lf_tag(NULL);
         encode_tag(&(buffer[1]), tag);
         // Trace the event when tracing is enabled
         tracepoint_federate_to_RTI(send_RESIGN, _lf_my_fed_id, &tag);

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -381,7 +381,7 @@ int send_timed_message(interval_t additional_delay,
 
     // Apply the additional delay to the current tag and use that as the intended
     // tag of the outgoing message
-    tag_t current_message_intended_tag = _lf_delay_tag(lf_tag(NULL),
+    tag_t current_message_intended_tag = lf_delay_tag(lf_tag(NULL),
                                                     additional_delay);
 
     // Next 8 + 4 will be the tag (timestamp, microstep)
@@ -1512,7 +1512,7 @@ void send_port_absent_to_federate(interval_t additional_delay,
 
     // Apply the additional delay to the current tag and use that as the intended
     // tag of the outgoing message
-    tag_t current_message_intended_tag = _lf_delay_tag(lf_tag(NULL),
+    tag_t current_message_intended_tag = lf_delay_tag(lf_tag(NULL),
                                                     additional_delay);
 
     LF_PRINT_LOG("Sending port "

--- a/core/modal_models/modes.c
+++ b/core/modal_models/modes.c
@@ -416,7 +416,7 @@ void _lf_process_mode_changes(
                         } else if (state->next_mode != state->current_mode && event->trigger != NULL) { // History transition to a different mode
                             // Remaining time that the event would have been waiting before mode was left
                             instant_t local_remaining_delay = event->time - (state->next_mode->deactivation_time != 0 ? state->next_mode->deactivation_time : lf_time_start());
-                            tag_t current_logical_tag = lf_tag();
+                            tag_t current_logical_tag = lf_tag(NULL);
 
                             // Reschedule event with original local delay
                             LF_PRINT_DEBUG("Modes: Re-enqueuing event with a suspended delay of " PRINTF_TIME
@@ -461,7 +461,7 @@ void _lf_process_mode_changes(
                 // Apply transition effect
                 if (state->next_mode != NULL) {
                     // Save time when mode was left to handle suspended events in the future
-                    state->current_mode->deactivation_time = lf_time_logical();
+                    state->current_mode->deactivation_time = lf_time_logical(NULL);
 
                     // Apply transition
                     state->current_mode = state->next_mode;

--- a/core/modal_models/modes.c
+++ b/core/modal_models/modes.c
@@ -530,7 +530,7 @@ void _lf_process_mode_changes(
         if (_lf_mode_triggered_reactions_request) {
             // Insert a dummy event in the event queue for the next microstep to make
             // sure startup/reset reactions (if any) are triggered as soon as possible.
-            pqueue_insert(event_q, _lf_create_dummy_events(NULL, lf_tag().time, NULL, 1));
+            pqueue_insert(event_q, _lf_create_dummy_events(NULL, lf_tag(NULL).time, NULL, 1));
         }
     }
 }

--- a/core/reactor.c
+++ b/core/reactor.c
@@ -302,9 +302,6 @@ int next(void) {
 
 /**
  * Stop execution at the conclusion of the next microstep.
- * FIXME: If this is called from a LET reaction we will either:
- * A) requrest a stop tag "in the past" if we are using reactors local tag
- * B) request stop sometime "in the futre" if we use global tag <- This is what we are doing now
  */
 void lf_request_stop() {
 	tag_t new_stop_tag;

--- a/core/reactor.c
+++ b/core/reactor.c
@@ -249,7 +249,7 @@ int next(void) {
         next_tag.time = event->time;
         // Deduce the microstep
         if (next_tag.time == current_tag.time) {
-            next_tag.microstep = lf_tag().microstep + 1;
+            next_tag.microstep = current_tag.microstep + 1;
         } else {
             next_tag.microstep = 0;
         }
@@ -302,6 +302,9 @@ int next(void) {
 
 /**
  * Stop execution at the conclusion of the next microstep.
+ * FIXME: If this is called from a LET reaction we will either:
+ * A) requrest a stop tag "in the past" if we are using reactors local tag
+ * B) request stop sometime "in the futre" if we use global tag <- This is what we are doing now
  */
 void lf_request_stop() {
 	tag_t new_stop_tag;

--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -1363,119 +1363,11 @@ void schedule_output_reactions(reaction_t* reaction, int worker) {
                                     downstream_reaction->is_STP_violated, downstream_reaction->name);
                         }
 #endif
-                    //     if (downstream_reaction != NULL && downstream_reaction != downstream_to_execute_now) {
-                    //         num_downstream_reactions++;
-                    //         // If there is exactly one downstream reaction that is enabled by this
-                    //         // reaction, then we can execute that reaction immediately without
-                    //         // going through the reaction queue. In multithreaded execution, this
-                    //         // avoids acquiring a mutex lock.
-                    //         // FIXME: Check the earliest deadline on the reaction queue.
-                    //         // This optimization could violate EDF scheduling otherwise.
-                    //         if (num_downstream_reactions == 1 && downstream_reaction->last_enabling_reaction == reaction) {
-                    //             // So far, this downstream reaction is a candidate to execute now.
-                    //             downstream_to_execute_now = downstream_reaction;
-                    //         } else {
-                    //             // If there is a previous candidate reaction to execute now,
-                    //             // it is no longer a candidate.
-                    //             if (downstream_to_execute_now != NULL) {
-                    //                 // More than one downstream reaction is enabled.
-                    //                 // In this case, if we were to execute the downstream reaction
-                    //                 // immediately without changing any queues, then the second
-                    //                 // downstream reaction would be blocked because this reaction
-                    //                 // remains on the executing queue. Hence, the optimization
-                    //                 // is not valid. Put the candidate reaction on the queue.
-                    //                 _lf_trigger_reaction(downstream_to_execute_now, worker);
-                    //                 downstream_to_execute_now = NULL;
-                    //             }
-                    //             // Queue the reaction.
-                    //             _lf_trigger_reaction(downstream_reaction, worker);
-                    //         }
-                    //     }
-                    // }
                 }
             }
         }
     }
     }
-//     if (downstream_to_execute_now != NULL) { LF_PRINT_LOG("Worker %d: Optimizing and executing downstream reaction now: %s", worker, downstream_to_execute_now->name);
-//         bool violation = false;
-// #ifdef FEDERATED_DECENTRALIZED // Only use the STP handler for federated programs that use decentralized coordination
-//         // If the is_STP_violated for the reaction is true,
-//         // an input trigger to this reaction has been triggered at a later
-//         // logical time than originally anticipated. In this case, a special
-//         // STP handler will be invoked.
-//         // FIXME: Note that the STP handler will be invoked
-//         // at most once per logical time value. If the STP handler triggers the
-//         // same reaction at the current time value, even if at a future superdense time,
-//         // then the reaction will be invoked and the STP handler will not be invoked again.
-//         // However, input ports to a federate reactor are network port types so this possibly should
-//         // be disallowed.
-//         // @note The STP handler and the deadline handler are not mutually exclusive.
-//         //  In other words, both can be invoked for a reaction if it is triggered late
-//         //  in logical time (STP offset is violated) and also misses the constraint on
-//         //  physical time (deadline).
-//         // @note In absence of a STP handler, the is_STP_violated will be passed down the reaction
-//         //  chain until it is dealt with in a downstream STP handler.
-//         if (downstream_to_execute_now->is_STP_violated == true) {
-//             // Tardiness has occurred
-//             LF_PRINT_LOG("Event has STP violation.");
-//             reaction_function_t handler = downstream_to_execute_now->STP_handler;
-//             // Invoke the STP handler if there is one.
-//             if (handler != NULL) {
-//                 // There is a violation and it is being handled here
-//                 // If there is no STP handler, pass the is_STP_violated
-//                 // to downstream reactions.
-//                 violation = true;
-//                 LF_PRINT_LOG("Invoke tardiness handler.");
-//                 (*handler)(downstream_to_execute_now->self);
-
-//                 // If the reaction produced outputs, put the resulting
-//                 // triggered reactions into the queue or execute them directly if possible.
-//                 schedule_output_reactions(downstream_to_execute_now, worker);
-
-//                 // Reset the tardiness because it has been dealt with in the
-//                 // STP handler
-//                 downstream_to_execute_now->is_STP_violated = false;
-//                 LF_PRINT_DEBUG("Reset reaction's is_STP_violated field to false: %s",
-//                         downstream_to_execute_now->name);
-//             }
-//         }
-// #endif
-//         if (downstream_to_execute_now->deadline >= 0LL) {
-//             // Get the current physical time.
-//             instant_t physical_time = lf_time_physical();
-//             // Check for deadline violation.
-//             if (downstream_to_execute_now->deadline == 0 || physical_time > current_tag.time + downstream_to_execute_now->deadline) {
-//                 // Deadline violation has occurred.
-//                 tracepoint_reaction_deadline_missed(downstream_to_execute_now, worker);
-//                 violation = true;
-//                 // Invoke the local handler, if there is one.
-//                 reaction_function_t handler = downstream_to_execute_now->deadline_violation_handler;
-//                 if (handler != NULL) {
-//                     // Assume the mutex is still not held.
-//                     (*handler)(downstream_to_execute_now->self);
-
-//                     // If the reaction produced outputs, put the resulting
-//                     // triggered reactions into the queue or execute them directly if possible.
-//                     schedule_output_reactions(downstream_to_execute_now, worker);
-//                 }
-//             }
-//         }
-//         if (!violation) {
-//             // Invoke the downstream_reaction function.
-//             _lf_invoke_reaction(downstream_to_execute_now, worker);
-
-//             // If the downstream_reaction produced outputs, put the resulting triggered
-//             // reactions into the queue (or execute them directly, if possible).
-//             schedule_output_reactions(downstream_to_execute_now, worker);
-//         }
-
-//         // Reset the is_STP_violated because it has been passed
-//         // down the chain
-//         downstream_to_execute_now->is_STP_violated = false;
-//         LF_PRINT_DEBUG("Finally, reset reaction's is_STP_violated field to false: %s",
-//                 downstream_to_execute_now->name);
-//     }
 }
 
 /**

--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -444,8 +444,7 @@ void _lf_pop_events() {
         // If the trigger is a periodic timer, create a new event for its next execution.
         if (event->trigger->is_timer && event->trigger->period > 0LL) {
             // Reschedule the trigger.
-            tag_t next_tag = {current_tag.time + event->trigger->period, 0UL};
-            _lf_schedule_at_tag(event->trigger, next_tag, NULL);
+            _lf_schedule(event->trigger, event->trigger->period, NULL);
         }
 
         // Copy the token pointer into the trigger struct so that the

--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -1354,6 +1354,7 @@ void schedule_output_reactions(reaction_t* reaction, int worker) {
                     LF_PRINT_DEBUG("Trigger %p lists %d reactions.", trigger, trigger->number_of_reactions);
                     for (int k=0; k < trigger->number_of_reactions; k++) {
                         reaction_t* downstream_reaction = trigger->reactions[k];
+                        _lf_trigger_reaction(downstream_reaction, worker);
 #ifdef FEDERATED_DECENTRALIZED // Only pass down tardiness for federated LF programs
                         // Set the is_STP_violated for the downstream reaction
                         if (downstream_reaction != NULL) {
@@ -1362,119 +1363,119 @@ void schedule_output_reactions(reaction_t* reaction, int worker) {
                                     downstream_reaction->is_STP_violated, downstream_reaction->name);
                         }
 #endif
-                        if (downstream_reaction != NULL && downstream_reaction != downstream_to_execute_now) {
-                            num_downstream_reactions++;
-                            // If there is exactly one downstream reaction that is enabled by this
-                            // reaction, then we can execute that reaction immediately without
-                            // going through the reaction queue. In multithreaded execution, this
-                            // avoids acquiring a mutex lock.
-                            // FIXME: Check the earliest deadline on the reaction queue.
-                            // This optimization could violate EDF scheduling otherwise.
-                            if (num_downstream_reactions == 1 && downstream_reaction->last_enabling_reaction == reaction) {
-                                // So far, this downstream reaction is a candidate to execute now.
-                                downstream_to_execute_now = downstream_reaction;
-                            } else {
-                                // If there is a previous candidate reaction to execute now,
-                                // it is no longer a candidate.
-                                if (downstream_to_execute_now != NULL) {
-                                    // More than one downstream reaction is enabled.
-                                    // In this case, if we were to execute the downstream reaction
-                                    // immediately without changing any queues, then the second
-                                    // downstream reaction would be blocked because this reaction
-                                    // remains on the executing queue. Hence, the optimization
-                                    // is not valid. Put the candidate reaction on the queue.
-                                    _lf_trigger_reaction(downstream_to_execute_now, worker);
-                                    downstream_to_execute_now = NULL;
-                                }
-                                // Queue the reaction.
-                                _lf_trigger_reaction(downstream_reaction, worker);
-                            }
-                        }
-                    }
+                    //     if (downstream_reaction != NULL && downstream_reaction != downstream_to_execute_now) {
+                    //         num_downstream_reactions++;
+                    //         // If there is exactly one downstream reaction that is enabled by this
+                    //         // reaction, then we can execute that reaction immediately without
+                    //         // going through the reaction queue. In multithreaded execution, this
+                    //         // avoids acquiring a mutex lock.
+                    //         // FIXME: Check the earliest deadline on the reaction queue.
+                    //         // This optimization could violate EDF scheduling otherwise.
+                    //         if (num_downstream_reactions == 1 && downstream_reaction->last_enabling_reaction == reaction) {
+                    //             // So far, this downstream reaction is a candidate to execute now.
+                    //             downstream_to_execute_now = downstream_reaction;
+                    //         } else {
+                    //             // If there is a previous candidate reaction to execute now,
+                    //             // it is no longer a candidate.
+                    //             if (downstream_to_execute_now != NULL) {
+                    //                 // More than one downstream reaction is enabled.
+                    //                 // In this case, if we were to execute the downstream reaction
+                    //                 // immediately without changing any queues, then the second
+                    //                 // downstream reaction would be blocked because this reaction
+                    //                 // remains on the executing queue. Hence, the optimization
+                    //                 // is not valid. Put the candidate reaction on the queue.
+                    //                 _lf_trigger_reaction(downstream_to_execute_now, worker);
+                    //                 downstream_to_execute_now = NULL;
+                    //             }
+                    //             // Queue the reaction.
+                    //             _lf_trigger_reaction(downstream_reaction, worker);
+                    //         }
+                    //     }
+                    // }
                 }
             }
         }
     }
-    if (downstream_to_execute_now != NULL) {
-        LF_PRINT_LOG("Worker %d: Optimizing and executing downstream reaction now: %s", worker, downstream_to_execute_now->name);
-        bool violation = false;
-#ifdef FEDERATED_DECENTRALIZED // Only use the STP handler for federated programs that use decentralized coordination
-        // If the is_STP_violated for the reaction is true,
-        // an input trigger to this reaction has been triggered at a later
-        // logical time than originally anticipated. In this case, a special
-        // STP handler will be invoked.
-        // FIXME: Note that the STP handler will be invoked
-        // at most once per logical time value. If the STP handler triggers the
-        // same reaction at the current time value, even if at a future superdense time,
-        // then the reaction will be invoked and the STP handler will not be invoked again.
-        // However, input ports to a federate reactor are network port types so this possibly should
-        // be disallowed.
-        // @note The STP handler and the deadline handler are not mutually exclusive.
-        //  In other words, both can be invoked for a reaction if it is triggered late
-        //  in logical time (STP offset is violated) and also misses the constraint on
-        //  physical time (deadline).
-        // @note In absence of a STP handler, the is_STP_violated will be passed down the reaction
-        //  chain until it is dealt with in a downstream STP handler.
-        if (downstream_to_execute_now->is_STP_violated == true) {
-            // Tardiness has occurred
-            LF_PRINT_LOG("Event has STP violation.");
-            reaction_function_t handler = downstream_to_execute_now->STP_handler;
-            // Invoke the STP handler if there is one.
-            if (handler != NULL) {
-                // There is a violation and it is being handled here
-                // If there is no STP handler, pass the is_STP_violated
-                // to downstream reactions.
-                violation = true;
-                LF_PRINT_LOG("Invoke tardiness handler.");
-                (*handler)(downstream_to_execute_now->self);
-
-                // If the reaction produced outputs, put the resulting
-                // triggered reactions into the queue or execute them directly if possible.
-                schedule_output_reactions(downstream_to_execute_now, worker);
-
-                // Reset the tardiness because it has been dealt with in the
-                // STP handler
-                downstream_to_execute_now->is_STP_violated = false;
-                LF_PRINT_DEBUG("Reset reaction's is_STP_violated field to false: %s",
-                        downstream_to_execute_now->name);
-            }
-        }
-#endif
-        if (downstream_to_execute_now->deadline >= 0LL) {
-            // Get the current physical time.
-            instant_t physical_time = lf_time_physical();
-            // Check for deadline violation.
-            if (downstream_to_execute_now->deadline == 0 || physical_time > current_tag.time + downstream_to_execute_now->deadline) {
-                // Deadline violation has occurred.
-                tracepoint_reaction_deadline_missed(downstream_to_execute_now, worker);
-                violation = true;
-                // Invoke the local handler, if there is one.
-                reaction_function_t handler = downstream_to_execute_now->deadline_violation_handler;
-                if (handler != NULL) {
-                    // Assume the mutex is still not held.
-                    (*handler)(downstream_to_execute_now->self);
-
-                    // If the reaction produced outputs, put the resulting
-                    // triggered reactions into the queue or execute them directly if possible.
-                    schedule_output_reactions(downstream_to_execute_now, worker);
-                }
-            }
-        }
-        if (!violation) {
-            // Invoke the downstream_reaction function.
-            _lf_invoke_reaction(downstream_to_execute_now, worker);
-
-            // If the downstream_reaction produced outputs, put the resulting triggered
-            // reactions into the queue (or execute them directly, if possible).
-            schedule_output_reactions(downstream_to_execute_now, worker);
-        }
-
-        // Reset the is_STP_violated because it has been passed
-        // down the chain
-        downstream_to_execute_now->is_STP_violated = false;
-        LF_PRINT_DEBUG("Finally, reset reaction's is_STP_violated field to false: %s",
-                downstream_to_execute_now->name);
     }
+//     if (downstream_to_execute_now != NULL) { LF_PRINT_LOG("Worker %d: Optimizing and executing downstream reaction now: %s", worker, downstream_to_execute_now->name);
+//         bool violation = false;
+// #ifdef FEDERATED_DECENTRALIZED // Only use the STP handler for federated programs that use decentralized coordination
+//         // If the is_STP_violated for the reaction is true,
+//         // an input trigger to this reaction has been triggered at a later
+//         // logical time than originally anticipated. In this case, a special
+//         // STP handler will be invoked.
+//         // FIXME: Note that the STP handler will be invoked
+//         // at most once per logical time value. If the STP handler triggers the
+//         // same reaction at the current time value, even if at a future superdense time,
+//         // then the reaction will be invoked and the STP handler will not be invoked again.
+//         // However, input ports to a federate reactor are network port types so this possibly should
+//         // be disallowed.
+//         // @note The STP handler and the deadline handler are not mutually exclusive.
+//         //  In other words, both can be invoked for a reaction if it is triggered late
+//         //  in logical time (STP offset is violated) and also misses the constraint on
+//         //  physical time (deadline).
+//         // @note In absence of a STP handler, the is_STP_violated will be passed down the reaction
+//         //  chain until it is dealt with in a downstream STP handler.
+//         if (downstream_to_execute_now->is_STP_violated == true) {
+//             // Tardiness has occurred
+//             LF_PRINT_LOG("Event has STP violation.");
+//             reaction_function_t handler = downstream_to_execute_now->STP_handler;
+//             // Invoke the STP handler if there is one.
+//             if (handler != NULL) {
+//                 // There is a violation and it is being handled here
+//                 // If there is no STP handler, pass the is_STP_violated
+//                 // to downstream reactions.
+//                 violation = true;
+//                 LF_PRINT_LOG("Invoke tardiness handler.");
+//                 (*handler)(downstream_to_execute_now->self);
+
+//                 // If the reaction produced outputs, put the resulting
+//                 // triggered reactions into the queue or execute them directly if possible.
+//                 schedule_output_reactions(downstream_to_execute_now, worker);
+
+//                 // Reset the tardiness because it has been dealt with in the
+//                 // STP handler
+//                 downstream_to_execute_now->is_STP_violated = false;
+//                 LF_PRINT_DEBUG("Reset reaction's is_STP_violated field to false: %s",
+//                         downstream_to_execute_now->name);
+//             }
+//         }
+// #endif
+//         if (downstream_to_execute_now->deadline >= 0LL) {
+//             // Get the current physical time.
+//             instant_t physical_time = lf_time_physical();
+//             // Check for deadline violation.
+//             if (downstream_to_execute_now->deadline == 0 || physical_time > current_tag.time + downstream_to_execute_now->deadline) {
+//                 // Deadline violation has occurred.
+//                 tracepoint_reaction_deadline_missed(downstream_to_execute_now, worker);
+//                 violation = true;
+//                 // Invoke the local handler, if there is one.
+//                 reaction_function_t handler = downstream_to_execute_now->deadline_violation_handler;
+//                 if (handler != NULL) {
+//                     // Assume the mutex is still not held.
+//                     (*handler)(downstream_to_execute_now->self);
+
+//                     // If the reaction produced outputs, put the resulting
+//                     // triggered reactions into the queue or execute them directly if possible.
+//                     schedule_output_reactions(downstream_to_execute_now, worker);
+//                 }
+//             }
+//         }
+//         if (!violation) {
+//             // Invoke the downstream_reaction function.
+//             _lf_invoke_reaction(downstream_to_execute_now, worker);
+
+//             // If the downstream_reaction produced outputs, put the resulting triggered
+//             // reactions into the queue (or execute them directly, if possible).
+//             schedule_output_reactions(downstream_to_execute_now, worker);
+//         }
+
+//         // Reset the is_STP_violated because it has been passed
+//         // down the chain
+//         downstream_to_execute_now->is_STP_violated = false;
+//         LF_PRINT_DEBUG("Finally, reset reaction's is_STP_violated field to false: %s",
+//                 downstream_to_execute_now->name);
+//     }
 }
 
 /**
@@ -1754,4 +1755,44 @@ void termination(void) {
     _lf_free_all_reactors();
     free(_lf_is_present_fields);
     free(_lf_is_present_fields_abbreviated);
+}
+
+// FIXME: Document
+void lf_main_loop(int worker_number) {
+    // Keep track of whether we have decremented the idle thread count.
+    // Obtain a reaction from the scheduler that is ready to execute
+    // (i.e., it is not blocked by concurrently executing reactions
+    // that it depends on).
+    // lf_print_snapshot(); // This is quite verbose (but very useful in debugging reaction deadlocks).
+    reaction_t* current_reaction_to_execute = NULL;
+    while ((current_reaction_to_execute =
+            lf_get_ready_reaction(worker_number))
+            != NULL) {
+        // Got a reaction that is ready to run.
+        LF_PRINT_DEBUG("Worker %d: Got from scheduler reaction %s: "
+                "level: %lld, is control reaction: %d, chain ID: %llu, and deadline " PRINTF_TIME ".",
+                worker_number,
+                current_reaction_to_execute->name,
+                LF_LEVEL(current_reaction_to_execute->index),
+                current_reaction_to_execute->is_a_control_reaction,
+                current_reaction_to_execute->chain_id,
+                current_reaction_to_execute->deadline);
+
+        bool violation = lf_handle_violations(
+            worker_number,
+            current_reaction_to_execute
+        );
+
+        if (!violation) {
+            // Invoke the reaction function.
+            _lf_invoke_reaction(current_reaction_to_execute, worker_number);
+        }
+
+        schedule_output_reactions(current_reaction_to_execute, worker_number);
+
+        LF_PRINT_DEBUG("Worker %d: Done with reaction %s.",
+                worker_number, current_reaction_to_execute->name);
+
+        lf_done_with_reaction(worker_number, current_reaction_to_execute);
+    }
 }

--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -662,7 +662,7 @@ int _lf_schedule_at_tag(trigger_t* trigger, tag_t tag, lf_token_t* token) {
 
     // Do not schedule events if the tag is after the stop tag
     if (_lf_is_tag_after_stop_tag(tag)) {
-         LF_PRINT_DEBUG("_lf_schedule_at_tag: event time is past the timeout. Discarding event.");
+         lf_print_warning("_lf_schedule_at_tag: event time is past the timeout. Discarding event.");
         _lf_done_using(token);
         return -1;
     }

--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -1170,7 +1170,7 @@ trigger_handle_t _lf_insert_reactions_for_trigger(trigger_t* trigger, lf_token_t
         // Do not enqueue this reaction twice.
         if (reaction->status == inactive) {
             reaction->is_STP_violated = is_STP_violated;
-            _lf_trigger_reaction(reaction, -1);
+            _lf_trigger_reaction(reaction,  -1);
             LF_PRINT_LOG("Enqueued reaction %s at time " PRINTF_TIME ".", reaction->name, lf_time_logical(NULL));
         }
     }
@@ -1354,7 +1354,7 @@ void schedule_output_reactions(reaction_t* reaction, int worker) {
                     LF_PRINT_DEBUG("Trigger %p lists %d reactions.", trigger, trigger->number_of_reactions);
                     for (int k=0; k < trigger->number_of_reactions; k++) {
                         reaction_t* downstream_reaction = trigger->reactions[k];
-                        _lf_trigger_reaction(downstream_reaction, worker);
+                        _lf_enable_downstream_reaction(reaction, downstream_reaction, worker);
 #ifdef FEDERATED_DECENTRALIZED // Only pass down tardiness for federated LF programs
                         // Set the is_STP_violated for the downstream reaction
                         if (downstream_reaction != NULL) {

--- a/core/tag.c
+++ b/core/tag.c
@@ -15,7 +15,10 @@
 #include "tag.h"
 #include "util.h"
 #include "platform.h"
+#include "reactor.h"
 #include "util.h"
+#include "lf_types.h"
+
 
 /**
  * An enum for specifying the desired tag when calling "lf_time"
@@ -148,8 +151,14 @@ instant_t _lf_time(_lf_time_type type) {
 
 ////////////////  Functions declared in tag.h
 
-tag_t lf_tag() {
-    return current_tag;
+tag_t lf_tag(void* self) {
+    if (self == NULL) {
+        return current_tag;
+    } else if (((self_base_t *) self)->executing_reaction) {
+        return ((self_base_t *) self)->current_tag;
+    } else {
+        return current_tag;
+    }
 }
 
 int lf_tag_compare(tag_t tag1, tag_t tag2) {
@@ -186,12 +195,16 @@ tag_t lf_delay_tag(tag_t tag, interval_t interval) {
     return result;
 }
 
-instant_t lf_time_logical(void) {
-    return _lf_time(LF_LOGICAL);
+instant_t lf_time_logical(void *self) {
+    if (self) return ((self_base_t *) self)->current_tag.time;
+    else return _lf_time(LF_LOGICAL);
 }
 
-interval_t lf_time_logical_elapsed(void) {
-    return _lf_time(LF_ELAPSED_LOGICAL);
+/**
+ * Return the elapsed logical time in nanoseconds since the start of execution.
+ */
+interval_t lf_time_logical_elapsed(void *self) {
+    return lf_time_logical(self) - start_time;
 }
 
 instant_t lf_time_physical(void) {

--- a/core/tag.c
+++ b/core/tag.c
@@ -152,9 +152,7 @@ instant_t _lf_time(_lf_time_type type) {
 ////////////////  Functions declared in tag.h
 
 tag_t lf_tag(void* self) {
-    if (self == NULL) {
-        return current_tag;
-    } else if (((self_base_t *) self)->executing_reaction) {
+    if (self != NULL && ((self_base_t *) self)->executing_reaction != NULL) {
         return ((self_base_t *) self)->current_tag;
     } else {
         return current_tag;

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -141,6 +141,7 @@ void _lf_increment_global_tag_barrier_already_locked(tag_t future_tag) {
         lf_print_warning("Attempting to raise a barrier after the stop tag.");
         future_tag = stop_tag;
     }
+    tag_t current_tag = lf_tag(NULL);
     // Check to see if future_tag is actually in the future.
     if (lf_tag_compare(future_tag, current_tag) > 0) {
         // Future tag is actually in the future.
@@ -464,7 +465,7 @@ tag_t get_next_event_tag() {
         if (next_tag.time == current_tag.time) {
         	LF_PRINT_DEBUG("Earliest event matches current time. Incrementing microstep. Event is dummy: %d.",
         			event->is_dummy);
-            next_tag.microstep =  lf_tag().microstep + 1;
+            next_tag.microstep =  lf_tag(NULL).microstep + 1;
         } else {
             next_tag.microstep = 0;
         }

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -900,7 +900,7 @@ bool _lf_worker_handle_STP_violation_for_reaction(int worker_number, reaction_t*
  *
  * @return true if a violation occurred. false otherwise.
  */
-bool _lf_worker_handle_violations(int worker_number, reaction_t* reaction) {
+bool lf_handle_violations(int worker_number, reaction_t* reaction) {
     bool violation = false;
 
     violation = _lf_worker_handle_deadline_violation_for_reaction(worker_number, reaction) ||
@@ -909,70 +909,11 @@ bool _lf_worker_handle_violations(int worker_number, reaction_t* reaction) {
 }
 
 /**
- * Invoke 'reaction' and schedule any resulting triggered reaction(s) on the
- * reaction queue.
- * The mutex should NOT be locked when this function is called. It might acquire
- * the mutex when scheduling the reactions that are triggered as a result of
- * executing 'reaction'.
- */
-void _lf_worker_invoke_reaction(int worker_number, reaction_t* reaction) {
-    LF_PRINT_LOG("Worker %d: Invoking reaction %s at elapsed tag " PRINTF_TAG ".",
-            worker_number,
-            reaction->name,
-            current_tag.time - start_time,
-            current_tag.microstep);
-    _lf_invoke_reaction(reaction, worker_number);
-
-    // If the reaction produced outputs, put the resulting triggered
-    // reactions into the queue or execute them immediately.
-    schedule_output_reactions(reaction, worker_number);
-
-    reaction->is_STP_violated = false;
-}
-
-/**
  * The main looping logic of each LF worker thread.
  * This function assumes the caller holds the mutex lock.
  *
  * @param worker_number The number assigned to this worker thread
  */
-void _lf_worker_do_work(int worker_number) {
-    // Keep track of whether we have decremented the idle thread count.
-    // Obtain a reaction from the scheduler that is ready to execute
-    // (i.e., it is not blocked by concurrently executing reactions
-    // that it depends on).
-    // lf_print_snapshot(); // This is quite verbose (but very useful in debugging reaction deadlocks).
-    reaction_t* current_reaction_to_execute = NULL;
-    while ((current_reaction_to_execute =
-            lf_sched_get_ready_reaction(worker_number))
-            != NULL) {
-        // Got a reaction that is ready to run.
-        LF_PRINT_DEBUG("Worker %d: Got from scheduler reaction %s: "
-                "level: %lld, is control reaction: %d, chain ID: %llu, and deadline " PRINTF_TIME ".",
-                worker_number,
-                current_reaction_to_execute->name,
-                LF_LEVEL(current_reaction_to_execute->index),
-                current_reaction_to_execute->is_a_control_reaction,
-                current_reaction_to_execute->chain_id,
-                current_reaction_to_execute->deadline);
-
-        bool violation = _lf_worker_handle_violations(
-            worker_number,
-            current_reaction_to_execute
-        );
-
-        if (!violation) {
-            // Invoke the reaction function.
-            _lf_worker_invoke_reaction(worker_number, current_reaction_to_execute);
-        }
-
-        LF_PRINT_DEBUG("Worker %d: Done with reaction %s.",
-                worker_number, current_reaction_to_execute->name);
-
-        lf_sched_done_with_reaction(worker_number, current_reaction_to_execute);
-    }
-}
-
 /**
  * Worker thread for the thread pool.
  * This acquires the mutex lock and releases it to wait for time to
@@ -984,7 +925,7 @@ void* worker(void* arg) {
     LF_PRINT_LOG("Worker thread %d started.", worker_number);
     lf_mutex_unlock(&mutex);
 
-    _lf_worker_do_work(worker_number);
+    lf_main_loop(worker_number);
 
     lf_mutex_lock(&mutex);
 
@@ -1191,4 +1132,14 @@ int lf_critical_section_enter() {
 int lf_critical_section_exit() {
     return lf_mutex_unlock(&mutex); 
 }
+
+reaction_t *lf_get_ready_reaction(int worker_number) {
+    return lf_sched_get_ready_reaction(worker_number);
+}
+
+void lf_done_with_reaction(int worker_number, reaction_t * reaction) {
+    lf_sched_done_with_reaction(worker_number, reaction);
+}
+
+
 #endif

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -694,6 +694,7 @@ void lf_request_stop() {
  *  unthreaded C runtime). -1 is used for an anonymous call in a context where a
  *  worker number does not make sense (e.g., the caller is not a worker thread).
  */
+// FIXME: Document enable vs trigger
 void _lf_trigger_reaction(reaction_t* reaction, int worker_number) {
 #ifdef MODAL_REACTORS
         // Check if reaction is disabled by mode inactivity
@@ -706,6 +707,22 @@ void _lf_trigger_reaction(reaction_t* reaction, int worker_number) {
             		reaction->name, reaction->mode->name);
         }
 #endif
+}
+
+// FIXME: Document enable vs trigger
+void _lf_enable_downstream_reaction(reaction_t* upstream, reaction_t * downstream, int worker_number) {
+#ifdef MODAL_REACTORS
+        // Check if reaction is disabled by mode inactivity
+        if (_lf_mode_is_active(reaction->mode)) {
+#endif
+    lf_sched_enable_downstream_reaction(upstream, downstream, worker_number);
+#ifdef MODAL_REACTORS
+        } else { // Suppress reaction by preventing entering reaction queue
+            LF_PRINT_DEBUG("Suppressing downstream reaction %s due inactivity of mode %s.",
+            		reaction->name, reaction->mode->name);
+        }
+#endif
+
 }
 
 /**

--- a/core/threaded/scheduler_NP.c
+++ b/core/threaded/scheduler_NP.c
@@ -353,20 +353,27 @@ void lf_sched_free() {
  */
 // FIXME: Chain docs
 reaction_t* lf_sched_get_ready_reaction(int worker_number) {
+    reaction_t *reaction_to_return = NULL;
 
+    // FIXME: We might want to put all chain calculations into a separate file
+    //  so all schedulers can use it.
     // See if this worker has a potential chain:
     if (_lf_sched_instance->_lf_sched_chain[worker_number].proposed_next) {
-        reaction_t* next = 
-            _lf_sched_instance->_lf_sched_chain[worker_number].proposed_next ;
+        reaction_to_return = _lf_sched_instance->_lf_sched_chain[worker_number].proposed_next ;
+        LF_PRINT_DEBUG("Worker %u execute chain-reaction %s", worker_number, reaction_to_return->name);
         // If this is the beginning of the chain, store the pointer to it
         // FIXME: May not be needed
         if (!_lf_sched_instance->_lf_sched_chain[worker_number].start) {
-            _lf_sched_instance->_lf_sched_chain[worker_number].start = next;
+            _lf_sched_instance->_lf_sched_chain[worker_number].start = reaction_to_return;
         }
+    }
 
-        // Reset the prposed next of chain
-        _lf_sched_instance->_lf_sched_chain[worker_number].proposed_next = NULL; 
-        return next;
+    // Reset chain stuff
+    _lf_sched_instance->_lf_sched_chain[worker_number].proposed_next = NULL; 
+    _lf_sched_instance->_lf_sched_chain[worker_number].is_candidate = true; 
+    
+    if (reaction_to_return) {
+        return reaction_to_return;
     }
 
 
@@ -375,7 +382,6 @@ reaction_t* lf_sched_get_ready_reaction(int worker_number) {
         // Calculate the current level of reactions to execute
         size_t current_level =
             _lf_sched_instance->_lf_sched_next_reaction_level - 1;
-        reaction_t* reaction_to_return = NULL;
 #ifdef FEDERATED
         // Need to lock the mutex because federate.c could trigger reactions at
         // the current level (if there is a causality loop)
@@ -481,25 +487,39 @@ void lf_sched_enable_downstream_reaction(reaction_t* upstream,  reaction_t *down
     if (downstream == NULL || upstream == NULL || !lf_bool_compare_and_swap(&downstream->status, inactive, queued)) {
         return;
     }
+    _lf_sched_chain_t * chain = &_lf_sched_instance->_lf_sched_chain[worker_number];
 
-    assert(upstream && downstream && worker_number>=0);
+    // Figure out if
+    // 1) We should schedule the downstream we got now
+    // 2) We should schedule a downstream stored in the `proposed_next` field of the chain struct
+    bool schedule_now = false;
+    bool schedule_proposed_now = false;
 
-    // This could be the start of a chain if:
-    // 1) This is the first downstream reaction enabled
-    // 2) The upstream reaction is the last enablig downstream reaction
-    if (_lf_sched_instance->_lf_sched_chain[worker_number].proposed_next == NULL) {
-        if (downstream->last_enabling_reaction == upstream) {
-            LF_PRINT_DEBUG("Scheduler: Proposing reaction %s for a chain.", downstream->name);
-            _lf_sched_instance->_lf_sched_chain[worker_number].proposed_next = downstream;
+    if (chain->is_candidate) {
+        if (chain->proposed_next == NULL ) {
+            if (downstream->last_enabling_reaction == upstream) {
+                LF_PRINT_DEBUG("Worker %u: Proposing reaction %s for a chain.", worker_number, downstream->name);
+                _lf_sched_instance->_lf_sched_chain[worker_number].proposed_next = downstream;
+            } else {
+                schedule_now = true;
+            }
+        } else {
+            schedule_now = true;
+            schedule_proposed_now = true;
         }
     } else {
-        // No chain, also insert the proposed next chain reaction
-        _lf_sched_insert_reaction(_lf_sched_instance->_lf_sched_chain[worker_number].proposed_next);
-        LF_PRINT_DEBUG("Scheduler: Enqueing reaction %s, which has level %lld for later execution.",
-            downstream->name, LF_LEVEL(downstream->index));
+        schedule_now = true;
+    }
+
+    if (schedule_proposed_now) {
+        _lf_sched_insert_reaction(chain->proposed_next);
+        chain->is_candidate = false;
+        chain->proposed_next = NULL;
+    }
+
+    if (schedule_now) {
         _lf_sched_insert_reaction(downstream);
-        // Reset the proposed_next
-        _lf_sched_instance->_lf_sched_chain[worker_number].proposed_next = NULL;
+        chain->is_candidate = false;
     }
 }
 #endif

--- a/core/threaded/scheduler_NP.c
+++ b/core/threaded/scheduler_NP.c
@@ -478,29 +478,20 @@ void lf_sched_trigger_reaction(reaction_t* reaction, int worker_number) {
 
 // FIXME: Chain docs
 void lf_sched_enable_downstream_reaction(reaction_t* upstream,  reaction_t *downstream, int worker_number) {
-    if (downstream == NULL || !lf_bool_compare_and_swap(&downstream->status, inactive, queued)) {
+    if (downstream == NULL || upstream == NULL || !lf_bool_compare_and_swap(&downstream->status, inactive, queued)) {
         return;
     }
 
-    // If reaction is triggered outside a "worker-context", then insert it and
-    //  dont do chain optimization
-    if (worker_number < 0) {
-        LF_PRINT_DEBUG("Scheduler: Enqueing reaction %s, which has level %lld for later execution.",
-            downstream->name, LF_LEVEL(downstream->index));
-        _lf_sched_insert_reaction(downstream);
-        return;
-    }
-
+    assert(upstream && downstream && worker_number>=0);
 
     // This could be the start of a chain if:
     // 1) This is the first downstream reaction enabled
     // 2) The upstream reaction is the last enablig downstream reaction
-    if (_lf_sched_instance->_lf_sched_chain[worker_number].proposed_next == NULL &&
-        downstream->last_enabling_reaction == upstream
-    
-    )  {
-        LF_PRINT_DEBUG("Scheduler: Proposing reaction %s for a chain.", downstream->name);
-        _lf_sched_instance->_lf_sched_chain[worker_number].proposed_next = downstream;
+    if (_lf_sched_instance->_lf_sched_chain[worker_number].proposed_next == NULL) {
+        if (downstream->last_enabling_reaction == upstream) {
+            LF_PRINT_DEBUG("Scheduler: Proposing reaction %s for a chain.", downstream->name);
+            _lf_sched_instance->_lf_sched_chain[worker_number].proposed_next = downstream;
+        }
     } else {
         // No chain, also insert the proposed next chain reaction
         _lf_sched_insert_reaction(_lf_sched_instance->_lf_sched_chain[worker_number].proposed_next);

--- a/core/trace.c
+++ b/core/trace.c
@@ -294,14 +294,7 @@ void tracepoint(
     int i = _lf_trace_buffer_size[index];
     // Write to memory buffer.
     // Get the correct time of the event
-    tag_t tag;
-    if (trigger) {
-        self_base_t* reactor = (self_base_t *) trigger->reactions[0]->self;
-        tag = lf_tag(reactor);
-    } else {
-        tag = lf_tag(pointer);
-    }
-
+    
     _lf_trace_buffer[index][i].event_type = event_type;
     _lf_trace_buffer[index][i].pointer = pointer;
     _lf_trace_buffer[index][i].src_id = src_id;

--- a/core/trace.c
+++ b/core/trace.c
@@ -293,6 +293,15 @@ void tracepoint(
     // The above flush_trace resets the write pointer.
     int i = _lf_trace_buffer_size[index];
     // Write to memory buffer.
+    // Get the correct time of the event
+    tag_t tag;
+    if (trigger) {
+        self_base_t* reactor = (self_base_t *) trigger->reactions[0]->self;
+        tag = lf_tag(reactor);
+    } else {
+        tag = lf_tag(pointer);
+    }
+
     _lf_trace_buffer[index][i].event_type = event_type;
     _lf_trace_buffer[index][i].pointer = pointer;
     _lf_trace_buffer[index][i].src_id = src_id;
@@ -301,8 +310,8 @@ void tracepoint(
         _lf_trace_buffer[index][i].logical_time = tag->time;
         _lf_trace_buffer[index][i].microstep = tag->microstep;
     } else {
-        _lf_trace_buffer[index][i].logical_time = lf_time_logical();
-        _lf_trace_buffer[index][i].microstep = lf_tag().microstep;
+        _lf_trace_buffer[index][i].logical_time = lf_time_logical(pointer);
+        _lf_trace_buffer[index][i].microstep = lf_tag(pointer).microstep;
     }
     _lf_trace_buffer[index][i].trigger = trigger;
     _lf_trace_buffer[index][i].extra_delay = extra_delay;

--- a/include/api/api.h
+++ b/include/api/api.h
@@ -185,6 +185,6 @@ int lf_tag_compare(tag_t tag1, tag_t tag2);
 /**
  * Return the current tag, a logical time, microstep pair.
  */
-tag_t lf_tag();
+tag_t lf_tag(void * self);
 
 #endif // API_H

--- a/include/api/api.h
+++ b/include/api/api.h
@@ -183,8 +183,11 @@ bool lf_check_deadline(void* self, bool invoke_deadline_handler);
 int lf_tag_compare(tag_t tag1, tag_t tag2);
 
 /**
- * Return the current tag, a logical time, microstep pair.
+ * Return the current tag of a reactor. If NULL is passed to this function it
+ * will return the "global tag" of the runtime.  
+ * @param self A pointer to the self-struct of the reactor. 
+ * @return the current tag 
  */
-tag_t lf_tag(void * self);
+tag_t lf_tag(void* self);
 
 #endif // API_H

--- a/include/api/set.h
+++ b/include/api/set.h
@@ -211,3 +211,14 @@ do { \
 #endif // MODAL_REACTORS
 
 #endif // CTARGET_SET
+
+// For simplicity and backward compatability, dont require the self-pointer when calling the timing API.
+// Since this is always done from the context of a reaction `self` is in scope and is a pointer to the self-struct
+#define lf_tag() lf_tag(self)
+#define get_current_tag() get_current_tag(self)
+#define get_microstep() get_microstep(self)
+
+#define lf_time_logical() lf_time_logical(self)
+#define lf_time_logical_elapsed() lf_time_logical_elapsed(self)
+#define get_elapsed_logical_time() get_elapsed_logical_time(self)
+#define get_logical_time() get_logical_time(self)

--- a/include/api/set_undef.h
+++ b/include/api/set_undef.h
@@ -112,4 +112,12 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #undef SET_MODE
 #endif
 
+#undef lf_time_logical 
+#undef lf_time_logical_elapsed 
+#undef get_logical_time
+#undef get_elapsed_logical_time
+
+#undef lf_tag
+#undef get_current_tag
+#undef get_microstep
 #endif // CTARGET_SET

--- a/include/core/lf_types.h
+++ b/include/core/lf_types.h
@@ -240,6 +240,7 @@ struct trigger_t {
                               //   downstream messages have been produced for the same port for the same logical time.
     reactor_mode_t* mode;     // The enclosing mode of this reaction (if exists).
                               // If enclosed in multiple, this will point to the innermost mode.
+    void* parent;             // Pointer to reactor which contains the trigger
 #ifdef FEDERATED
     tag_t last_known_status_tag;        // Last known status of the port, either via a timed message, a port absent, or a
                                         // TAG from the RTI.
@@ -278,6 +279,7 @@ typedef struct allocation_record_t {
 typedef struct self_base_t {
 	struct allocation_record_t *allocations;
 	struct reaction_t *executing_reaction;   // The currently executing reaction of the reactor.
+    tag_t current_tag;                       // The current tag the reactor is executing at (used for e.g. LET scheduling)
 #ifdef MODAL_REACTORS
     reactor_mode_state_t _lf__mode_state;    // The current mode (for modal models).
 #endif

--- a/include/core/reactor_common.h
+++ b/include/core/reactor_common.h
@@ -88,4 +88,9 @@ int process_args(int argc, const char* argv[]);
 void initialize(void);
 void termination(void);
 
+// FIXME: Document functions and should they be prepended by underscore?
+void lf_main_loop(int worker_number);
+reaction_t * lf_get_ready_reaction(int worker_number);
+bool lf_handle_violations(int worker_number, reaction_t *reaction);
+void lf_done_with_reaction(int worker_number, reaction_t *reaction);
 #endif

--- a/include/core/reactor_common.h
+++ b/include/core/reactor_common.h
@@ -58,6 +58,7 @@ void lf_set_stp_offset(interval_t offset);
 extern pqueue_t* event_q;
 
 void _lf_trigger_reaction(reaction_t* reaction, int worker_number);
+void _lf_enable_downstream_reaction(reaction_t* upstream, reaction_t *downstream, int worker_number);
 void _lf_start_time_step();
 bool _lf_is_tag_after_stop_tag(tag_t tag);
 void _lf_pop_events();

--- a/include/core/tag.h
+++ b/include/core/tag.h
@@ -77,7 +77,7 @@ typedef struct {
 /**
  * Return the current tag, a logical time, microstep pair.
  */
-tag_t lf_tag();
+tag_t lf_tag(void* self);
 
 /**
  * Compare two tags. Return -1 if the first is less than
@@ -116,14 +116,14 @@ tag_t lf_delay_tag(tag_t tag, interval_t interval);
  *
  * @return A time instant.
  */
-instant_t lf_time_logical(void);
+instant_t lf_time_logical(void* self);
 
 /**
  * Return the elapsed logical time in nanoseconds
  * since the start of execution.
  * @return A time interval.
  */
-interval_t lf_time_logical_elapsed(void);
+interval_t lf_time_logical_elapsed(void *self);
 
 /**
  * Return the current physical time in nanoseconds.

--- a/include/core/threaded/scheduler.h
+++ b/include/core/threaded/scheduler.h
@@ -135,4 +135,6 @@ void lf_sched_done_with_reaction(size_t worker_number, reaction_t* done_reaction
  */
 void lf_sched_trigger_reaction(reaction_t* reaction, int worker_number);
 
+void lf_sched_enable_downstream_reaction(reaction_t * upstream, reaction_t* downstream, int worker_number);
+
 #endif // LF_SCHEDULER_H

--- a/include/core/threaded/scheduler_instance.h
+++ b/include/core/threaded/scheduler_instance.h
@@ -47,6 +47,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 extern lf_mutex_t mutex;
 
+// FIXME: Document
+// FIXME: Do these have to be volatile
+typedef struct {
+    reaction_t * start;
+    reaction_t * proposed_next;
+} _lf_sched_chain_t;
 
 /**
  * @brief Paramters used in schedulers of the threaded reactor C runtime.
@@ -132,6 +138,11 @@ typedef struct {
      *
      */
     volatile size_t _lf_sched_next_reaction_level;
+
+    // A pointer to the reaction at the start of the chain currently executed
+    // by the worker
+    volatile _lf_sched_chain_t * _lf_sched_chain;
+
 } _lf_sched_instance_t;
 
 /**
@@ -181,6 +192,10 @@ bool init_sched_instance(
     (*instance)->_lf_sched_next_reaction_level = 1;
 
     (*instance)->_lf_sched_should_stop = false;
+
+    (*instance)->_lf_sched_chain = 
+        (_lf_sched_chain_t *) calloc(number_of_workers, sizeof(_lf_sched_chain_t));
+
 
     return true;
 }

--- a/lib/schedule.c
+++ b/lib/schedule.c
@@ -191,7 +191,7 @@ trigger_handle_t lf_schedule_value(void* action, interval_t extra_delay, void* v
  */
 bool lf_check_deadline(void* self, bool invoke_deadline_handler) {
     reaction_t* reaction = ((self_base_t*)self)->executing_reaction;
-    if (lf_time_physical() > lf_time_logical() + reaction->deadline) {
+    if (lf_time_physical() > lf_time_logical(self) + reaction->deadline) {
         if (invoke_deadline_handler) {
             reaction->deadline_violation_handler(self);
         }

--- a/lingua-franca-ref.txt
+++ b/lingua-franca-ref.txt
@@ -1,1 +1,1 @@
-master
+reactor-local-time


### PR DESCRIPTION
This is still a draft PR. Docs have not been updated. Just want to run the CI.
---

This PR addresses the issue that the scheduler API is not really "consistent". The API is:

1. `lf_sched_get_ready_reaction`
2. `lf_sched_done_with_reaction`
3. `lf_sched_trigger_reaction`

But due to an optimization there can be executed reactions without a corresponding call to `lf_sched_get_ready_reaction`. This happens if a reaction produces an output that enables a single other reaction. Then the runtime will go ahead and execute this reaction right away. This is problematic for the LET scheduler and the static scheduler where we would like to have complete control over which worker executes which reaction. It should be a scheduler optimization because whether or not you should execute this downstream reaction depends on its deadline relative the deadline of the first reaction on the reaction queue.

This proposal removes this "chain optimization" from `reactor_common.c` and puts it in the scheduler. To simplify this we also unify the threaded and the unthreaded runtime. I have created a common `lf_main_loop` which both the workers of the threaded and the unthreaded runtime should run. It depends on a few functions which both threaded and unthreaded runtime must implement.
