### PR TITLE
Output error when trying to use --auth (-a) for RTI built without -DAUTH=ON

### DIFF
--- a/core/federated/RTI/rti_lib.c
+++ b/core/federated/RTI/rti_lib.c
@@ -1586,7 +1586,7 @@ bool authenticate_federate(int socket) {
     write_to_socket(socket, message_length, rti_hello_buffer);
 
     // Check HMAC of received FED_RESPONSE message.
-    size_t hmac_length = SHA256_HMAC_LENGTH;
+    unsigned int hmac_length = SHA256_HMAC_LENGTH;
     size_t federation_id_length = strnlen(_RTI.federation_id, 255);
     size_t fed_id_length = sizeof(uint16_t);
 
@@ -1997,6 +1997,11 @@ int process_args(int argc, const char* argv[]) {
            i++;
            i += process_clock_sync_args((argc-i), &argv[i]);
         } else if (strcmp(argv[i], "-a") == 0 || strcmp(argv[i], "--auth") == 0) {
+            #ifndef __RTI_AUTH__
+            fprintf(stderr, "Error: --auth requires the RTI to be built with the -DAUTH=ON option.\n");
+            usage(argc, argv);
+            return 0;
+            #endif
             _RTI.authentication_enabled = true;
         } else if (strcmp(argv[i], "-t") == 0 || strcmp(argv[i], "--tracing") == 0) {
             _RTI.tracing_enabled = true;


### PR DESCRIPTION
Add an error message when trying to use the --auth (-a) option for the RTI built without the -DAUTH=ON option. Also fix a minor build warning.

Relevant issue: https://github.com/lf-lang/lingua-franca/issues/1777