### PR TITLE
Suppress "no symbols" warnings emitted by ranlib

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -51,6 +51,13 @@ target_include_directories(core PUBLIC ../include/core/modal_models)
 target_include_directories(core PUBLIC ../include/core/threaded)
 target_include_directories(core PUBLIC ../include/core/utils)
 
+if (APPLE)
+    SET(CMAKE_C_ARCHIVE_CREATE   "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
+    SET(CMAKE_CXX_ARCHIVE_CREATE "<CMAKE_AR> Scr <TARGET> <LINK_FLAGS> <OBJECTS>")
+    SET(CMAKE_C_ARCHIVE_FINISH   "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
+    SET(CMAKE_CXX_ARCHIVE_FINISH "<CMAKE_RANLIB> -no_warning_for_no_symbols -c <TARGET>")
+endif()
+
 # Link with OpenSSL library
 if(DEFINED FEDERATED_AUTHENTICATED)
     if (APPLE)


### PR DESCRIPTION
This addresses warnings reported on Mac such as:
` /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/ranlib: file: libcore.a(scheduler_adaptive.c.o) has no symbols`

These warnings are expected because we use the preprocessor to exclude the contents of files that relate to features that are not used.

I have checked that this change suppresses the warnings on the 2013 Mac that we have been using.