### PR TITLE
Zephyr federated support

### DIFF
--- a/core/federated/clock-sync.c
+++ b/core/federated/clock-sync.c
@@ -31,12 +31,15 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
 #ifdef FEDERATED
+#ifdef PLATFORM_ZEPHYR
+#else
+#include <sys/socket.h>
+#include <netinet/in.h>
+#endif
 #include <errno.h>
 #include <math.h>
 #include <string.h>
 #include <stdlib.h>
-#include <sys/socket.h>
-#include <netinet/in.h>
 
 #include "platform.h"
 #include "clock-sync.h"

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -33,6 +33,8 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifdef FEDERATED
 #ifdef PLATFORM_ARDUINO
 #error To be implemented. No support for federation on Arduino yet.
+#elif PLATFORM_ZEPHYR
+#warning Federated support on Zephyr is still experimental.
 #else
 #include <arpa/inet.h>  // inet_ntop & inet_pton
 #include <netdb.h>      // Defines getaddrinfo(), freeaddrinfo() and struct addrinfo.
@@ -2414,6 +2416,7 @@ void terminate_execution() {
     // possibility of deadlock. To ensure this, this
     // function should NEVER be called while holding any mutex lock.
     lf_mutex_lock(&outbound_socket_mutex);
+    // FIXME: Should this be _fed.number_of_outbound_p2p_connections instead?
     for (int i=0; i < NUMBER_OF_FEDERATES; i++) {
         // Close outbound connections, in case they have not closed themselves.
         // This will result in EOF being sent to the remote federate, I think.

--- a/core/federated/net_util.c
+++ b/core/federated/net_util.c
@@ -576,6 +576,7 @@ void encode_tag(
  * @return true if there is a match, false otherwise.
  */
 bool match_regex(const char* str, char* regex) {
+    #ifndef PLATFORM_ZEPHYR
     regex_t regex_compiled;
     regmatch_t group;
     bool valid = false;
@@ -591,6 +592,9 @@ bool match_regex(const char* str, char* regex) {
     }
     regfree(&regex_compiled);
     return valid;
+    #else
+    return true;
+    #endif
 }
 
 
@@ -637,6 +641,8 @@ bool validate_user(const char* user) {
     return match_regex(user, username_regex);
 }
 
+#ifndef PLATFORM_ZEPHYR
+
 /**
  * Extract one match group from the rti_addr regex .
  * @return true if SUCCESS, else false.
@@ -671,10 +677,13 @@ bool extract_match_groups(const char* rti_addr, char** rti_addr_strs, bool** rti
     return true;
 }
 
+#endif
+
 /**
  * Extract the host, port and user from rti_addr.
  */
 void extract_rti_addr_info(const char* rti_addr, rti_addr_info_t* rti_addr_info) {
+    #ifndef PLATFORM_ZEPHYR
     const char* regex_str = "(([a-zA-Z0-9_-]{1,254})@)?([a-zA-Z0-9.]{1,255})(:([0-9]{1,5}))?";
     size_t max_groups = 6;
     // The group indices of each field of interest in the regex.
@@ -710,5 +719,6 @@ void extract_rti_addr_info(const char* rti_addr, rti_addr_info_t* rti_addr_info)
         }
     }
     regfree(&regex_compiled);
+    #endif
 }
 #endif

--- a/core/platform/lf_zephyr_support.c
+++ b/core/platform/lf_zephyr_support.c
@@ -348,7 +348,7 @@ int lf_notify_of_event() {
 #warning "Threaded support on Zephyr is still experimental."
 
 // FIXME: What is an appropriate stack size?
-#define _LF_STACK_SIZE 1024
+#define _LF_STACK_SIZE 4096
 // FIXME: What is an appropriate thread prio?
 #define _LF_THREAD_PRIORITY 5
 
@@ -363,7 +363,38 @@ int lf_notify_of_event() {
 #define USER_THREADS 0
 #endif
 
+#if defined(FEDERATED) && defined(FEDERATED_DECENTRALIZED)
+#define RTI_SOCKET_LISTENER_THREAD 1
+#define FEDERATE_SOCKET_LISTENER_THREADS NUMBER_OF_FEDERATES
+#define P2P_HANDLER_THREAD 1
+
+#elif defined(FEDERATED) && defined(FEDERATED_CENTRALIZED)
+#define RTI_SOCKET_LISTENER_THREAD 1
+#define FEDERATE_SOCKET_LISTENER_THREADS 0
+#define P2P_HANDLER_THREAD 0
+
+#else 
+#define RTI_SOCKET_LISTENER_THREAD 0
+#define FEDERATE_SOCKET_LISTENER_THREADS 0
+#define P2P_HANDLER_THREAD 0
+#endif
+
+#if defined(FEDERATED) && defined(_LF_CLOCK_SYNC_ON)
+#define CLOCK_SYNC_THREAD 1
+#else
+#define CLOCK_SYNC_THREAD 0
+#endif
+
+#ifndef WORKERS_NEEDED_FOR_FEDERATE
+#define WORKERS_NEEDED_FOR_FEDERATE 0
+#endif
+
 #define NUMBER_OF_THREADS (NUMBER_OF_WORKERS \
+                           + WORKERS_NEEDED_FOR_FEDERATE \
+                           + RTI_SOCKET_LISTENER_THREAD \
+                           + FEDERATE_SOCKET_LISTENER_THREADS \
+                           + P2P_HANDLER_THREAD \
+                           + CLOCK_SYNC_THREAD \
                            + USER_THREADS)
 
 K_MUTEX_DEFINE(thread_mutex);

--- a/include/core/federated/net_util.h
+++ b/include/core/federated/net_util.h
@@ -40,6 +40,8 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef PLATFORM_ARDUINO
 #error To be implemented. No support for federation on Arduino yet.
+#elif PLATFORM_ZEPHYR
+#warning Federated support on Zephyr is still experimental.
 #else
 #include <sys/socket.h>
 #include <regex.h>
@@ -345,6 +347,7 @@ bool validate_host(const char* host);
  */
 bool validate_user(const char* user);
 
+#ifndef PLATFORM_ZEPHYR
 
 /**
  * Extract one match group from the rti_addr regex .
@@ -358,6 +361,8 @@ bool extract_match_group(const char* rti_addr, char* dest, regmatch_t group,
  * @return true if success, else false.
  */
 bool extract_match_groups(const char* rti_addr, char** rti_addr_strs, bool** rti_addr_flags, regmatch_t* group_array, int* gids, int* max_lens, int* min_lens, const char** err_msgs);
+
+#endif
 
 /**
  * Extract the host, port and user from rti_addr.

--- a/include/core/platform/lf_zephyr_support.h
+++ b/include/core/platform/lf_zephyr_support.h
@@ -39,6 +39,8 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdlib.h> //malloc, calloc, free, realloc
 
 #include <zephyr/kernel.h>
+#include <zephyr/posix/sys/socket.h>
+#include <zephyr/posix/netdb.h>
 
 #define NO_TTY
 #define _LF_TIMEOUT 1


### PR DESCRIPTION
To be able to run federates on Zephyr, the following changes must be made to reactor-c. Notice that https://github.com/lf-lang/reactor-c/pull/220 has been merged into this PR as well. This is because Zephyr does not offer support for the obsolete _gethostbyname()_. So, if https://github.com/lf-lang/reactor-c/pull/220 is not approved, then this PR must add a macro separating the two implementations. 

In the Zephyr platform-specific functions, macros are added to allow for static thread stack definition for federated execution.

Additionally, the regex library is not supported by Zephyr.