### PR TITLE
Step 1: Introduce a global environment replacing the global variables

### DIFF
--- a/core/federated/RTI/rti_lib.c
+++ b/core/federated/RTI/rti_lib.c
@@ -60,10 +60,10 @@ RTI_instance_t _RTI = {
  * to not change unless they are changed within the critical section.
  * this can be implemented by disabling interrupts.
  * Users of this function must ensure that lf_init_critical_sections() is
- * called first and that lf_critical_section_exit() is called later.
+ * called first and that lf_critical_section_exit(env) is called later.
  * @return 0 on success, platform-specific error number otherwise.
  */
-extern int lf_critical_section_enter() {
+extern int lf_critical_section_enter(env) {
     return pthread_mutex_lock(&_RTI.rti_mutex);
 }
 
@@ -71,7 +71,7 @@ extern int lf_critical_section_enter() {
  * Exit the critical section entered with lf_lock_time().
  * @return 0 on success, platform-specific error number otherwise.
  */
-extern int lf_critical_section_exit() {
+extern int lf_critical_section_exit(env) {
     return pthread_mutex_unlock(&_RTI.rti_mutex);
 }
 

--- a/core/federated/RTI/rti_lib.h
+++ b/core/federated/RTI/rti_lib.h
@@ -214,16 +214,16 @@ typedef struct RTI_instance_t {
  * to not change unless they are changed within the critical section.
  * this can be implemented by disabling interrupts.
  * Users of this function must ensure that lf_init_critical_sections() is
- * called first and that lf_critical_section_exit() is called later.
+ * called first and that lf_critical_section_exit(env) is called later.
  * @return 0 on success, platform-specific error number otherwise.
  */
-extern int lf_critical_section_enter();
+extern int lf_critical_section_enter(env);
 
 /**
  * Exit the critical section entered with lf_lock_time().
  * @return 0 on success, platform-specific error number otherwise.
  */
-extern int lf_critical_section_exit();
+extern int lf_critical_section_exit(env);
 
 /**
  * Create a server and enable listening for socket connections.

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -2421,7 +2421,7 @@ void terminate_execution() {
         size_t bytes_to_write = 1 + sizeof(tag_t);
         unsigned char buffer[bytes_to_write];
         buffer[0] = MSG_TYPE_RESIGN;
-        tag_t tag = lf_tag();
+        tag_t tag = lf_tag(NULL);
         encode_tag(&(buffer[1]), tag);
         // Trace the event when tracing is enabled
         tracepoint_federate_to_RTI(send_RESIGN, _lf_my_fed_id, &tag);

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -381,7 +381,7 @@ int send_timed_message(interval_t additional_delay,
 
     // Apply the additional delay to the current tag and use that as the intended
     // tag of the outgoing message
-    tag_t current_message_intended_tag = lf_delay_tag(lf_tag(),
+    tag_t current_message_intended_tag = _lf_delay_tag(lf_tag(NULL),
                                                     additional_delay);
 
     // Next 8 + 4 will be the tag (timestamp, microstep)
@@ -1402,13 +1402,13 @@ port_status_t get_current_port_status(int portID) {
         // The status of the trigger is absent.
         return absent;
     } else if (network_input_port_action->status == unknown
-            && lf_tag_compare(network_input_port_action->last_known_status_tag, lf_tag()) >= 0) {
+            && lf_tag_compare(network_input_port_action->last_known_status_tag, lf_tag(NULL)) >= 0) {
         // We have a known status for this port in a future tag. Therefore, no event is going
         // to be present for this port at the current tag.
         set_network_port_status(portID, absent);
         return absent;
     } else if (_fed.is_last_TAG_provisional
-            && lf_tag_compare(_fed.last_TAG, lf_tag()) > 0) {
+            && lf_tag_compare(_fed.last_TAG, lf_tag(NULL)) > 0) {
         // In this case, a PTAG has been received with a larger tag than the current tag,
         // which means that the input port is known to be absent.
         set_network_port_status(portID, absent);
@@ -1483,7 +1483,7 @@ void enqueue_network_control_reactions() {
 #ifdef FEDERATED_CENTRALIZED
     // If the granted tag is not provisional, there is no
     // need for network input control reactions
-    if (lf_tag_compare(_fed.last_TAG, lf_tag()) != 0
+    if (lf_tag_compare(_fed.last_TAG, lf_tag(NULL)) != 0
             || _fed.is_last_TAG_provisional == false) {
         return;
     }
@@ -1512,7 +1512,7 @@ void send_port_absent_to_federate(interval_t additional_delay,
 
     // Apply the additional delay to the current tag and use that as the intended
     // tag of the outgoing message
-    tag_t current_message_intended_tag = lf_delay_tag(lf_tag(),
+    tag_t current_message_intended_tag = _lf_delay_tag(lf_tag(NULL),
                                                     additional_delay);
 
     LF_PRINT_LOG("Sending port "
@@ -1617,8 +1617,8 @@ void wait_until_port_status_known(int port_ID, interval_t STAA) {
     // The wait has timed out. However, a message header
     // for the current tag could have been received in time
     // but not the the body of the message.
-    // Wait on the tag barrier based on the current tag.
-    _lf_wait_on_global_tag_barrier(lf_tag());
+    // Wait on the tag barrier based on the current tag. 
+    _lf_wait_on_global_tag_barrier(lf_tag(NULL));
 
     // Done waiting
     // If the status of the port is still unknown, assume it is absent.
@@ -1699,7 +1699,7 @@ trigger_handle_t schedule_message_received_from_network_already_locked(
         // In case the message is in the future, call
         // _lf_schedule_at_tag() so that the microstep is respected.
         LF_PRINT_LOG("Received a message that is (" PRINTF_TIME " nanoseconds, " PRINTF_MICROSTEP " microsteps) "
-                "in the future.", extra_delay, tag.microstep - lf_tag().microstep);
+                "in the future.", extra_delay, tag.microstep - lf_tag(NULL).microstep);
         return_value = _lf_schedule_at_tag(trigger, tag, token);
     }
     // Notify the main thread in case it is waiting for physical time to elapse.
@@ -1931,7 +1931,7 @@ void handle_tagged_message(int socket, int fed_id) {
 #endif
     LF_PRINT_LOG("Received message with tag: " PRINTF_TAG ", Current tag: " PRINTF_TAG ".",
             intended_tag.time - start_time, intended_tag.microstep,
-            lf_time_logical_elapsed(), lf_tag().microstep);
+            lf_time_logical_elapsed(NULL), lf_tag(NULL).microstep);
 
     // Read the payload.
     // Allocate memory for the message contents.
@@ -1984,7 +1984,7 @@ void handle_tagged_message(int socket, int fed_id) {
     // to exit. The port status is on the other hand changed in this thread, and thus,
     // can be checked in this scenario without this race condition. The message with
     // intended_tag of 9 in this case needs to wait one microstep to be processed.
-    if (lf_tag_compare(intended_tag, lf_tag()) <= 0 && // The event is meant for the current or a previous tag.
+    if (lf_tag_compare(intended_tag, lf_tag(NULL)) <= 0 && // The event is meant for the current or a previous tag.
             ((action->trigger->is_a_control_reaction_waiting && // Check if a control reaction is waiting and
              action->trigger->status == unknown) ||             // if the status of the port is still unknown.
              (_lf_execution_started == false))         // Or, execution hasn't even started, so it's safe to handle this event.
@@ -1995,9 +1995,9 @@ void handle_tagged_message(int socket, int fed_id) {
         LF_PRINT_LOG(
             "Inserting reactions directly at tag " PRINTF_TAG ". "
             "Intended tag: " PRINTF_TAG ".",
-            lf_tag().time - lf_time_start(),
-            lf_tag().microstep,
-            intended_tag.time - lf_time_start(),
+            lf_tag(NULL).time - lf_time_start(),
+            lf_tag(NULL).microstep, 
+            intended_tag.time - lf_time_start(), 
             intended_tag.microstep
         );
         action->trigger->intended_tag = intended_tag;
@@ -2017,12 +2017,12 @@ void handle_tagged_message(int socket, int fed_id) {
 
         // Before that, if the current time >= stop time, discard the message.
         // But only if the stop time is not equal to the start time!
-        if (lf_tag_compare(lf_tag(), stop_tag) >= 0) {
+        if (lf_tag_compare(lf_tag(NULL), stop_tag) >= 0) {
             lf_mutex_unlock(&mutex);
             lf_print_error("Received message too late. Already at stop tag.\n"
             		"Current tag is " PRINTF_TAG " and intended tag is " PRINTF_TAG ".\n"
             		"Discarding message.",
-					lf_tag().time - start_time, lf_tag().microstep,
+					lf_tag(NULL).time - start_time, lf_tag(NULL).microstep,
 					intended_tag.time - start_time, intended_tag.microstep);
             return;
         }

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -381,7 +381,7 @@ int send_timed_message(interval_t additional_delay,
 
     // Apply the additional delay to the current tag and use that as the intended
     // tag of the outgoing message
-    tag_t current_message_intended_tag = _lf_delay_tag(lf_tag(NULL),
+    tag_t current_message_intended_tag = lf_delay_tag(lf_tag(NULL),
                                                     additional_delay);
 
     // Next 8 + 4 will be the tag (timestamp, microstep)
@@ -1512,7 +1512,7 @@ void send_port_absent_to_federate(interval_t additional_delay,
 
     // Apply the additional delay to the current tag and use that as the intended
     // tag of the outgoing message
-    tag_t current_message_intended_tag = _lf_delay_tag(lf_tag(NULL),
+    tag_t current_message_intended_tag = lf_delay_tag(lf_tag(NULL),
                                                     additional_delay);
 
     LF_PRINT_LOG("Sending port "

--- a/core/lf_token.c
+++ b/core/lf_token.c
@@ -40,9 +40,10 @@ int _lf_count_payload_allocations;
 #include <assert.h>
 #include <string.h>  // Defines memcpy
 #include "lf_token.h"
+#include "lf_types.h"
 #include "hashset/hashset_itr.h"
 #include "util.h"
-#include "platform.h" // Defines lf_critical_section_enter() and exit.
+#include "reactor_common.h" // Enter/exit critical sections
 #include "port.h"     // Defines lf_port_base_t.
 
 lf_token_t* _lf_tokens_allocated_in_reactions = NULL;
@@ -72,11 +73,11 @@ static hashset_t _lf_token_templates = NULL;
 ////////////////////////////////////////////////////////////////////
 //// Functions that users may call.
 
-lf_token_t* lf_new_token(void* port_or_action, void* val, size_t len) {
-    return _lf_new_token((token_type_t*)port_or_action, val, len);
+lf_token_t* lf_new_token(void *env, void* port_or_action, void* val, size_t len) {
+    return _lf_new_token((environment_t*)env, (token_type_t*)port_or_action, val, len);
 }
 
-lf_token_t* lf_writable_copy(lf_port_base_t* port) {
+lf_token_t* lf_writable_copy(struct environment_t* env, lf_port_base_t* port) {
     assert(port != NULL);
 
     lf_token_t* token = port->tmplt.token;
@@ -115,7 +116,7 @@ lf_token_t* lf_writable_copy(lf_port_base_t* port) {
     _lf_count_payload_allocations++;
 
     // Create a new, dynamically allocated token.
-    lf_token_t* result = _lf_new_token((token_type_t*)port, copy, token->length);
+    lf_token_t* result = _lf_new_token(env, (token_type_t*)port, copy, token->length);
     result->ref_count = 1;
     // Arrange for the token to be released (and possibly freed) at
     // the start of the next time step.
@@ -148,7 +149,7 @@ void _lf_free_token_value(lf_token_t* token) {
     }
 }
 
-token_freed _lf_free_token(lf_token_t* token) {
+token_freed _lf_free_token(struct environment_t* env, lf_token_t* token) {
     token_freed result = NOT_FREED;
     if (token == NULL) return result;
     if (token->ref_count > 0) return result;
@@ -157,13 +158,13 @@ token_freed _lf_free_token(lf_token_t* token) {
     // Tokens that are created at the start of execution and associated with
     // output ports or actions persist until they are overwritten.
     // Need to acquire a mutex to access the recycle bin.
-    if (lf_critical_section_enter() != 0) {
+    if (lf_critical_section_enter(env) != 0) {
         lf_print_error_and_exit("Could not enter critical section");
     }
     if (_lf_token_recycling_bin == NULL) {
         _lf_token_recycling_bin = hashset_create(4); // Initial size is 16.
         if (_lf_token_recycling_bin == NULL) {
-            lf_critical_section_exit();
+            lf_critical_section_exit(env);
             lf_print_error_and_exit("Out of memory: failed to setup _lf_token_recycling_bin");
         }
     }
@@ -178,7 +179,7 @@ token_freed _lf_free_token(lf_token_t* token) {
         LF_PRINT_DEBUG("_lf_free_token: Freeing allocated memory for token: %p", token);
         free(token);
     }
-    if(lf_critical_section_exit() != 0) {
+    if(lf_critical_section_exit(env) != 0) {
         lf_print_error_and_exit("Could not leave critical section");
     }
     _lf_count_token_allocations--;
@@ -187,10 +188,10 @@ token_freed _lf_free_token(lf_token_t* token) {
     return result;
 }
 
-lf_token_t* _lf_new_token(token_type_t* type, void* value, size_t length) {
+lf_token_t* _lf_new_token(struct environment_t* env, token_type_t* type, void* value, size_t length) {
     lf_token_t* result = NULL;
     // Check the recycling bin.
-    if (lf_critical_section_enter() != 0) {
+    if (lf_critical_section_enter(env) != 0) {
         lf_print_error_and_exit("Could not enter critical section");
     }
     if (_lf_token_recycling_bin != NULL) {
@@ -202,7 +203,7 @@ lf_token_t* _lf_new_token(token_type_t* type, void* value, size_t length) {
         }
         free(iterator);
     }
-    if(lf_critical_section_exit() != 0) {
+    if(lf_critical_section_exit(env) != 0) {
         lf_print_error_and_exit("Could not leave critical section");
     }
     if (result == NULL) {
@@ -217,7 +218,7 @@ lf_token_t* _lf_new_token(token_type_t* type, void* value, size_t length) {
     return result;
 }
 
-lf_token_t* _lf_get_token(token_template_t* tmplt) {
+lf_token_t* _lf_get_token(struct environment_t* env, token_template_t* tmplt) {
     if (tmplt->token != NULL) {
         if (tmplt->token->ref_count == 1) {
             LF_PRINT_DEBUG("_lf_get_token: Reusing template token: %p with ref_count %zu",
@@ -227,25 +228,25 @@ lf_token_t* _lf_get_token(token_template_t* tmplt) {
             return tmplt->token;
         } else {
             // Liberate the token.
-            _lf_done_using(tmplt->token);
+            _lf_done_using(env, tmplt->token);
         }
     }
     // If we get here, we need a new token.
-    tmplt->token = _lf_new_token((token_type_t*)tmplt, NULL, 0);
+    tmplt->token = _lf_new_token(env, (token_type_t*)tmplt, NULL, 0);
     tmplt->token->ref_count = 1;
     return tmplt->token;
 }
 
-void _lf_initialize_template(token_template_t* tmplt, size_t element_size) {
+void _lf_initialize_template(environment_t* env, token_template_t* tmplt, size_t element_size) {
     assert(tmplt != NULL);
-    if (lf_critical_section_enter() != 0) {
+    if (lf_critical_section_enter(env) != 0) {
         lf_print_error_and_exit("Could not enter critical section");
     }
     if (_lf_token_templates == NULL) {
         _lf_token_templates = hashset_create(4); // Initial size is 16.
     }
     hashset_add(_lf_token_templates, tmplt);
-    if(lf_critical_section_exit() != 0) {
+    if(lf_critical_section_exit(env) != 0) {
         lf_print_error_and_exit("Could not leave critical section");
     }
     if (tmplt->token != NULL) {
@@ -258,18 +259,18 @@ void _lf_initialize_template(token_template_t* tmplt, size_t element_size) {
             return;
         }
         // Replace the token.
-        _lf_done_using(tmplt->token);
+        _lf_done_using(env, tmplt->token);
         tmplt->token = NULL;
     }
     tmplt->type.element_size = element_size;
-    tmplt->token = _lf_new_token((token_type_t*)tmplt, NULL, 0);
+    tmplt->token = _lf_new_token(env, (token_type_t*)tmplt, NULL, 0);
     tmplt->token->ref_count = 1;
 }
 
-lf_token_t* _lf_initialize_token_with_value(token_template_t* tmplt, void* value, size_t length) {
+lf_token_t* _lf_initialize_token_with_value(struct environment_t* env, token_template_t* tmplt, void* value, size_t length) {
     assert(tmplt != NULL);
     LF_PRINT_DEBUG("_lf_initialize_token_with_value: template %p, value %p", tmplt, value);
-    lf_token_t* result = _lf_get_token(tmplt);
+    lf_token_t* result = _lf_get_token(env, tmplt);
     result->value = value;
     // Count allocations to issue a warning if this is never freed.
     _lf_count_payload_allocations++;
@@ -277,17 +278,17 @@ lf_token_t* _lf_initialize_token_with_value(token_template_t* tmplt, void* value
     return result;
 }
 
-lf_token_t* _lf_initialize_token(token_template_t* tmplt, size_t length) {
+lf_token_t* _lf_initialize_token(struct environment_t* env, token_template_t* tmplt, size_t length) {
     assert(tmplt != NULL);
     // Allocate memory for storing the array.
     void* value = calloc(length, tmplt->type.element_size);
-    lf_token_t* result = _lf_initialize_token_with_value(tmplt, value, length);
+    lf_token_t* result = _lf_initialize_token_with_value(env, tmplt, value, length);
     return result;
 }
 
-void _lf_free_all_tokens() {
+void _lf_free_all_tokens(environment_t* env) {
     // Free template tokens.
-    if (lf_critical_section_enter() != 0) {
+    if (lf_critical_section_enter(env) != 0) {
         lf_print_error_and_exit("Could not enter critical section");
     }
     // It is possible for a token to be a template token for more than one port
@@ -296,7 +297,7 @@ void _lf_free_all_tokens() {
         hashset_itr_t iterator = hashset_iterator(_lf_token_templates);
         while (hashset_iterator_next(iterator) >= 0) {
             token_template_t* tmplt = (token_template_t*)hashset_iterator_value(iterator);
-            _lf_done_using(tmplt->token);
+            _lf_done_using(env, tmplt->token);
             tmplt->token = NULL;
         }
         free(iterator);
@@ -315,17 +316,17 @@ void _lf_free_all_tokens() {
         hashset_destroy(_lf_token_recycling_bin);
         _lf_token_recycling_bin = NULL;
     }
-    if(lf_critical_section_exit() != 0) {
+    if(lf_critical_section_exit(env) != 0) {
         lf_print_error_and_exit("Could not leave critical section");
     }
 }
 
-void _lf_replace_template_token(token_template_t* tmplt, lf_token_t* newtoken) {
+void _lf_replace_template_token(struct environment_t *env, token_template_t* tmplt, lf_token_t* newtoken) {
     assert(tmplt != NULL);
     LF_PRINT_DEBUG("_lf_replace_template_token: template: %p newtoken: %p.", tmplt, newtoken);
     if (tmplt->token != newtoken) {
         if (tmplt->token != NULL) {
-            _lf_done_using(tmplt->token);
+            _lf_done_using(env, tmplt->token);
         }
         if (newtoken != NULL) {
             newtoken->ref_count++;
@@ -336,7 +337,7 @@ void _lf_replace_template_token(token_template_t* tmplt, lf_token_t* newtoken) {
     }
 }
 
-token_freed _lf_done_using(lf_token_t* token) {
+token_freed _lf_done_using(struct environment_t* env, lf_token_t* token) {
     if (token == NULL) {
         return NOT_FREED;
     }
@@ -346,13 +347,13 @@ token_freed _lf_done_using(lf_token_t* token) {
         return NOT_FREED;
     }
     token->ref_count--;
-    return _lf_free_token(token);
+    return _lf_free_token(env, token);
 }
 
-void _lf_free_token_copies() {
+void _lf_free_token_copies(struct environment_t* env) {
     while (_lf_tokens_allocated_in_reactions != NULL) {
         lf_token_t* next = _lf_tokens_allocated_in_reactions->next;
-        _lf_done_using(_lf_tokens_allocated_in_reactions);
+        _lf_done_using(env, _lf_tokens_allocated_in_reactions);
         _lf_tokens_allocated_in_reactions = next;
     }
 }

--- a/core/modal_models/modes.c
+++ b/core/modal_models/modes.c
@@ -416,7 +416,7 @@ void _lf_process_mode_changes(
                         } else if (state->next_mode != state->current_mode && event->trigger != NULL) { // History transition to a different mode
                             // Remaining time that the event would have been waiting before mode was left
                             instant_t local_remaining_delay = event->time - (state->next_mode->deactivation_time != 0 ? state->next_mode->deactivation_time : lf_time_start());
-                            tag_t current_logical_tag = lf_tag();
+                            tag_t current_logical_tag = lf_tag(NULL);
 
                             // Reschedule event with original local delay
                             LF_PRINT_DEBUG("Modes: Re-enqueuing event with a suspended delay of " PRINTF_TIME
@@ -461,7 +461,7 @@ void _lf_process_mode_changes(
                 // Apply transition effect
                 if (state->next_mode != NULL) {
                     // Save time when mode was left to handle suspended events in the future
-                    state->current_mode->deactivation_time = lf_time_logical();
+                    state->current_mode->deactivation_time = lf_time_logical(NULL);
 
                     // Apply transition
                     state->current_mode = state->next_mode;

--- a/core/modal_models/modes.c
+++ b/core/modal_models/modes.c
@@ -530,7 +530,7 @@ void _lf_process_mode_changes(
         if (_lf_mode_triggered_reactions_request) {
             // Insert a dummy event in the event queue for the next microstep to make
             // sure startup/reset reactions (if any) are triggered as soon as possible.
-            pqueue_insert(event_q, _lf_create_dummy_events(NULL, lf_tag().time, NULL, 1));
+            pqueue_insert(event_q, _lf_create_dummy_events(NULL, lf_tag(NULL).time, NULL, 1));
         }
     }
 }

--- a/core/modal_models/modes.c
+++ b/core/modal_models/modes.c
@@ -461,7 +461,7 @@ void _lf_process_mode_changes(
                 // Apply transition effect
                 if (state->next_mode != NULL) {
                     // Save time when mode was left to handle suspended events in the future
-                    state->current_mode->deactivation_time = lf_time_logical(NULL);
+                    state->current_mode->deactivation_time = lf_time_logical(env);
 
                     // Apply transition
                     state->current_mode = state->next_mode;

--- a/core/platform/lf_nrf52_support.c
+++ b/core/platform/lf_nrf52_support.c
@@ -241,13 +241,13 @@ int lf_sleep_until_locked(instant_t wakeup_time) {
         }
 
         // Leave critical section
-        lf_critical_section_exit();
+        lf_critical_section_exit(env);
         
         // wait for exception
         __WFE();
 
         // Enter critical section again
-        lf_critical_section_enter();
+        lf_critical_section_enter(env);
 
         // Redo while loop and go back to sleep if:
         //  1) We didnt have async event AND
@@ -270,7 +270,7 @@ int lf_sleep_until_locked(instant_t wakeup_time) {
  * @brief Enter critical section. Let NRF Softdevice handle nesting
  * @return int 
  */
-int lf_critical_section_enter() {
+int lf_platform_enable_interrupts_nested() {
     return sd_nvic_critical_region_enter(&_lf_nested_region);
 }
 
@@ -279,7 +279,7 @@ int lf_critical_section_enter() {
  * 
  * @return int 
  */
-int lf_critical_section_exit() {
+int lf_platform_disable_interrupts_nested() {
     return sd_nvic_critical_region_exit(_lf_nested_region);
 }
 
@@ -288,7 +288,7 @@ int lf_critical_section_exit() {
  * 
  * @return int 
  */
-int lf_notify_of_event() {
+int lf_platform_notify_of_event() {
     _lf_async_event = true;
     return 0;
 }

--- a/core/platform/lf_os_single_threaded_support.c
+++ b/core/platform/lf_os_single_threaded_support.c
@@ -22,15 +22,15 @@
  * 
  * @return int 
  */
-int lf_critical_section_enter() {
+int lf_platform_disable_interrupts_nested() {
     return 0;
 }
 
-int lf_critical_section_exit() {
+int lf_platform_enable_interrupts_nested() {
     return 0;
 }
 
-int lf_notify_of_event() {
+int lf_platform_notify_of_event() {
     return 0;
 }
 

--- a/core/reactor.c
+++ b/core/reactor.c
@@ -302,9 +302,6 @@ int next(void) {
 
 /**
  * Stop execution at the conclusion of the next microstep.
- * FIXME: If this is called from a LET reaction we will either:
- * A) requrest a stop tag "in the past" if we are using reactors local tag
- * B) request stop sometime "in the futre" if we use global tag <- This is what we are doing now
  */
 void lf_request_stop() {
 	tag_t new_stop_tag;

--- a/core/reactor.c
+++ b/core/reactor.c
@@ -302,6 +302,9 @@ int next(void) {
 
 /**
  * Stop execution at the conclusion of the next microstep.
+ * FIXME: If this is called from a LET reaction we will either:
+ * A) requrest a stop tag "in the past" if we are using reactors local tag
+ * B) request stop sometime "in the futre" if we use global tag <- This is what we are doing now
  */
 void lf_request_stop() {
 	tag_t new_stop_tag;

--- a/core/reactor.c
+++ b/core/reactor.c
@@ -47,7 +47,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 // Global variable defined in tag.c:
-extern tag_t current_tag;
+extern tag_t env->current_tag;
 extern instant_t start_time;
 
 /**
@@ -150,7 +150,7 @@ int _lf_do_step(void) {
 
         LF_PRINT_LOG("Invoking reaction %s at elapsed logical tag " PRINTF_TAG ".",
         		reaction->name,
-                current_tag.time - start_time, current_tag.microstep);
+                env->current_tag.time - start_time, env->current_tag.microstep);
 
         bool violation = false;
 
@@ -171,7 +171,7 @@ int _lf_do_step(void) {
             // container deadlines are defined in the container.
             // They can have different deadlines, so we have to check both.
             // Handle the local deadline first.
-            if (reaction->deadline == 0 || physical_time > current_tag.time + reaction->deadline) {
+            if (reaction->deadline == 0 || physical_time > env->current_tag.time + reaction->deadline) {
                 LF_PRINT_LOG("Deadline violation. Invoking deadline handler.");
                 tracepoint_reaction_deadline_missed(reaction, 0);
                 // Deadline violation has occurred.
@@ -205,7 +205,7 @@ int _lf_do_step(void) {
     _lf_handle_mode_changes();
 #endif
 
-    if (lf_tag_compare(current_tag, stop_tag) >= 0) {
+    if (lf_tag_compare(env->current_tag, stop_tag) >= 0) {
         return 0;
     }
 
@@ -214,7 +214,7 @@ int _lf_do_step(void) {
 
 // Wait until physical time matches or exceeds the time of the least tag
 // on the event queue. If there is no event in the queue, return 0.
-// After this wait, advance current_tag.time to match
+// After this wait, advance env->current_tag.time to match
 // this tag. Then pop the next event(s) from the
 // event queue that all have the same tag, and extract from those events
 // the reactions that are to be invoked at this logical time.
@@ -242,13 +242,13 @@ int next(void) {
         // No event in the queue.
         if (!keepalive_specified) {
             _lf_set_stop_tag(
-                (tag_t){.time=current_tag.time, .microstep=current_tag.microstep+1}
+                (tag_t){.time=env->current_tag.time, .microstep=env->current_tag.microstep+1}
             );
         }
     } else {
         next_tag.time = event->time;
         // Deduce the microstep
-        if (next_tag.time == current_tag.time) {
+        if (next_tag.time == env->current_tag.time) {
             next_tag.microstep = lf_tag().microstep + 1;
         } else {
             next_tag.microstep = 0;
@@ -281,7 +281,7 @@ int next(void) {
     _lf_advance_logical_time(next_tag.time);
     
     // Trigger shutdown reactions if appropriate.
-    if (lf_tag_compare(current_tag, stop_tag) >= 0) {        
+    if (lf_tag_compare(env->current_tag, stop_tag) >= 0) {        
         _lf_trigger_shutdown_reactions();
     }
 
@@ -289,7 +289,7 @@ int next(void) {
     // such as initializing outputs to be absent.
     _lf_start_time_step();
 
-    // Pop all events from event_q with timestamp equal to current_tag.time,
+    // Pop all events from event_q with timestamp equal to env->current_tag.time,
     // extract all the reactions triggered by these events, and
     // stick them into the reaction queue.
     _lf_pop_events();
@@ -305,8 +305,8 @@ int next(void) {
  */
 void lf_request_stop() {
 	tag_t new_stop_tag;
-	new_stop_tag.time = current_tag.time;
-	new_stop_tag.microstep = current_tag.microstep + 1;
+	new_stop_tag.time = env->current_tag.time;
+	new_stop_tag.microstep = env->current_tag.microstep + 1;
 	_lf_set_stop_tag(new_stop_tag);
 }
 
@@ -363,14 +363,14 @@ int lf_reactor_c_main(int argc, const char* argv[]) {
         reaction_q = pqueue_init(INITIAL_REACT_QUEUE_SIZE, in_reverse_order, get_reaction_index,
                 get_reaction_position, set_reaction_position, reaction_matches, print_reaction);
 
-        current_tag = (tag_t){.time = start_time, .microstep = 0u};
+        env->current_tag = (tag_t){.time = start_time, .microstep = 0u};
         _lf_execution_started = true;
         _lf_trigger_startup_reactions();
         _lf_initialize_timers();
         // If the stop_tag is (0,0), also insert the shutdown
         // reactions. This can only happen if the timeout time
         // was set to 0.
-        if (lf_tag_compare(current_tag, stop_tag) >= 0) {
+        if (lf_tag_compare(env->current_tag, stop_tag) >= 0) {
             _lf_trigger_shutdown_reactions();
         }
         LF_PRINT_DEBUG("Running the program's main loop.");

--- a/core/reactor.c
+++ b/core/reactor.c
@@ -230,7 +230,7 @@ int _lf_do_step(void) {
 int next(void) {
     // Enter the critical section and do not leave until we have
     // determined which tag to commit to and start invoking reactions for.
-    if (lf_critical_section_enter() != 0) {
+    if (lf_critical_section_enter(env) != 0) {
         lf_print_error_and_exit("Could not enter critical section");
     }
     event_t* event = (event_t*)pqueue_peek(event_q);
@@ -270,7 +270,7 @@ int next(void) {
         // gets scheduled from an interrupt service routine.
         // In this case, check the event queue again to make sure to
         // advance time to the correct tag.
-        if(lf_critical_section_exit() != 0) {
+        if(lf_critical_section_exit(env) != 0) {
             lf_print_error_and_exit("Could not leave critical section");
         }
         return 1;
@@ -293,7 +293,7 @@ int next(void) {
     // extract all the reactions triggered by these events, and
     // stick them into the reaction queue.
     _lf_pop_events();
-    if(lf_critical_section_exit() != 0) {
+    if(lf_critical_section_exit(env) != 0) {
         lf_print_error_and_exit("Could not leave critical section");
     }
 
@@ -383,5 +383,26 @@ int lf_reactor_c_main(int argc, const char* argv[]) {
     } else {
         return -1;
     }
+}
+
+/**
+ * @brief Notify of new event by broadcasting on a condition variable. 
+ */
+int lf_notify_of_event(environment_t* env) {
+    return lf_platform_notify_of_event();
+}
+
+/**
+ * @brief Enter critical section by locking the global mutex.
+ */
+int lf_critical_section_enter(environment_t* env) {
+    return lf_platform_disable_interrupts_nester();
+}
+
+/**
+ * @brief Leave a critical section by unlocking the global mutex.
+ */
+int lf_critical_section_exit(environment_t* env) {
+    return lf_platform_enable_interrupts_nester();
 }
 #endif

--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -662,7 +662,7 @@ int _lf_schedule_at_tag(trigger_t* trigger, tag_t tag, lf_token_t* token) {
 
     // Do not schedule events if the tag is after the stop tag
     if (_lf_is_tag_after_stop_tag(tag)) {
-         LF_PRINT_DEBUG("_lf_schedule_at_tag: event time is past the timeout. Discarding event.");
+         lf_print_warning("_lf_schedule_at_tag: event time is past the timeout. Discarding event.");
         _lf_done_using(token);
         return -1;
     }

--- a/core/tag.c
+++ b/core/tag.c
@@ -15,7 +15,10 @@
 #include "tag.h"
 #include "util.h"
 #include "platform.h"
+#include "reactor.h"
 #include "util.h"
+#include "lf_types.h"
+
 
 /**
  * An enum for specifying the desired tag when calling "lf_time"
@@ -186,12 +189,16 @@ tag_t lf_delay_tag(tag_t tag, interval_t interval) {
     return result;
 }
 
-instant_t lf_time_logical(void) {
-    return _lf_time(LF_LOGICAL);
+instant_t lf_time_logical(void *self) {
+    if (self) return ((self_base_t *) self)->current_tag.time;
+    else return _lf_time(LF_LOGICAL);
 }
 
-interval_t lf_time_logical_elapsed(void) {
-    return _lf_time(LF_ELAPSED_LOGICAL);
+/**
+ * Return the elapsed logical time in nanoseconds since the start of execution.
+ */
+interval_t lf_time_logical_elapsed(void *self) {
+    return lf_time_logical(self) - start_time;
 }
 
 instant_t lf_time_physical(void) {

--- a/core/tag.c
+++ b/core/tag.c
@@ -117,7 +117,7 @@ instant_t _lf_physical_time() {
 ////////////////  Functions declared in tag.h
 
 tag_t lf_tag(void *env) {
-    return ((environment_t *) env)->current_tag;
+    return ((environment_t *)env)->current_tag;
 }
 
 int lf_tag_compare(tag_t tag1, tag_t tag2) {

--- a/core/tag.c
+++ b/core/tag.c
@@ -114,45 +114,10 @@ instant_t _lf_physical_time() {
     return _lf_last_reported_physical_time_ns;
 }
 
-/**
- * Get the time specified by "type".
- *
- * Example use cases:
- * - Getting the starting time:
- * _lf_time(LF_START)
- *
- * - Getting the elapsed physical time:
- * _lf_time(LF_ELAPSED_PHYSICAL)
- *
- * - Getting the logical time
- * _lf_time(LF_LOGICAL)
- *
- * @param type A field in an enum specifying the time type.
- *             See enum "lf_time_type" above.
- * @return The desired time
- */
-instant_t _lf_time(_lf_time_type type) {
-    switch (type)
-    {
-    case LF_LOGICAL:
-        return env->current_tag.time;
-    case LF_PHYSICAL:
-        return _lf_physical_time();
-    case LF_ELAPSED_LOGICAL:
-        return env->current_tag.time - start_time;
-    case LF_ELAPSED_PHYSICAL:
-        return _lf_physical_time() - start_time;
-    case LF_START:
-        return start_time;
-    default:
-        return NEVER;
-    }
-}
-
 ////////////////  Functions declared in tag.h
 
-tag_t lf_tag(environment_t *env) {
-    return env->current_tag;
+tag_t lf_tag(void *env) {
+    return ((environment_t *) env)->current_tag;
 }
 
 int lf_tag_compare(tag_t tag1, tag_t tag2) {
@@ -189,28 +154,27 @@ tag_t lf_delay_tag(tag_t tag, interval_t interval) {
     return result;
 }
 
-instant_t lf_time_logical(void *self) {
-    if (self) return ((self_base_t *) self)->current_tag.time;
-    else return _lf_time(LF_LOGICAL);
+instant_t lf_time_logical(void *env) {
+    return ((environment_t *) env)->current_tag.time;
 }
 
 /**
  * Return the elapsed logical time in nanoseconds since the start of execution.
  */
-interval_t lf_time_logical_elapsed(void *self) {
-    return lf_time_logical(self) - start_time;
+interval_t lf_time_logical_elapsed(void *env) {
+    return lf_time_logical(env) - start_time;
 }
 
 instant_t lf_time_physical(void) {
-    return _lf_time(LF_PHYSICAL);
+    return _lf_physical_time();
 }
 
 instant_t lf_time_physical_elapsed(void) {
-    return _lf_time(LF_ELAPSED_PHYSICAL);
+    return _lf_physical_time() - start_time;
 }
 
 instant_t lf_time_start(void) {
-    return _lf_time(LF_START);
+    return start_time;
 }
 
 void lf_set_physical_clock_offset(interval_t offset) {

--- a/core/tag.c
+++ b/core/tag.c
@@ -40,7 +40,7 @@ instant_t start_time = NEVER;
  * This is not in scope for reactors.
  * This should only ever be accessed while holding the mutex lock.
  */
-tag_t current_tag = {.time = 0LL, .microstep = 0};
+// tag_t env->current_tag = {.time = 0LL, .microstep = 0};
 
 /**
  * Global physical clock offset.
@@ -132,11 +132,11 @@ instant_t _lf_time(_lf_time_type type) {
     switch (type)
     {
     case LF_LOGICAL:
-        return current_tag.time;
+        return env->current_tag.time;
     case LF_PHYSICAL:
         return _lf_physical_time();
     case LF_ELAPSED_LOGICAL:
-        return current_tag.time - start_time;
+        return env->current_tag.time - start_time;
     case LF_ELAPSED_PHYSICAL:
         return _lf_physical_time() - start_time;
     case LF_START:
@@ -148,8 +148,8 @@ instant_t _lf_time(_lf_time_type type) {
 
 ////////////////  Functions declared in tag.h
 
-tag_t lf_tag() {
-    return current_tag;
+tag_t lf_tag(environment_t *env) {
+    return env->current_tag;
 }
 
 int lf_tag_compare(tag_t tag1, tag_t tag2) {

--- a/core/threaded/CMakeLists.txt
+++ b/core/threaded/CMakeLists.txt
@@ -7,6 +7,7 @@ set(
     scheduler_NP.c
     scheduler_PEDF_NP.c
     scheduler_sync_tag_advance.c
+    scheduler_instance.c
 )
 list(APPEND INFO_SOURCES ${THREADED_SOURCES})
 

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -141,6 +141,7 @@ void _lf_increment_global_tag_barrier_already_locked(tag_t future_tag) {
         lf_print_warning("Attempting to raise a barrier after the stop tag.");
         future_tag = stop_tag;
     }
+    tag_t current_tag = lf_tag(NULL);
     // Check to see if future_tag is actually in the future.
     if (lf_tag_compare(future_tag, env->current_tag) > 0) {
         // Future tag is actually in the future.
@@ -464,7 +465,7 @@ tag_t get_next_event_tag() {
         if (next_tag.time == env->current_tag.time) {
         	LF_PRINT_DEBUG("Earliest event matches current time. Incrementing microstep. Event is dummy: %d.",
         			event->is_dummy);
-            next_tag.microstep =  lf_tag().microstep + 1;
+            next_tag.microstep =  lf_tag(NULL).microstep + 1;
         } else {
             next_tag.microstep = 0;
         }

--- a/core/threaded/scheduler_GEDF_NP.c
+++ b/core/threaded/scheduler_GEDF_NP.c
@@ -52,9 +52,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "trace.h"
 #include "util.h"
 
-/////////////////// External Variables /////////////////////////
-extern lf_mutex_t mutex;
-
 /////////////////// Scheduler Variables and Structs /////////////////////////
 _lf_sched_instance_t* _lf_sched_instance;
 

--- a/core/threaded/scheduler_GEDF_NP.c
+++ b/core/threaded/scheduler_GEDF_NP.c
@@ -266,7 +266,7 @@ void lf_sched_init(
  *
  * This must be called when the scheduler is no longer needed.
  */
-void lf_sched_free() {
+void lf_sched_free(_lf_sched_instance_t* _lf_sched_instance) {
     // for (size_t j = 0; j <= _lf_sched_instance->max_reaction_level; j++) {
     //     pqueue_free(_lf_sched_instance->_lf_sched_triggered_reactions[j]);
     //     FIXME: This is causing weird memory errors.

--- a/core/threaded/scheduler_GEDF_NP_CI.c
+++ b/core/threaded/scheduler_GEDF_NP_CI.c
@@ -59,9 +59,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define MAX_REACTION_LEVEL INITIAL_REACT_QUEUE_SIZE
 #endif
 
-/////////////////// External Variables /////////////////////////
-extern lf_mutex_t mutex;
-
 /////////////////// Scheduler Variables and Structs /////////////////////////
 _lf_sched_instance_t* _lf_sched_instance;
 

--- a/core/threaded/scheduler_GEDF_NP_CI.c
+++ b/core/threaded/scheduler_GEDF_NP_CI.c
@@ -439,7 +439,7 @@ void lf_sched_init(
  *
  * This must be called when the scheduler is no longer needed.
  */
-void lf_sched_free() {
+void lf_sched_free(_lf_sched_instance_t* _lf_sched_instance) {
     for (int i = 0; i < _lf_sched_instance->_lf_sched_number_of_workers; i++) {
         pqueue_free(_lf_sched_threads_info[i].output_reactions);
     }

--- a/core/threaded/scheduler_PEDF_NP.c
+++ b/core/threaded/scheduler_PEDF_NP.c
@@ -50,9 +50,6 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "semaphore.h"
 #include "vector.h"
 
-/////////////////// External Variables /////////////////////////
-extern lf_mutex_t mutex;
-
 
 /////////////////// Scheduler Variables and Structs /////////////////////////
 _lf_sched_instance_t* _lf_sched_instance;

--- a/core/threaded/scheduler_PEDF_NP.c
+++ b/core/threaded/scheduler_PEDF_NP.c
@@ -563,7 +563,7 @@ void lf_sched_init(
  *
  * This must be called when the scheduler is no longer needed.
  */
-void lf_sched_free() {
+void lf_sched_free(_lf_sched_instance_t* _lf_sched_instance) {
     for (int i=0; i < _lf_sched_instance->_lf_sched_number_of_workers; i++) {
         pqueue_free(_lf_sched_threads_info[i].ready_reactions);
         vector_free(&_lf_sched_threads_info[i].output_reactions);

--- a/core/threaded/scheduler_adaptive.c
+++ b/core/threaded/scheduler_adaptive.c
@@ -90,7 +90,7 @@ void lf_sched_init(size_t number_of_workers, sched_params_t* params) {
     init_called = true;
 }
 
-void lf_sched_free() {
+void lf_sched_free(_lf_sched_instance_t* _lf_sched_instance) {
     worker_states_free();
     worker_assignments_free();
 }

--- a/core/threaded/scheduler_instance.c
+++ b/core/threaded/scheduler_instance.c
@@ -1,0 +1,40 @@
+#include "scheduler_instance.h"
+
+
+bool init_sched_instance(
+    _lf_sched_instance_t** instance,
+    size_t number_of_workers,
+    sched_params_t* params) {
+
+    // Check if the instance is already initialized
+    lf_mutex_lock(&mutex); // Safeguard against multiple threads calling this
+                           // function.
+    if (*instance != NULL) {
+        // Already initialized
+        lf_mutex_unlock(&mutex);
+        return false;
+    } else {
+        *instance =
+            (_lf_sched_instance_t*)calloc(1, sizeof(_lf_sched_instance_t));
+    }
+    lf_mutex_unlock(&mutex);
+
+    if (params == NULL || params->num_reactions_per_level_size == 0) {
+        (*instance)->max_reaction_level = DEFAULT_MAX_REACTION_LEVEL;
+    }
+
+    if (params != NULL) {
+        if (params->num_reactions_per_level != NULL) {
+            (*instance)->max_reaction_level =
+                params->num_reactions_per_level_size - 1;
+        }
+    }
+
+    (*instance)->_lf_sched_semaphore = lf_semaphore_new(0);
+    (*instance)->_lf_sched_number_of_workers = number_of_workers;
+    (*instance)->_lf_sched_next_reaction_level = 1;
+
+    (*instance)->_lf_sched_should_stop = false;
+
+    return true;
+}

--- a/core/threaded/scheduler_instance.c
+++ b/core/threaded/scheduler_instance.c
@@ -1,23 +1,25 @@
 #include "scheduler_instance.h"
+#include "reactor_common.h"
+#include "lf_types.h"
 
 
 bool init_sched_instance(
+    environment_t * env,
     _lf_sched_instance_t** instance,
     size_t number_of_workers,
     sched_params_t* params) {
-
+    // FIXME: env pointer in the sched instance must be set by now
     // Check if the instance is already initialized
-    lf_mutex_lock(&mutex); // Safeguard against multiple threads calling this
-                           // function.
+    lf_critical_section_enter(env);
     if (*instance != NULL) {
         // Already initialized
-        lf_mutex_unlock(&mutex);
+        lf_critical_section_exit(env);
         return false;
     } else {
         *instance =
             (_lf_sched_instance_t*)calloc(1, sizeof(_lf_sched_instance_t));
     }
-    lf_mutex_unlock(&mutex);
+    lf_mutex_unlock(&env->mutex);
 
     if (params == NULL || params->num_reactions_per_level_size == 0) {
         (*instance)->max_reaction_level = DEFAULT_MAX_REACTION_LEVEL;
@@ -35,6 +37,7 @@ bool init_sched_instance(
     (*instance)->_lf_sched_next_reaction_level = 1;
 
     (*instance)->_lf_sched_should_stop = false;
+    (*instance)->env = env;
 
     return true;
 }

--- a/core/threaded/scheduler_sync_tag_advance.c
+++ b/core/threaded/scheduler_sync_tag_advance.c
@@ -40,8 +40,8 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "util.h"
 
 // Global variable defined in tag.c:
-extern tag_t current_tag;
-extern tag_t stop_tag;
+// extern tag_t env->current_tag;
+// extern tag_t stop_tag;
 
 /////////////////// External Functions /////////////////////////
 /**
@@ -66,7 +66,7 @@ bool _lf_sched_should_stop_locked() {
     if (_lf_logical_tag_completed) {
         // If we are at the stop tag, do not call _lf_next_locked()
         // to prevent advancing the logical time.
-        if (lf_tag_compare(current_tag, stop_tag) >= 0) {
+        if (lf_tag_compare(env->current_tag, stop_tag) >= 0) {
             return true;
         }
     }
@@ -82,7 +82,7 @@ bool _lf_sched_should_stop_locked() {
  * @return should_exit True if the worker thread should exit. False otherwise.
  */
 bool _lf_sched_advance_tag_locked() {
-    logical_tag_complete(current_tag);
+    logical_tag_complete(env->current_tag);
 
     if (_lf_sched_should_stop_locked()) {
         return true;

--- a/core/trace.c
+++ b/core/trace.c
@@ -294,14 +294,7 @@ void tracepoint(
     int i = _lf_trace_buffer_size[index];
     // Write to memory buffer.
     // Get the correct time of the event
-    tag_t tag;
-    if (trigger) {
-        self_base_t* reactor = (self_base_t *) trigger->reactions[0]->self;
-        tag = lf_tag(reactor);
-    } else {
-        tag = lf_tag(pointer);
-    }
-
+    
     _lf_trace_buffer[index][i].event_type = event_type;
     _lf_trace_buffer[index][i].pointer = pointer;
     _lf_trace_buffer[index][i].src_id = src_id;

--- a/core/trace.c
+++ b/core/trace.c
@@ -293,6 +293,15 @@ void tracepoint(
     // The above flush_trace resets the write pointer.
     int i = _lf_trace_buffer_size[index];
     // Write to memory buffer.
+    // Get the correct time of the event
+    tag_t tag;
+    if (trigger) {
+        self_base_t* reactor = (self_base_t *) trigger->reactions[0]->self;
+        tag = lf_tag(reactor);
+    } else {
+        tag = lf_tag(pointer);
+    }
+
     _lf_trace_buffer[index][i].event_type = event_type;
     _lf_trace_buffer[index][i].pointer = pointer;
     _lf_trace_buffer[index][i].src_id = src_id;
@@ -301,8 +310,8 @@ void tracepoint(
         _lf_trace_buffer[index][i].logical_time = tag->time;
         _lf_trace_buffer[index][i].microstep = tag->microstep;
     } else {
-        _lf_trace_buffer[index][i].logical_time = lf_time_logical();
-        _lf_trace_buffer[index][i].microstep = lf_tag().microstep;
+        _lf_trace_buffer[index][i].logical_time = lf_time_logical(pointer);
+        _lf_trace_buffer[index][i].microstep = lf_tag(pointer).microstep;
     }
     _lf_trace_buffer[index][i].trigger = trigger;
     _lf_trace_buffer[index][i].extra_delay = extra_delay;

--- a/include/api/api.h
+++ b/include/api/api.h
@@ -185,6 +185,6 @@ int lf_tag_compare(tag_t tag1, tag_t tag2);
 /**
  * Return the current tag, a logical time, microstep pair.
  */
-tag_t lf_tag();
+tag_t lf_tag(void * self);
 
 #endif // API_H

--- a/include/api/api.h
+++ b/include/api/api.h
@@ -183,8 +183,11 @@ bool lf_check_deadline(void* self, bool invoke_deadline_handler);
 int lf_tag_compare(tag_t tag1, tag_t tag2);
 
 /**
- * Return the current tag, a logical time, microstep pair.
+ * Return the current tag of a reactor. If NULL is passed to this function it
+ * will return the "global tag" of the runtime.  
+ * @param self A pointer to the self-struct of the reactor. 
+ * @return the current tag 
  */
-tag_t lf_tag(void * self);
+tag_t lf_tag(void* self);
 
 #endif // API_H

--- a/include/api/set.h
+++ b/include/api/set.h
@@ -211,3 +211,14 @@ do { \
 #endif // MODAL_REACTORS
 
 #endif // CTARGET_SET
+
+// For simplicity and backward compatability, dont require the self-pointer when calling the timing API.
+// Since this is always done from the context of a reaction `self` is in scope and is a pointer to the self-struct
+#define lf_tag() lf_tag(self)
+#define get_current_tag() get_current_tag(self)
+#define get_microstep() get_microstep(self)
+
+#define lf_time_logical() lf_time_logical(self)
+#define lf_time_logical_elapsed() lf_time_logical_elapsed(self)
+#define get_elapsed_logical_time() get_elapsed_logical_time(self)
+#define get_logical_time() get_logical_time(self)

--- a/include/api/set_undef.h
+++ b/include/api/set_undef.h
@@ -112,4 +112,12 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #undef SET_MODE
 #endif
 
+#undef lf_time_logical 
+#undef lf_time_logical_elapsed 
+#undef get_logical_time
+#undef get_elapsed_logical_time
+
+#undef lf_tag
+#undef get_current_tag
+#undef get_microstep
 #endif // CTARGET_SET

--- a/include/core/lf_token.h
+++ b/include/core/lf_token.h
@@ -64,6 +64,9 @@
 
 #include <stdlib.h> // Defines size_t
 
+// Forward declarations
+struct environment_t;
+
 //////////////////////////////////////////////////////////
 //// Constants and enums
 
@@ -208,7 +211,7 @@ static int _lf_count_token_allocations;
  * @param len The length, or 1 if it not an array.
  * @return A pointer to a lf_token_t struct. 
  */
-lf_token_t* lf_new_token(void* port_or_action, void* val, size_t len);
+lf_token_t* lf_new_token(void *env, void* port_or_action, void* val, size_t len);
 
 /**
  * Return a writable copy of the token in the specified template.
@@ -223,7 +226,7 @@ lf_token_t* lf_new_token(void* port_or_action, void* val, size_t len);
  * is no need for a writable copy. Return NULL.
  * @param port An input port.
  */
-lf_token_t* lf_writable_copy(lf_port_base_t* port);
+lf_token_t* lf_writable_copy(struct environment_t* env, lf_port_base_t* port);
 
 //////////////////////////////////////////////////////////
 //// Functions not intended to be used by users
@@ -242,7 +245,7 @@ lf_token_t* lf_writable_copy(lf_port_base_t* port);
  *  was freed, TOKEN_FREED if only the token was freed, and
  *  TOKEN_AND_VALUE_FREED if both the value and the token were freed.
  */
-token_freed _lf_free_token(lf_token_t* token);
+token_freed _lf_free_token(struct environment_t* env, lf_token_t* token);
 
 /**
  * @brief Return a new token with the specified type, value, and length.
@@ -257,7 +260,7 @@ token_freed _lf_free_token(lf_token_t* token);
  *  or 0 to have no value.
  * @return lf_token_t* 
  */
-lf_token_t* _lf_new_token(token_type_t* type, void* value, size_t length);
+lf_token_t* _lf_new_token(struct environment_t* env, token_type_t* type, void* value, size_t length);
 
 /**
  * Get a token for the specified template.
@@ -268,7 +271,7 @@ lf_token_t* _lf_new_token(token_type_t* type, void* value, size_t length);
  * @param tmplt The template. // template is a C++ keyword.
  * @return A new or recycled lf_token_t struct.
  */
-lf_token_t* _lf_get_token(token_template_t* tmplt);
+lf_token_t* _lf_get_token(struct environment_t* env, token_template_t* tmplt);
 
 /**
  * Initialize the specified template to contain a token that is an
@@ -280,7 +283,7 @@ lf_token_t* _lf_get_token(token_template_t* tmplt);
  * @param tmplt The template. // template is a C++ keyword.
  * @param element_size The element size.
  */
-void _lf_initialize_template(token_template_t* tmplt, size_t element_size);
+void _lf_initialize_template(struct environment_t* env, token_template_t* tmplt, size_t element_size);
 
 /**
  * Return a token storing the specified value, which is assumed to
@@ -298,7 +301,7 @@ void _lf_initialize_template(token_template_t* tmplt, size_t element_size);
  * @return Either the specified token or a new one, in each case with a value
  *  field pointing to newly allocated memory.
  */
-lf_token_t* _lf_initialize_token_with_value(token_template_t* tmplt, void* value, size_t length);
+lf_token_t* _lf_initialize_token_with_value(struct environment_t* env, token_template_t* tmplt, void* value, size_t length);
 
 /**
  * Return a token for storing an array of the specified length
@@ -317,14 +320,14 @@ lf_token_t* _lf_initialize_token_with_value(token_template_t* tmplt, void* value
  * @return Either the template's token or a new one, in each case with a value
  *  field pointing to newly allocated memory.
  */
-lf_token_t* _lf_initialize_token(token_template_t* tmplt, size_t length);
+lf_token_t* _lf_initialize_token(struct environment_t* env, token_template_t* tmplt, size_t length);
 
 /**
  * @brief Free all tokens.
  * Free tokens on the _lf_token_recycling_bin hashset and all
  * template tokens.
  */
-void _lf_free_all_tokens();
+void _lf_free_all_tokens(struct environment_t* env);
 
 /**
  * @brief Replace the token in the specified template, if there is one,
@@ -333,7 +336,7 @@ void _lf_free_all_tokens();
  * @param tmplt Pointer to a template. // template is a C++ keyword.
  * @param newtoken The replacement token.
  */
-void _lf_replace_template_token(token_template_t* tmplt, lf_token_t* newtoken);
+void _lf_replace_template_token(struct environment_t* env, token_template_t* tmplt, lf_token_t* newtoken);
 
 /**
  * Decrement the reference count of the specified token.
@@ -345,14 +348,14 @@ void _lf_replace_template_token(token_template_t* tmplt, lf_token_t* newtoken);
  *  was freed, TOKEN_FREED if only the token was freed, and
  *  TOKEN_AND_VALUE_FREED if both the value and the token were freed.
  */
-token_freed _lf_done_using(lf_token_t* token);
+token_freed _lf_done_using(struct environment_t* env, lf_token_t* token);
 
 /**
  * @brief Free token copies made for mutable inputs.
  * This function should be called at the beginning of each time step
  * to avoid memory leaks.
  */
-void _lf_free_token_copies();
+void _lf_free_token_copies(struct environment_t* env);
 
 #endif /* LF_TOKEN_H */
 /** @} */

--- a/include/core/lf_types.h
+++ b/include/core/lf_types.h
@@ -42,6 +42,7 @@
 #include "utils/pqueue.h"
 #include "lf_token.h"
 #include "platform.h"
+#include "scheduler_instance.h"
 
 /**
  * ushort type. Redefine here for portability if sys/types.h is not included.
@@ -268,7 +269,7 @@ typedef struct allocation_record_t {
 } allocation_record_t;
 
 // Forward declarations so that a pointers can appear in the environment struct.
-struct _lf_sched_instance_t;
+// struct _lf_sched_instance_t;
 struct _lf_tag_advancement_barrier;
 
 /**
@@ -292,7 +293,7 @@ typedef struct environment_t {
 #ifdef LF_THREADED
     lf_mutex_t mutex;
     lf_cond_t event_q_changed;
-    struct _lf_sched_instance_t* scheduler;
+    _lf_sched_instance_t* scheduler;
     struct _lf_tag_advancement_barrier*  barrier;
     lf_cond_t global_tag_barrier_requestors_reached_zero;
 #endif // LF_THREADED

--- a/include/core/lf_types.h
+++ b/include/core/lf_types.h
@@ -240,6 +240,7 @@ struct trigger_t {
                               //   downstream messages have been produced for the same port for the same logical time.
     reactor_mode_t* mode;     // The enclosing mode of this reaction (if exists).
                               // If enclosed in multiple, this will point to the innermost mode.
+    void* parent;             // Pointer to reactor which contains the trigger
 #ifdef FEDERATED
     tag_t last_known_status_tag;        // Last known status of the port, either via a timed message, a port absent, or a
                                         // TAG from the RTI.

--- a/include/core/lf_types.h
+++ b/include/core/lf_types.h
@@ -280,10 +280,14 @@ struct _lf_tag_advancement_barrier;
  */
 typedef struct environment_t {
     tag_t current_tag;
-    bool** _lf_is_present_fields = NULL;
-    int _lf_is_present_fields_size = 0;
-    bool** _lf_is_present_fields_abbreviated = NULL;
-    int _lf_is_present_fields_abbreviated_size = 0;
+    tag_t stop_tag;
+    pqueue_t *event_q;
+    pqueue_t *recycle_q;
+    pqueue_t *next_w;
+    bool** _lf_is_present_fields;
+    int _lf_is_present_fields_size;
+    bool** _lf_is_present_fields_abbreviated;
+    int _lf_is_present_fields_abbreviated_size;
 #ifdef LF_THREADED
     lf_mutex_t mutex;
     lf_cond_t event_q_changed;
@@ -292,8 +296,8 @@ typedef struct environment_t {
     lf_cond_t global_tag_barrier_requestors_reached_zero;
 #endif // LF_THREADED
 #ifdef FEDERATED
-    tag_t** _lf_intended_tag_fields = NULL;
-    int _lf_intended_tag_fields_size = 0;
+    tag_t** _lf_intended_tag_fields;
+    int _lf_intended_tag_fields_size;
 #endif // FEDERATED
 } environment_t;
 
@@ -309,6 +313,7 @@ typedef struct environment_t {
 typedef struct self_base_t {
 	struct allocation_record_t *allocations;
 	struct reaction_t *executing_reaction;   // The currently executing reaction of the reactor.
+    environment_t * environment;
 #ifdef MODAL_REACTORS
     reactor_mode_state_t _lf__mode_state;    // The current mode (for modal models).
 #endif

--- a/include/core/platform.h
+++ b/include/core/platform.h
@@ -85,28 +85,18 @@ extern "C" {
 
 #define LF_TIMEOUT _LF_TIMEOUT
 
-/**
- * Enter a critical section where logical time and the event queue are guaranteed
- * to not change unless they are changed within the critical section.
- * this can be implemented by disabling interrupts.
- * Users of this function must ensure that lf_init_critical_sections() is
- * called first and that lf_critical_section_exit() is called later.
- * @return 0 on success, platform-specific error number otherwise.
- */
-extern int lf_critical_section_enter();
+#if defined (LF_UNTHREADED)
+    int lf_platform_disable_interrupts_nested();
+    int lf_platform_enable_interrupts_nested();
+    int lf_platform_notify_of_event();
+#endif
 
-/**
- * Exit the critical section entered with lf_lock_time().
- * @return 0 on success, platform-specific error number otherwise.
- */
-extern int lf_critical_section_exit();
 
 /**
  * Notify any listeners that an event has been created.
- * The caller should call lf_critical_section_enter() before calling this function.
+ * The caller should call lf_critical_section_enter(env) before calling this function.
  * @return 0 on success, platform-specific error number otherwise.
  */
-extern int lf_notify_of_event();
 
 // For platforms with threading support, the following functions
 // abstract the API so that the LF runtime remains portable.

--- a/include/core/platform/lf_arduino_support.h
+++ b/include/core/platform/lf_arduino_support.h
@@ -119,9 +119,6 @@ typedef void* lf_mutex_t;
 typedef void* lf_cond_t;
 typedef void* lf_thread_t;
 
-extern lf_mutex_t mutex;
-extern lf_cond_t event_q_changed;
-
 #endif // LF_THREADED
 
 #define PRINTF_TIME "%" PRIu32

--- a/include/core/platform/lf_zephyr_support.h
+++ b/include/core/platform/lf_zephyr_support.h
@@ -54,9 +54,6 @@ typedef struct {
 } lf_cond_t;
 typedef k_tid_t lf_thread_t;
 
-extern lf_mutex_t mutex;
-extern lf_cond_t event_q_changed;
-
 /**
  * @brief Add `value` to `*ptr` and return original value of `*ptr` 
  */

--- a/include/core/reactor.h
+++ b/include/core/reactor.h
@@ -369,7 +369,7 @@ void _lf_free_all_reactors(void);
  * Free memory recorded on the allocations list of the specified reactor.
  * @param self The self struct of the reactor.
  */
-void _lf_free_reactor(struct self_base_t *self);
+void _lf_free_reactor(self_base_t *self);
 
 /**
  * Generated function that optionally sets default command-line options.
@@ -380,7 +380,7 @@ void _lf_set_default_command_line_options(void);
  * Generated function that resets outputs to be absent at the
  * start of a new time step.
  */
-void _lf_start_time_step(void);
+void _lf_start_time_step(environment_t *env);
 
 /**
  * Generated function that produces a table containing all triggers
@@ -393,7 +393,7 @@ void _lf_initialize_trigger_objects(void);
  * the reactions triggered by these events, and stick them into the reaction
  * queue.
  */
-void _lf_pop_events(void);
+void _lf_pop_events(environment_t *env);
 
 /**
  * Internal version of the lf_schedule() function, used by generated
@@ -403,7 +403,7 @@ void _lf_pop_events(void);
  * @param token The token payload.
  * @return A handle to the event, or 0 if no event was scheduled, or -1 for error.
  */
-trigger_handle_t _lf_schedule(trigger_t* trigger, interval_t delay, lf_token_t* token);
+trigger_handle_t _lf_schedule(environment_t *env, trigger_t* trigger, interval_t delay, lf_token_t* token);
 
 /**
  * Function (to be code generated) to schedule timers.
@@ -422,7 +422,7 @@ void _lf_trigger_startup_reactions(void);
  */
 void terminate_execution(void);
 
-void termination(void);
+void termination(environment_t *env);
 
 /**
  * Function (to be code generated) to trigger shutdown reactions.
@@ -439,7 +439,7 @@ bool _lf_trigger_shutdown_reactions(void);
  * @param value The value to send.
  * @return A handle to the event, or 0 if no event was scheduled, or -1 for error.
  */
-trigger_handle_t _lf_schedule_int(lf_action_base_t* action, interval_t extra_delay, int value);
+trigger_handle_t _lf_schedule_int(lenvironment_t *env, f_action_base_t* action, interval_t extra_delay, int value);
 
 /**
  * Create a dummy event to be used as a spacer in the event queue.
@@ -493,7 +493,7 @@ event_t* _lf_create_dummy_event(trigger_t* trigger, instant_t time, event_t* nex
  * @param token The token to carry the payload or null for no payload.
  * @return A handle to the event, or 0 if no event was scheduled, or -1 for error.
  */
-trigger_handle_t _lf_schedule_token(lf_action_base_t* action, interval_t extra_delay, lf_token_t* token);
+trigger_handle_t _lf_schedule_token(environment_t *env, lf_action_base_t* action, interval_t extra_delay, lf_token_t* token);
 
 /**
  * Variant of schedule_token that creates a token to carry the specified value.
@@ -507,7 +507,7 @@ trigger_handle_t _lf_schedule_token(lf_action_base_t* action, interval_t extra_d
  *  scalar and 0 for no payload.
  * @return A handle to the event, or 0 if no event was scheduled, or -1 for error.
  */
-trigger_handle_t _lf_schedule_value(lf_action_base_t* action, interval_t extra_delay, void* value, size_t length);
+trigger_handle_t _lf_schedule_value(environment_t *env, lf_action_base_t* action, interval_t extra_delay, void* value, size_t length);
 
 /**
  * Schedule an action to occur with the specified value and time offset
@@ -522,7 +522,7 @@ trigger_handle_t _lf_schedule_value(lf_action_base_t* action, interval_t extra_d
  * @param length The length, if an array, 1 if a scalar, and 0 if value is NULL.
  * @return A handle to the event, or 0 if no event was scheduled, or -1 for error.
  */
-trigger_handle_t _lf_schedule_copy(lf_action_base_t* action, interval_t offset, void* value, size_t length);
+trigger_handle_t _lf_schedule_copy(environment_t *env, lf_action_base_t* action, interval_t offset, void* value, size_t length);
 
 /**
  * For a federated execution, send a STOP_REQUEST message

--- a/include/core/reactor.h
+++ b/include/core/reactor.h
@@ -325,7 +325,7 @@ void lf_print_snapshot(void);
  * a later logical time determined by the RTI so that
  * all federates stop at the same logical time.
  */
-void lf_request_stop(void);
+void lf_request_stop(environment_t *env);
 
 /**
  * Allocate zeroed-out memory and record the allocated memory on
@@ -422,7 +422,7 @@ void _lf_trigger_startup_reactions(void);
  */
 void terminate_execution(void);
 
-void termination(environment_t *env);
+void termination();
 
 /**
  * Function (to be code generated) to trigger shutdown reactions.
@@ -439,7 +439,7 @@ bool _lf_trigger_shutdown_reactions(void);
  * @param value The value to send.
  * @return A handle to the event, or 0 if no event was scheduled, or -1 for error.
  */
-trigger_handle_t _lf_schedule_int(lenvironment_t *env, f_action_base_t* action, interval_t extra_delay, int value);
+trigger_handle_t _lf_schedule_int(environment_t *env, lf_action_base_t* action, interval_t extra_delay, int value);
 
 /**
  * Create a dummy event to be used as a spacer in the event queue.

--- a/include/core/reactor.h
+++ b/include/core/reactor.h
@@ -403,7 +403,7 @@ void _lf_pop_events(environment_t *env);
  * @param token The token payload.
  * @return A handle to the event, or 0 if no event was scheduled, or -1 for error.
  */
-trigger_handle_t _lf_schedule(environment_t *env, trigger_t* trigger, interval_t delay, lf_token_t* token);
+trigger_handle_t _lf_schedule(environment_t* env, trigger_t* trigger, interval_t delay, lf_token_t* token);
 
 /**
  * Function (to be code generated) to schedule timers.
@@ -439,7 +439,7 @@ bool _lf_trigger_shutdown_reactions(void);
  * @param value The value to send.
  * @return A handle to the event, or 0 if no event was scheduled, or -1 for error.
  */
-trigger_handle_t _lf_schedule_int(environment_t *env, lf_action_base_t* action, interval_t extra_delay, int value);
+trigger_handle_t _lf_schedule_int(lf_action_base_t* action, interval_t extra_delay, int value);
 
 /**
  * Create a dummy event to be used as a spacer in the event queue.
@@ -493,7 +493,7 @@ event_t* _lf_create_dummy_event(trigger_t* trigger, instant_t time, event_t* nex
  * @param token The token to carry the payload or null for no payload.
  * @return A handle to the event, or 0 if no event was scheduled, or -1 for error.
  */
-trigger_handle_t _lf_schedule_token(environment_t *env, lf_action_base_t* action, interval_t extra_delay, lf_token_t* token);
+trigger_handle_t _lf_schedule_token(lf_action_base_t* action, interval_t extra_delay, lf_token_t* token);
 
 /**
  * Variant of schedule_token that creates a token to carry the specified value.
@@ -507,7 +507,7 @@ trigger_handle_t _lf_schedule_token(environment_t *env, lf_action_base_t* action
  *  scalar and 0 for no payload.
  * @return A handle to the event, or 0 if no event was scheduled, or -1 for error.
  */
-trigger_handle_t _lf_schedule_value(environment_t *env, lf_action_base_t* action, interval_t extra_delay, void* value, size_t length);
+trigger_handle_t _lf_schedule_value(lf_action_base_t* action, interval_t extra_delay, void* value, size_t length);
 
 /**
  * Schedule an action to occur with the specified value and time offset
@@ -522,7 +522,7 @@ trigger_handle_t _lf_schedule_value(environment_t *env, lf_action_base_t* action
  * @param length The length, if an array, 1 if a scalar, and 0 if value is NULL.
  * @return A handle to the event, or 0 if no event was scheduled, or -1 for error.
  */
-trigger_handle_t _lf_schedule_copy(environment_t *env, lf_action_base_t* action, interval_t offset, void* value, size_t length);
+trigger_handle_t _lf_schedule_copy(lf_action_base_t* action, interval_t offset, void* value, size_t length);
 
 /**
  * For a federated execution, send a STOP_REQUEST message

--- a/include/core/reactor_common.h
+++ b/include/core/reactor_common.h
@@ -70,8 +70,8 @@ event_t* _lf_create_dummy_events(
     event_t* next,
     microstep_t offset
 );
-int _lf_schedule_at_tag(trigger_t* trigger, tag_t tag, lf_token_t* token);
-trigger_handle_t _lf_schedule(environment_t *env, trigger_t* trigger, interval_t extra_delay, lf_token_t* token);
+int _lf_schedule_at_tag(environment_t* env, trigger_t* trigger, tag_t tag, lf_token_t* token);
+trigger_handle_t _lf_schedule(environment_t* env, trigger_t* trigger, interval_t extra_delay, lf_token_t* token);
 trigger_handle_t _lf_insert_reactions_for_trigger(environment_t* env, trigger_t* trigger, lf_token_t* token);
 
 /**
@@ -82,11 +82,15 @@ trigger_handle_t _lf_insert_reactions_for_trigger(environment_t* env, trigger_t*
  */
 void _lf_advance_logical_time(environment_t *env, instant_t next_time);
 
-trigger_handle_t _lf_schedule_int(environment_t *env, lf_action_base_t* action, interval_t extra_delay, int value);
+trigger_handle_t _lf_schedule_int(lf_action_base_t* action, interval_t extra_delay, int value);
 void _lf_invoke_reaction(reaction_t* reaction, int worker);
 void schedule_output_reactions(environment_t *env, reaction_t* reaction, int worker);
 int process_args(int argc, const char* argv[]);
 void initialize(environment_t *env);
 void termination();
+
+int lf_notify_of_event(environment_t* env);
+int lf_critical_section_enter(environment_t* env);
+int lf_critical_section_exit(environment_t* env);
 
 #endif

--- a/include/core/reactor_common.h
+++ b/include/core/reactor_common.h
@@ -11,6 +11,7 @@
 
 
 //  ******** Global Variables :( ********  //
+extern environment_t _lf_environment;
 extern unsigned int _lf_number_of_workers;
 extern bool fast;
 extern instant_t duration;
@@ -57,11 +58,11 @@ void lf_set_stp_offset(interval_t offset);
 
 extern pqueue_t* event_q;
 
-void _lf_trigger_reaction(reaction_t* reaction, int worker_number);
+void _lf_trigger_reaction(environment_t* env, reaction_t* reaction, int worker_number);
 void _lf_start_time_step(environment_t *env);
 bool _lf_is_tag_after_stop_tag(tag_t tag);
 void _lf_pop_events(environment_t *env);
-void _lf_initialize_timer(trigger_t* timer);
+void _lf_initialize_timer(environment_t* env, trigger_t* timer);
 void _lf_recycle_event(event_t* e);
 event_t* _lf_create_dummy_events(
     trigger_t* trigger,
@@ -71,7 +72,7 @@ event_t* _lf_create_dummy_events(
 );
 int _lf_schedule_at_tag(trigger_t* trigger, tag_t tag, lf_token_t* token);
 trigger_handle_t _lf_schedule(environment_t *env, trigger_t* trigger, interval_t extra_delay, lf_token_t* token);
-trigger_handle_t _lf_insert_reactions_for_trigger(trigger_t* trigger, lf_token_t* token);
+trigger_handle_t _lf_insert_reactions_for_trigger(environment_t* env, trigger_t* trigger, lf_token_t* token);
 
 /**
  * Advance from the current tag to the next. If the given next_time is equal to
@@ -86,6 +87,6 @@ void _lf_invoke_reaction(reaction_t* reaction, int worker);
 void schedule_output_reactions(environment_t *env, reaction_t* reaction, int worker);
 int process_args(int argc, const char* argv[]);
 void initialize(environment_t *env);
-void termination(environment_t *env);
+void termination();
 
 #endif

--- a/include/core/reactor_common.h
+++ b/include/core/reactor_common.h
@@ -49,7 +49,7 @@ void set_federation_id(const char* fid);
 extern struct allocation_record_t* _lf_reactors_to_free;
 void* _lf_new_reactor(size_t size);
 void _lf_free(struct allocation_record_t** head);
-void _lf_free_reactor(struct self_base_t *self);
+void _lf_free_reactor(self_base_t *self);
 void _lf_free_all_reactors(void);
 void _lf_set_stop_tag(tag_t tag);
 extern interval_t lf_get_stp_offset();
@@ -58,9 +58,9 @@ void lf_set_stp_offset(interval_t offset);
 extern pqueue_t* event_q;
 
 void _lf_trigger_reaction(reaction_t* reaction, int worker_number);
-void _lf_start_time_step();
+void _lf_start_time_step(environment_t *env);
 bool _lf_is_tag_after_stop_tag(tag_t tag);
-void _lf_pop_events();
+void _lf_pop_events(environment_t *env);
 void _lf_initialize_timer(trigger_t* timer);
 void _lf_recycle_event(event_t* e);
 event_t* _lf_create_dummy_events(
@@ -70,7 +70,7 @@ event_t* _lf_create_dummy_events(
     microstep_t offset
 );
 int _lf_schedule_at_tag(trigger_t* trigger, tag_t tag, lf_token_t* token);
-trigger_handle_t _lf_schedule(trigger_t* trigger, interval_t extra_delay, lf_token_t* token);
+trigger_handle_t _lf_schedule(environment_t *env, trigger_t* trigger, interval_t extra_delay, lf_token_t* token);
 trigger_handle_t _lf_insert_reactions_for_trigger(trigger_t* trigger, lf_token_t* token);
 
 /**
@@ -79,13 +79,13 @@ trigger_handle_t _lf_insert_reactions_for_trigger(trigger_t* trigger, lf_token_t
  * time and set the microstep to zero.
  * @param next_time The time step to advance to.
  */
-void _lf_advance_logical_time(instant_t next_time);
+void _lf_advance_logical_time(environment_t *env, instant_t next_time);
 
-trigger_handle_t _lf_schedule_int(lf_action_base_t* action, interval_t extra_delay, int value);
+trigger_handle_t _lf_schedule_int(environment_t *env, lf_action_base_t* action, interval_t extra_delay, int value);
 void _lf_invoke_reaction(reaction_t* reaction, int worker);
-void schedule_output_reactions(reaction_t* reaction, int worker);
+void schedule_output_reactions(environment_t *env, reaction_t* reaction, int worker);
 int process_args(int argc, const char* argv[]);
-void initialize(void);
-void termination(void);
+void initialize(environment_t *env);
+void termination(environment_t *env);
 
 #endif

--- a/include/core/tag.h
+++ b/include/core/tag.h
@@ -77,7 +77,7 @@ typedef struct {
 /**
  * Return the current tag, a logical time, microstep pair.
  */
-tag_t lf_tag();
+tag_t lf_tag(void* self);
 
 /**
  * Compare two tags. Return -1 if the first is less than
@@ -116,14 +116,14 @@ tag_t lf_delay_tag(tag_t tag, interval_t interval);
  *
  * @return A time instant.
  */
-instant_t lf_time_logical(void);
+instant_t lf_time_logical(void* self);
 
 /**
  * Return the elapsed logical time in nanoseconds
  * since the start of execution.
  * @return A time interval.
  */
-interval_t lf_time_logical_elapsed(void);
+interval_t lf_time_logical_elapsed(void *self);
 
 /**
  * Return the current physical time in nanoseconds.

--- a/include/core/tag.h
+++ b/include/core/tag.h
@@ -77,7 +77,7 @@ typedef struct {
 /**
  * Return the current tag, a logical time, microstep pair.
  */
-tag_t lf_tag(void *self);
+tag_t lf_tag(void* env);
 
 /**
  * Compare two tags. Return -1 if the first is less than

--- a/include/core/tag.h
+++ b/include/core/tag.h
@@ -77,7 +77,7 @@ typedef struct {
 /**
  * Return the current tag, a logical time, microstep pair.
  */
-tag_t lf_tag(void* self);
+tag_t lf_tag(void *self);
 
 /**
  * Compare two tags. Return -1 if the first is less than

--- a/include/core/threaded/reactor_threaded.h
+++ b/include/core/threaded/reactor_threaded.h
@@ -1,6 +1,5 @@
 #ifndef REACTOR_THREADED_H
 #define REACTOR_THREADED_H
-
 extern lf_mutex_t mutex;
 extern lf_cond_t event_q_changed;
 extern lf_cond_t global_tag_barrier_requestors_reached_zero;
@@ -17,13 +16,13 @@ void enqueue_network_input_control_reactions();
  * message to downstream federates if a given network output port is not present.
  */
 void enqueue_network_output_control_reactions();
-void _lf_increment_global_tag_barrier_already_locked(tag_t future_tag);
-void _lf_increment_global_tag_barrier(tag_t future_tag);
+void _lf_increment_global_tag_barrier_already_locked(environment_t *env, tag_t future_tag);
+void _lf_increment_global_tag_barrier(environment_t *env, tag_t future_tag);
 void _lf_decrement_global_tag_barrier_locked();
 int _lf_wait_on_global_tag_barrier(tag_t proposed_tag);
 void synchronize_with_other_federates();
 bool wait_until(instant_t logical_time_ns, lf_cond_t* condition);
 tag_t get_next_event_tag();
 tag_t send_next_event_tag(tag_t tag, bool wait_for_reply);
-void _lf_next_locked();
+void _lf_next_locked(environment_t* env);
 #endif // REACTOR_THREADED_H

--- a/include/core/threaded/reactor_threaded.h
+++ b/include/core/threaded/reactor_threaded.h
@@ -1,9 +1,5 @@
 #ifndef REACTOR_THREADED_H
 #define REACTOR_THREADED_H
-extern lf_mutex_t mutex;
-extern lf_cond_t event_q_changed;
-extern lf_cond_t global_tag_barrier_requestors_reached_zero;
-
 /**
  * Enqueue network input control reactions that determine if the trigger for a
  * given network input port is going to be present at the current logical time

--- a/include/core/threaded/scheduler.h
+++ b/include/core/threaded/scheduler.h
@@ -39,7 +39,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define LF_SCHEDULER_H
 
 #include "lf_types.h"
-
+#include "scheduler_instance.h"
 /**
  * @brief Default value that is assumed to be the maximum reaction level in the
  *  program.
@@ -47,27 +47,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Can be overriden by passing the appropriate `parameters` argument to
  * `lf_sched_init`.
  */
-#define DEFAULT_MAX_REACTION_LEVEL 100
 
-/**
- * @brief Struct representing the most common scheduler parameters.
- *
- * @param num_reactions_per_level Optional. Default: NULL. An array of
- *  non-negative integers, where each element represents a reaction level
- *  (corresponding to the index), and the value of the element represents the
- *  maximum number of reactions in the program for that level. For example,
- *  num_reactions_per_level = { 2, 3 } indicates that there will be a maximum of
- *  2 reactions in the program with a level of 0, and a maximum of 3 reactions
- *  in the program with a level of 1. Can be NULL.
- * @param num_reactions_per_level_size Optional. The size of the
- * `num_reactions_per_level` array if it is not NULL. If set, it should be the
- * maximum level over all reactions in the program plus 1. If not set,
- * `DEFAULT_MAX_REACTION_LEVEL` will be used.
- */
-typedef struct {
-    size_t* num_reactions_per_level;
-    size_t num_reactions_per_level_size;
-} sched_params_t;
 
 /**
  * @brief Initialize the scheduler.
@@ -81,6 +61,7 @@ typedef struct {
  *  scheduler parameters. Can be NULL.
  */
 void lf_sched_init(
+    environment_t* env,
     size_t number_of_workers,
     sched_params_t* parameters
 );
@@ -90,7 +71,7 @@ void lf_sched_init(
  *
  * This must be called when the scheduler is no longer needed.
  */
-void lf_sched_free();
+void lf_sched_free(_lf_sched_instance_t* _lf_sched_instance);
 
 /**
  * @brief Ask the scheduler for one more reaction.
@@ -103,7 +84,7 @@ void lf_sched_free();
  * @return reaction_t* A reaction for the worker to execute. NULL if the calling
  * worker thread should exit.
  */
-reaction_t* lf_sched_get_ready_reaction(int worker_number);
+reaction_t* lf_sched_get_ready_reaction(_lf_sched_instance_t* _lf_sched_instance, int worker_number);
 
 /**
  * @brief Inform the scheduler that worker thread 'worker_number' is done
@@ -133,6 +114,6 @@ void lf_sched_done_with_reaction(size_t worker_number, reaction_t* done_reaction
  *  worker number does not make sense (e.g., the caller is not a worker thread).
  *
  */
-void lf_sched_trigger_reaction(reaction_t* reaction, int worker_number);
+void lf_sched_trigger_reaction(_lf_sched_instance_t* _lf_sched_instance, reaction_t* reaction, int worker_number);
 
 #endif // LF_SCHEDULER_H

--- a/include/core/threaded/scheduler_instance.h
+++ b/include/core/threaded/scheduler_instance.h
@@ -48,8 +48,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define DEFAULT_MAX_REACTION_LEVEL 100
 
-extern lf_mutex_t mutex;
-
 
 /**
  * @brief Paramters used in schedulers of the threaded reactor C runtime.
@@ -175,6 +173,7 @@ typedef struct {
  *  initialized (checked in a thread-safe way).
  */
 bool init_sched_instance(
+    struct environment_t* env,
     _lf_sched_instance_t** instance,
     size_t number_of_workers,
     sched_params_t* params);

--- a/include/core/threaded/scheduler_instance.h
+++ b/include/core/threaded/scheduler_instance.h
@@ -43,7 +43,10 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif  // NUMBER_OF_WORKERS
 
 #include "semaphore.h"
-#include "scheduler.h"
+#include <stdbool.h>
+// #include "scheduler.h"
+
+#define DEFAULT_MAX_REACTION_LEVEL 100
 
 extern lf_mutex_t mutex;
 
@@ -54,7 +57,11 @@ extern lf_mutex_t mutex;
  * @note Members of this struct are added based on existing schedulers' needs.
  *  These should be expanded to accommodate new schedulers.
  */
+
+struct environment_t;
+
 typedef struct {
+    struct environment_t * env;
     /**
      * @brief Maximum number of levels for reactions in the program.
      *
@@ -135,6 +142,26 @@ typedef struct {
 } _lf_sched_instance_t;
 
 /**
+ * @brief Struct representing the most common scheduler parameters.
+ *
+ * @param num_reactions_per_level Optional. Default: NULL. An array of
+ *  non-negative integers, where each element represents a reaction level
+ *  (corresponding to the index), and the value of the element represents the
+ *  maximum number of reactions in the program for that level. For example,
+ *  num_reactions_per_level = { 2, 3 } indicates that there will be a maximum of
+ *  2 reactions in the program with a level of 0, and a maximum of 3 reactions
+ *  in the program with a level of 1. Can be NULL.
+ * @param num_reactions_per_level_size Optional. The size of the
+ * `num_reactions_per_level` array if it is not NULL. If set, it should be the
+ * maximum level over all reactions in the program plus 1. If not set,
+ * `DEFAULT_MAX_REACTION_LEVEL` will be used.
+ */
+typedef struct {
+    size_t* num_reactions_per_level;
+    size_t num_reactions_per_level_size;
+} sched_params_t;
+
+/**
  * @brief Initialize `instance` using the provided information.
  *
  * No-op if `instance` is already initialized (i.e., not NULL).
@@ -150,39 +177,7 @@ typedef struct {
 bool init_sched_instance(
     _lf_sched_instance_t** instance,
     size_t number_of_workers,
-    sched_params_t* params) {
+    sched_params_t* params);
 
-    // Check if the instance is already initialized
-    lf_mutex_lock(&mutex); // Safeguard against multiple threads calling this
-                           // function.
-    if (*instance != NULL) {
-        // Already initialized
-        lf_mutex_unlock(&mutex);
-        return false;
-    } else {
-        *instance =
-            (_lf_sched_instance_t*)calloc(1, sizeof(_lf_sched_instance_t));
-    }
-    lf_mutex_unlock(&mutex);
-
-    if (params == NULL || params->num_reactions_per_level_size == 0) {
-        (*instance)->max_reaction_level = DEFAULT_MAX_REACTION_LEVEL;
-    }
-
-    if (params != NULL) {
-        if (params->num_reactions_per_level != NULL) {
-            (*instance)->max_reaction_level =
-                params->num_reactions_per_level_size - 1;
-        }
-    }
-
-    (*instance)->_lf_sched_semaphore = lf_semaphore_new(0);
-    (*instance)->_lf_sched_number_of_workers = number_of_workers;
-    (*instance)->_lf_sched_next_reaction_level = 1;
-
-    (*instance)->_lf_sched_should_stop = false;
-
-    return true;
-}
 
 #endif // LF_SCHEDULER_PARAMS_H

--- a/include/core/threaded/scheduler_sync_tag_advance.h
+++ b/include/core/threaded/scheduler_sync_tag_advance.h
@@ -29,9 +29,10 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdbool.h>
 
 #include "tag.h"
+#include "scheduler_instance.h"
 
 /////////////////// External Functions /////////////////////////
-void _lf_next_locked();
+void _lf_next_locked(struct environment_t* env);
 /**
  * Placeholder for code-generated function that will, in a federated
  * execution, be used to coordinate the advancement of tag. It will notify
@@ -41,7 +42,7 @@ void _lf_next_locked();
  * @param tag_to_send The tag to send.
  */
 void logical_tag_complete(tag_t tag_to_send);
-bool _lf_sched_should_stop_locked();
-bool _lf_sched_advance_tag_locked();
+bool _lf_sched_should_stop_locked(_lf_sched_instance_t * sched);
+bool _lf_sched_advance_tag_locked(_lf_sched_instance_t * sched);
 
 #endif // LF_C11_THREADS_SUPPORT_H

--- a/include/core/threaded/worker_states.h
+++ b/include/core/threaded/worker_states.h
@@ -56,9 +56,6 @@ extern size_t current_level;
 extern size_t** num_reactions_by_worker_by_level;
 extern size_t max_num_workers;
 
-/** See reactor_threaded.c for documentation. */
-extern lf_mutex_t mutex;
-
 /** See reactor_common.c for documentation. */
 extern bool fast;
 

--- a/lib/schedule.c
+++ b/lib/schedule.c
@@ -191,7 +191,7 @@ trigger_handle_t lf_schedule_value(void* action, interval_t extra_delay, void* v
  */
 bool lf_check_deadline(void* self, bool invoke_deadline_handler) {
     reaction_t* reaction = ((self_base_t*)self)->executing_reaction;
-    if (lf_time_physical() > lf_time_logical() + reaction->deadline) {
+    if (lf_time_physical() > lf_time_logical(self) + reaction->deadline) {
         if (invoke_deadline_handler) {
             reaction->deadline_violation_handler(self);
         }

--- a/lingua-franca-ref.txt
+++ b/lingua-franca-ref.txt
@@ -1,1 +1,1 @@
-master
+reactor-local-time


### PR DESCRIPTION
Currently only `current_tag` and the scheduler is actually used from the environment. Code-generator is not yet updated