### PR TITLE
Zephyr fixes on thread creation and deletion

### DIFF
--- a/core/platform/lf_zephyr_support.c
+++ b/core/platform/lf_zephyr_support.c
@@ -416,11 +416,11 @@ int lf_thread_create(lf_thread_t* thread, void *(*lf_thread) (void *), void* arg
 
 
     // Pass the pointer to the k_thread struct out. This is needed
-    // to join on the thread later
+    // to join on the thread later.
     *thread = &threads[tid];   
 
     // Increment the tid counter so that next call to `lf_thread_create`
-    // uses the next available k_thread struct and stack 
+    // uses the next available k_thread struct and stack.
     tid++; 
 
 

--- a/core/platform/lf_zephyr_support.c
+++ b/core/platform/lf_zephyr_support.c
@@ -414,9 +414,15 @@ int lf_thread_create(lf_thread_t* thread, void *(*lf_thread) (void *), void* arg
                                  (void *) lf_thread, arguments, NULL,
                                  _LF_THREAD_PRIORITY, 0, K_NO_WAIT);
 
+
+    // Pass the pointer to the k_thread struct out. This is needed
+    // to join on the thread later
+    *thread = &threads[tid];   
+
+    // Increment the tid counter so that next call to `lf_thread_create`
+    // uses the next available k_thread struct and stack 
     tid++; 
 
-    *thread = my_tid;   
 
     k_mutex_unlock(&thread_mutex);
 

--- a/include/core/platform/lf_zephyr_support.h
+++ b/include/core/platform/lf_zephyr_support.h
@@ -50,7 +50,7 @@ typedef struct {
     lf_mutex_t* mutex;
     struct k_condvar condition;
 } lf_cond_t;
-typedef k_tid_t lf_thread_t;
+typedef struct k_thread* lf_thread_t;
 
 extern lf_mutex_t mutex;
 extern lf_cond_t event_q_changed;


### PR DESCRIPTION
Addresses a bug in the implementation of the threaded platform API on Zephyr