### PR TITLE
Refactor of obsolete gethostbyname() in connect_to_rti()

### DIFF
--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -1046,12 +1046,12 @@ void connect_to_rti(const char* hostname, int port) {
         char str[6];
         sprintf(str,"%u",uport);
 
-        // Get address structures matching hostname, port and hints criteria
-        // There should only ever be one matching address structure, and
-        // we connect to that.
+        // Get address structure matching hostname and hints criteria, and
+        // set port to the port number provided in str. There should only 
+        // ever be one matching address structure, and we connect to that.
         int server = getaddrinfo(hostname, &str, &hints, &res);
         if (server != 0) {
-            lf_print_error_and_exit("No host for RTI matching given hostname and port: %s:%s", hostname, str);
+            lf_print_error_and_exit("No host for RTI matching given hostname: %s", hostname);
         }
 
         // Create a socket matching hints criteria

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -35,7 +35,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #error To be implemented. No support for federation on Arduino yet.
 #else
 #include <arpa/inet.h>  // inet_ntop & inet_pton
-#include <netdb.h>      // Defines gethostbyname().
+#include <netdb.h>      // Defines getaddrinfo(), freeaddrinfo() and struct addrinfo.
 #include <netinet/in.h> // Defines struct sockaddr_in
 #include <regex.h>
 #include <strings.h>    // Defines bzero().
@@ -1030,33 +1030,43 @@ void connect_to_rti(const char* hostname, int port) {
     int result = -1;
     int count_retries = 0;
 
+    struct addrinfo hints;
+    struct addrinfo *res;
+
+    memset(&hints, 0, sizeof(hints));
+    hints.ai_family = AF_INET;          /* Allow IPv4 */
+    hints.ai_socktype = SOCK_STREAM;    /* Stream socket */
+    hints.ai_protocol = IPPROTO_TCP;    /* TCP protocol */
+    hints.ai_addr = NULL;
+    hints.ai_next = NULL;
+    hints.ai_flags = AI_NUMERICSERV;    /* Allow only numeric port numbers */
+
     while (result < 0) {
-        // Create an IPv4 socket for TCP (not UDP) communication over IP (0).
-        _fed.socket_TCP_RTI = socket(AF_INET, SOCK_STREAM, 0);
+        // Convert port number to string
+        char str[6];
+        sprintf(str,"%u",uport);
+
+        // Get address structures matching hostname, port and hints criteria
+        // There should only ever be one matching address structure, and
+        // we connect to that.
+        int server = getaddrinfo(hostname, &str, &hints, &res);
+        if (server != 0) {
+            lf_print_error_and_exit("No host for RTI matching given hostname and port: %s:%s", hostname, str);
+        }
+
+        // Create a socket matching hints criteria
+        _fed.socket_TCP_RTI = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
         if (_fed.socket_TCP_RTI < 0) {
-            lf_print_error_and_exit("Creating socket to RTI.");
+            lf_print_error_and_exit("Failed to create socket to RTI.");
         }
 
-        struct hostent *server = gethostbyname(hostname);
-        if (server == NULL) {
-            lf_print_error_and_exit("ERROR, no such host for RTI: %s\n", hostname);
+        result = connect(_fed.socket_TCP_RTI, res->ai_addr, res->ai_addrlen);
+        if (result == 0) {
+            lf_print("Successfully connected to RTI.");
         }
-        // Server file descriptor.
-        struct sockaddr_in server_fd;
-        // Zero out the server_fd struct.
-        bzero((char*)&server_fd, sizeof(server_fd));
 
-        // Set up the server_fd fields.
-        server_fd.sin_family = AF_INET;    // IPv4
-        bcopy((char*)server->h_addr,
-             (char*)&server_fd.sin_addr.s_addr,
-             (size_t)server->h_length);
-        // Convert the port number from host byte order to network byte order.
-        server_fd.sin_port = htons(uport);
-        result = connect(
-            _fed.socket_TCP_RTI,
-            (struct sockaddr *)&server_fd,
-            sizeof(server_fd));
+        freeaddrinfo(res);           /* No longer needed */
+
         // If this failed, try more ports, unless a specific port was given.
         if (result != 0
                 && !specific_port_given


### PR DESCRIPTION
According to the linux man-page: 

> The gethostbyname*(), gethostbyaddr*(), herror(), and hstrerror() functions are obsolete. Applications should use getaddrinfo(3), getnameinfo(3), and gai_strerror(3) instead.

Currently, gethostbyname() is used in connect_to_rti(). This PR modifies the function to use getaddrinfo() instead. The functionality should be unchanged. If no host matches the given hostname, getaddrinfo() will return a non-zero value and exit. If at least one address structure matches the given hostname, it will set the port the be _uport_ and try to connect. Notice that getaddrinfo() returns a linked list of matching address structures, if more than one matches the hostname and _hints_. According to the man page:

>  There are several reasons why the linked list may have more than one addrinfo structure, including: the network host is multihomed, accessible over multiple protocols (e.g., both AF_INET and AF_INET6); or the same service is available from multiple socket types (one SOCK_STREAM address and another SOCK_DGRAM address, for example). Normally, the application should try using the addresses in the order in which they are returned.

So in the current application, I think it should never return more than one address structure (the _hints_ structure specifies AF_INET and SOCK_STREAM specifically). And if it does, we essentially ignore all but the first one, and if the first one fails, try with the next port number instead.