### PR TITLE
Make _lf_count_token_allocations extern instead of static

### DIFF
--- a/core/lf_token.c
+++ b/core/lf_token.c
@@ -35,6 +35,7 @@
  * allocated for message payloads and never freed.
  */
 int _lf_count_payload_allocations;
+int _lf_count_token_allocations;
 
 #include <stdbool.h>
 #include <assert.h>

--- a/include/core/lf_token.h
+++ b/include/core/lf_token.h
@@ -191,7 +191,7 @@ extern lf_token_t* _lf_tokens_allocated_in_reactions;
  * it. That token is not counted because it is not
  * expected to be freed.
  */
-static int _lf_count_token_allocations;
+extern int _lf_count_token_allocations;
 
 //////////////////////////////////////////////////////////
 //// Functions that users may call


### PR DESCRIPTION
I kept getting warnings with the Zephyr toolchain about `_lf_count_token_allocations` being unused. It is very uncommon to declare static variables in header files. It means that each file that includes this header will get its own copy of the variable. Is that intended? My guess is that its a typo and should be `extern` creating a single global variable shared across compilation units.