### PR TITLE
Change nanosleep to lf_sleep in federate and RTI code

### DIFF
--- a/core/federated/RTI/rti_lib.c
+++ b/core/federated/RTI/rti_lib.c
@@ -1109,20 +1109,14 @@ void* clock_synchronization_thread(void* noargs) {
     interval_t ns_to_wait = start_time - lf_time_physical();
 
     if (ns_to_wait > 0LL) {
-        struct timespec wait_time = {ns_to_wait / BILLION, ns_to_wait % BILLION};
-        struct timespec rem_time;
-        nanosleep(&wait_time, &rem_time);
+        lf_sleep(ns_to_wait);
     }
 
     // Initiate a clock synchronization every _RTI.clock_sync_period_ns
-    struct timespec sleep_time = {(time_t) _RTI.clock_sync_period_ns / BILLION,
-                                  _RTI.clock_sync_period_ns % BILLION};
-    struct timespec remaining_time;
-
     bool any_federates_connected = true;
     while (any_federates_connected) {
         // Sleep
-        nanosleep(&sleep_time, &remaining_time); // Can be interrupted
+        lf_sleep(_RTI.clock_sync_period_ns); // Can be interrupted
         any_federates_connected = false;
         for (int fed = 0; fed < _RTI.number_of_federates; fed++) {
             if (_RTI.federates[fed].state == NOT_CONNECTED) {

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -772,9 +772,8 @@ void connect_to_federate(uint16_t remote_federate_id) {
                 lf_print_error_and_exit("TIMEOUT obtaining IP/port for federate %d from the RTI.",
                         remote_federate_id);
             }
-            struct timespec wait_time = {0L, ADDRESS_QUERY_RETRY_INTERVAL};
-            struct timespec remaining_time;
-            if (nanosleep(&wait_time, &remaining_time) != 0) {
+            // Wait ADDRESS_QUERY_RETRY_INTERVAL nanoseconds.
+            if (lf_sleep(ADDRESS_QUERY_RETRY_INTERVAL) != 0) {
                 // Sleep was interrupted.
                 continue;
             }
@@ -838,10 +837,8 @@ void connect_to_federate(uint16_t remote_federate_id) {
             }
             lf_print_warning("Could not connect to federate %d. Will try again every " PRINTF_TIME " nanoseconds.\n",
                    remote_federate_id, ADDRESS_QUERY_RETRY_INTERVAL);
-            // Wait CONNECT_RETRY_INTERVAL seconds.
-            struct timespec wait_time = {0L, ADDRESS_QUERY_RETRY_INTERVAL};
-            struct timespec remaining_time;
-            if (nanosleep(&wait_time, &remaining_time) != 0) {
+            // Wait ADDRESS_QUERY_RETRY_INTERVAL nanoseconds.
+            if (lf_sleep(ADDRESS_QUERY_RETRY_INTERVAL) != 0) {
                 // Sleep was interrupted.
                 continue;
             }
@@ -1066,9 +1063,7 @@ void connect_to_rti(const char* hostname, int port) {
             lf_print("Failed to connect to RTI on port %d. Trying %d.", uport, uport + 1);
             uport++;
             // Wait PORT_KNOCKING_RETRY_INTERVAL seconds.
-            struct timespec wait_time = {0L, PORT_KNOCKING_RETRY_INTERVAL};
-            struct timespec remaining_time;
-            if (nanosleep(&wait_time, &remaining_time) != 0) {
+            if (lf_sleep(PORT_KNOCKING_RETRY_INTERVAL) != 0) {
                 // Sleep was interrupted.
                 continue;
             }
@@ -1084,11 +1079,9 @@ void connect_to_rti(const char* hostname, int port) {
                                      CONNECT_NUM_RETRIES);
             }
             lf_print("Could not connect to RTI at %s. Will try again every %d seconds.",
-                   hostname, CONNECT_RETRY_INTERVAL);
-            // Wait CONNECT_RETRY_INTERVAL seconds.
-            struct timespec wait_time = {(time_t)CONNECT_RETRY_INTERVAL, 0L};
-            struct timespec remaining_time;
-            if (nanosleep(&wait_time, &remaining_time) != 0) {
+                   hostname, CONNECT_RETRY_INTERVAL / BILLION);
+            // Wait CONNECT_RETRY_INTERVAL nanoseconds.
+            if (lf_sleep(CONNECT_RETRY_INTERVAL) != 0) {
                 // Sleep was interrupted.
                 continue;
             }

--- a/include/core/federated/net_common.h
+++ b/include/core/federated/net_common.h
@@ -217,10 +217,10 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define FED_COM_BUFFER_SIZE 256u
 
 /**
- * Number of seconds that elapse between a federate's attempts
+ * Number of nanoseconds that elapse between a federate's attempts
  * to connect to the RTI.
  */
-#define CONNECT_RETRY_INTERVAL 2
+#define CONNECT_RETRY_INTERVAL 2000000000LL
 
 /**
  * Bound on the number of retries to connect to the RTI.


### PR DESCRIPTION
Platform abstraction for sleep is already available as lf_sleep(), and should be used instead of nanosleep() in the federate and RTI code. Timespec structs can then be removed entirely and just use the available macros or variables in nanoseconds as input to lf_sleep().

CONNECT_RETRY_INTERVAL is changed to be in nanoseconds instead of seconds, as the other macros.