### PR TITLE
Enclaves tuning

### DIFF
--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -358,6 +358,8 @@ int send_timed_message(environment_t* env,
                         const char* next_destination_str,
                         size_t length,
                         unsigned char* message) {
+    assert(env != GLOBAL_ENVIRONMENT);
+
     unsigned char header_buffer[1 + sizeof(uint16_t) + sizeof(uint16_t)
              + sizeof(int32_t) + sizeof(instant_t) + sizeof(microstep_t)];
     // First byte identifies this as a timed message.
@@ -1408,6 +1410,7 @@ void mark_control_reaction_waiting(int portID, bool waiting) {
  * @param portID the ID of the port to determine status for
  */
 port_status_t get_current_port_status(environment_t* env, int portID) {
+    assert(env != GLOBAL_ENVIRONMENT);
     // Check whether the status of the port is known at the current tag.
     trigger_t* network_input_port_action = _lf_action_for_port(portID)->trigger;
     if (network_input_port_action->status == present) {
@@ -1439,6 +1442,7 @@ port_status_t get_current_port_status(environment_t* env, int portID) {
  * @param env The environment of the federate
  */
 void enqueue_network_input_control_reactions(environment_t* env) {
+    assert(env != GLOBAL_ENVIRONMENT);
 #ifdef FEDERATED_CENTRALIZED
     if (!_fed.has_upstream) {
         // This federate is not connected to any upstream federates via a
@@ -1467,6 +1471,7 @@ void enqueue_network_input_control_reactions(environment_t* env) {
  * @param env The environment of the federate
  */
 void enqueue_network_output_control_reactions(environment_t* env){
+    assert(env != GLOBAL_ENVIRONMENT);
 #ifdef FEDERATED_CENTRALIZED
     if (!_fed.has_downstream) {
         // This federate is not connected to any downstream federates via a
@@ -1497,6 +1502,7 @@ void enqueue_network_output_control_reactions(environment_t* env){
  * @param env The environment of the federate
  */
 void enqueue_network_control_reactions(environment_t *env) {
+    assert(env != GLOBAL_ENVIRONMENT);
     enqueue_network_output_control_reactions(env);
 #ifdef FEDERATED_CENTRALIZED
     // If the granted tag is not provisional, there is no
@@ -1525,6 +1531,8 @@ void enqueue_network_control_reactions(environment_t *env) {
 void send_port_absent_to_federate(environment_t* env, interval_t additional_delay,
                                     unsigned short port_ID,
                                   unsigned short fed_ID) {
+    assert(env != GLOBAL_ENVIRONMENT);
+
     // Construct the message
     size_t message_length = 1 + sizeof(port_ID) + sizeof(fed_ID) + sizeof(instant_t) + sizeof(microstep_t);
     unsigned char buffer[message_length];
@@ -1577,6 +1585,8 @@ void send_port_absent_to_federate(environment_t* env, interval_t additional_dela
  * @param STAA The safe-to-assume-absent threshold for the port
  */
 void wait_until_port_status_known(environment_t* env, int port_ID, interval_t STAA) {
+    assert(env != GLOBAL_ENVIRONMENT);
+
     // Need to lock the mutex to prevent
     // a race condition with the network
     // receiver logic.
@@ -1683,6 +1693,8 @@ static trigger_handle_t schedule_message_received_from_network_already_locked(
         trigger_t* trigger,
         tag_t tag,
         lf_token_t* token) {
+    assert(env != GLOBAL_ENVIRONMENT);
+
     // Return value of the function
     int return_value = 0;
 
@@ -1802,6 +1814,8 @@ void _lf_close_inbound_socket(int fed_id) {
  * @param fed_id The sending federate ID or -1 if the centralized coordination.
  */
 static void handle_port_absent_message(environment_t* env, int socket, int fed_id) {
+    assert(env != GLOBAL_ENVIRONMENT);
+
     size_t bytes_to_read = sizeof(uint16_t) + sizeof(uint16_t) + sizeof(instant_t) + sizeof(microstep_t);
     unsigned char buffer[bytes_to_read];
     read_from_socket_errexit(socket, bytes_to_read, buffer,
@@ -1907,6 +1921,8 @@ void handle_message(int socket, int fed_id) {
  * @param fed_id The sending federate ID or -1 if the centralized coordination.
  */
 void handle_tagged_message(environment_t* env, int socket, int fed_id) {
+    assert(env != GLOBAL_ENVIRONMENT);
+
     // FIXME: Need better error handling?
     // Read the header which contains the timestamp.
     size_t bytes_to_read = sizeof(uint16_t) + sizeof(uint16_t) + sizeof(int32_t)
@@ -2087,6 +2103,8 @@ void handle_tagged_message(environment_t* env, int socket, int fed_id) {
  *  it sets last_TAG_was_provisional to false.
  */
 void handle_tag_advance_grant(environment_t *env) {
+    assert(env != GLOBAL_ENVIRONMENT);
+
     size_t bytes_to_read = sizeof(instant_t) + sizeof(microstep_t);
     unsigned char buffer[bytes_to_read];
     read_from_socket_errexit(_fed.socket_TCP_RTI, bytes_to_read, buffer,
@@ -2167,6 +2185,8 @@ void _lf_logical_tag_complete(tag_t tag_to_send) {
  *  last known tag for input ports.
  */
 void handle_provisional_tag_advance_grant(environment_t* env) {
+    assert(env != GLOBAL_ENVIRONMENT);
+
     size_t bytes_to_read = sizeof(instant_t) + sizeof(microstep_t);
     unsigned char buffer[bytes_to_read];
     read_from_socket_errexit(_fed.socket_TCP_RTI, bytes_to_read, buffer,
@@ -2274,6 +2294,8 @@ void handle_provisional_tag_advance_grant(environment_t* env) {
  * @param env The environment of the federate
  */
 void _lf_fd_send_stop_request_to_rti(environment_t* env) {
+    assert(env != GLOBAL_ENVIRONMENT);
+
     // Do not send a stop request twice.
     if (_fed.sent_a_stop_request_to_rti == true) {
         return;
@@ -2314,6 +2336,8 @@ void _lf_fd_send_stop_request_to_rti(environment_t* env) {
  * @param env The environment of the federate
  */
 void handle_stop_granted_message(environment_t* env) {
+    assert(env != GLOBAL_ENVIRONMENT);
+
     size_t bytes_to_read = MSG_TYPE_STOP_GRANTED_LENGTH - 1;
     unsigned char buffer[bytes_to_read];
     read_from_socket_errexit(_fed.socket_TCP_RTI, bytes_to_read, buffer,
@@ -2361,6 +2385,8 @@ void handle_stop_granted_message(environment_t* env) {
  * @param env The environment of the federate
  */
 void handle_stop_request_message(environment_t* env) {
+    assert(env != GLOBAL_ENVIRONMENT);
+
     size_t bytes_to_read = MSG_TYPE_STOP_REQUEST_LENGTH - 1;
     unsigned char buffer[bytes_to_read];
     read_from_socket_errexit(_fed.socket_TCP_RTI, bytes_to_read, buffer,
@@ -2430,6 +2456,8 @@ void handle_stop_request_message(environment_t* env) {
  * @param env The environment of the federate
  */
 void terminate_execution(environment_t* env) {
+    assert(env != GLOBAL_ENVIRONMENT);
+
     // Check for all outgoing physical connections in
     // _fed.sockets_for_outbound_p2p_connections and
     // if the socket ID is not -1, the connection is still open.
@@ -2661,6 +2689,7 @@ void* listen_to_rti_TCP(void* args) {
  * FIXME: Possibly should be renamed
  */
 void synchronize_with_other_federates(environment_t* env) {
+    assert(env != GLOBAL_ENVIRONMENT);
 
     LF_PRINT_DEBUG("Synchronizing with other federates.");
 
@@ -2795,6 +2824,7 @@ bool _lf_bounded_NET(tag_t* tag) {
  * @param wait_for_reply If true, wait for a reply.
  */
 tag_t _lf_send_next_event_tag(environment_t* env, tag_t tag, bool wait_for_reply) {
+    assert(env != GLOBAL_ENVIRONMENT);
     while (true) {
         if (!_fed.has_downstream && !_fed.has_upstream) {
             // This federate is not connected (except possibly by physical links)

--- a/core/modal_models/modes.c
+++ b/core/modal_models/modes.c
@@ -557,6 +557,7 @@ void _lf_terminate_modal_reactors(environment_t* env) {
     _lf_unsused_suspended_events_head = NULL;
 }
 void _lf_initialize_modes(environment_t* env) {
+    assert(env != GLOBAL_ENVIRONMENT);
     if (env->modes) {
         _lf_initialize_mode_states(
             env, 
@@ -565,6 +566,7 @@ void _lf_initialize_modes(environment_t* env) {
     }
 }
 void _lf_handle_mode_changes(environment_t* env) {
+    assert(env != GLOBAL_ENVIRONMENT);
     if (env->modes) {
         _lf_process_mode_changes(
             env, 
@@ -579,6 +581,7 @@ void _lf_handle_mode_changes(environment_t* env) {
 }
 
 void _lf_handle_mode_triggered_reactions(environment_t* env) {
+    assert(env != GLOBAL_ENVIRONMENT);
     if (env->modes) {
         _lf_handle_mode_startup_reset_reactions(
             env, env->startup_reactions, env->startup_reactions_size,

--- a/core/reactor.c
+++ b/core/reactor.c
@@ -34,6 +34,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * @author{Soroush Bateni <soroush@utdallas.edu>}
  * @author{Erling Jellum <erlingrj@berkeley.edu>}
  */
+#include <assert.h>
 #include <string.h>
 
 #include "reactor.h"

--- a/core/reactor.c
+++ b/core/reactor.c
@@ -399,7 +399,7 @@ int lf_reactor_c_main(int argc, const char* argv[]) {
 
 /**
  * @brief Notify of new event by calling the unthreaded platform API
- * @param env Environment in which we are execution
+ * @param env Environment in which we are executing.
  */
 int lf_notify_of_event(environment_t* env) {
     return _lf_unthreaded_notify_of_event();
@@ -407,7 +407,7 @@ int lf_notify_of_event(environment_t* env) {
 
 /**
  * @brief Enter critical section by disabling interrupts
- * @param env Environment in which we are execution
+ * @param env Environment in which we are executing.
  */
 int lf_critical_section_enter(environment_t* env) {
     return lf_disable_interrupts_nested();
@@ -415,7 +415,7 @@ int lf_critical_section_enter(environment_t* env) {
 
 /**
  * @brief Leave a critical section by enabling interrupts
- * @param env Environment in which we are execution
+ * @param env Environment in which we are executing.
  */
 int lf_critical_section_exit(environment_t* env) {
     return lf_enable_interrupts_nested();

--- a/core/reactor.c
+++ b/core/reactor.c
@@ -115,6 +115,8 @@ void lf_print_snapshot(environment_t* env) {
  *  worker number does not make sense (e.g., the caller is not a worker thread).
  */
 void _lf_trigger_reaction(environment_t* env, reaction_t* reaction, int worker_number) {
+    assert(env != GLOBAL_ENVIRONMENT);
+
 #ifdef MODAL_REACTORS
     // Check if reaction is disabled by mode inactivity
     if (!_lf_mode_is_active(reaction->mode)) {
@@ -141,6 +143,8 @@ void _lf_trigger_reaction(environment_t* env, reaction_t* reaction, int worker_n
  *  should stop.
  */
 int _lf_do_step(environment_t* env) {
+    assert(env != GLOBAL_ENVIRONMENT);
+
     // Invoke reactions.
     while(pqueue_size(env->reaction_q) > 0) {
         // lf_print_snapshot();
@@ -227,6 +231,8 @@ int _lf_do_step(environment_t* env) {
 // the keepalive command-line option has not been given.
 // Otherwise, return 1.
 int next(environment_t* env) {
+    assert(env != GLOBAL_ENVIRONMENT);
+
     // Enter the critical section and do not leave until we have
     // determined which tag to commit to and start invoking reactions for.
     if (lf_critical_section_enter(env) != 0) {
@@ -304,6 +310,8 @@ int next(environment_t* env) {
  * @param env Environment in which we are executing
  */
 void _lf_request_stop(environment_t *env) {
+    assert(env != GLOBAL_ENVIRONMENT);
+
 	tag_t new_stop_tag;
 	new_stop_tag.time = env->current_tag.time;
 	new_stop_tag.microstep = env->current_tag.microstep + 1;

--- a/core/tag.c
+++ b/core/tag.c
@@ -8,6 +8,7 @@
  * @brief Implementation of time and tag functions for Lingua Franca programs.
  */
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
@@ -111,6 +112,7 @@ instant_t _lf_physical_time() {
 ////////////////  Functions declared in tag.h
 
 tag_t lf_tag(void *env) {
+    assert(env != GLOBAL_ENVIRONMENT);
     return ((environment_t *)env)->current_tag;
 }
 
@@ -149,6 +151,7 @@ tag_t lf_delay_tag(tag_t tag, interval_t interval) {
 }
 
 instant_t lf_time_logical(void *env) {
+    assert(env != GLOBAL_ENVIRONMENT);
     return ((environment_t *) env)->current_tag.time;
 }
 

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -35,6 +35,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define NUMBER_OF_WORKERS 1
 #endif // NUMBER_OF_WORKERS
 
+#include <assert.h>
 #include <signal.h>
 #include <string.h>
 #include <time.h>
@@ -106,6 +107,8 @@ lf_mutex_t global_mutex;
  * will freeze advancement of logical time.
  */
 void _lf_increment_global_tag_barrier_already_locked(environment_t *env, tag_t future_tag) {
+    assert(env != GLOBAL_ENVIRONMENT);
+
     // Check if future_tag is after stop tag.
     // This will only occur when a federate receives a timed message with
     // a tag that is after the stop tag
@@ -170,12 +173,14 @@ void _lf_increment_global_tag_barrier_already_locked(environment_t *env, tag_t f
  *  certain non-blocking functionalities such as receiving timed messages
  *  over the network or handling stop in a federated execution.
  *
+ * @param env The environment in which we are executing.
  * @param future_tag A desired tag for the barrier. This function will guarantee
  * that current tag will not go past future_tag if it is in the future.
  * If future_tag is in the past (or equals to current tag), the runtime
  * will freeze advancement of tag.
  */
 void _lf_increment_global_tag_barrier(environment_t *env, tag_t future_tag) {
+    assert(env != GLOBAL_ENVIRONMENT);
     lf_mutex_lock(&env->mutex);
     _lf_increment_global_tag_barrier_already_locked(env, future_tag);
     lf_mutex_unlock(&env->mutex);
@@ -192,8 +197,11 @@ void _lf_increment_global_tag_barrier(environment_t *env, tag_t future_tag) {
  * @note This function is only useful in threaded applications to facilitate
  *  certain non-blocking functionalities such as receiving timed messages
  *  over the network or handling stop in the federated execution.
+ *
+ * @param env The environment in which we are executing.
  */
 void _lf_decrement_global_tag_barrier_locked(environment_t* env) {
+    assert(env != GLOBAL_ENVIRONMENT);
     // Decrement the number of requestors for the tag barrier.
     env->barrier.requestors--;
     // Check to see if the semaphore is negative, which indicates that
@@ -230,10 +238,13 @@ void _lf_decrement_global_tag_barrier_locked(environment_t* env) {
  * Thus, it unlocks the mutex while it's waiting to allow
  * the tag barrier to change.
  *
+ * @param env Environment within which we are executing.
  * @param proposed_tag The tag that the runtime wants to advance to.
  * @return 0 if no wait was needed and 1 if a wait actually occurred.
  */
 int _lf_wait_on_global_tag_barrier(environment_t* env, tag_t proposed_tag) {
+    assert(env != GLOBAL_ENVIRONMENT);
+
     // Check the most common case first.
     if (env->barrier.requestors == 0) return 0;
 
@@ -306,6 +317,7 @@ void _lf_set_present(lf_port_base_t* port) {
  * and then returns. If --fast was specified, then this does
  * not wait for physical time to match the logical start time
  * returned by the RTI.
+ * @param env Environment within which we are executing.
  */
 void synchronize_with_other_federates(environment_t* env);
 
@@ -322,6 +334,7 @@ void synchronize_with_other_federates(environment_t* env);
  * was placed on the queue if that event time matches or exceeds
  * the specified time.
  *
+ * @param env Environment within which we are executing.
  * @param logical_time Logical time to wait until physical time matches it.
  * @param return_if_interrupted If this is false, then wait_util will wait
  *  until physical time matches the logical time regardless of whether new
@@ -420,8 +433,11 @@ bool wait_until(environment_t* env, instant_t logical_time, lf_cond_t* condition
  * Return the tag of the next event on the event queue.
  * If the event queue is empty then return either FOREVER_TAG
  * or, is a stop_time (timeout time) has been set, the stop time.
+ * @param env Environment within which we are executing.
  */
 tag_t get_next_event_tag(environment_t *env) {
+    assert(env != GLOBAL_ENVIRONMENT);
+
     // Peek at the earliest event in the event queue.
     event_t* event = (event_t*)pqueue_peek(env->event_q);
     tag_t next_tag = FOREVER_TAG;
@@ -468,6 +484,7 @@ tag_t _lf_send_next_event_tag(environment_t* env, tag_t tag, bool wait_for_reply
  * In unfederated execution or in federated execution with decentralized
  * control, this function returns the specified tag immediately.
  *
+ * @param env Environment within which we are executing.
  * @param tag The tag to which to advance.
  * @param wait_for_reply If true, wait for the RTI to respond.
  * @return The tag to which it is safe to advance.
@@ -498,8 +515,11 @@ tag_t send_next_event_tag(environment_t* env, tag_t tag, bool wait_for_reply) {
  * equal, shutdown reactions are triggered.
  *
  * This does not acquire the mutex lock. It assumes the lock is already held.
+ * @param env Environment within which we are executing.
  */
 void _lf_next_locked(environment_t *env) {
+    assert(env != GLOBAL_ENVIRONMENT);
+
 #ifdef MODAL_REACTORS
     // Perform mode transitions
     _lf_handle_mode_changes(env);
@@ -629,8 +649,11 @@ void _lf_next_locked(environment_t *env) {
  * In a federated execution, it will likely occur at
  * a later logical time determined by the RTI so that
  * all federates stop at the same logical time.
+ * @param env Environment within which we are executing.
  */
 void _lf_request_stop(environment_t *env) {
+    assert(env != GLOBAL_ENVIRONMENT);
+
     lf_mutex_lock(&env->mutex);
     // Check if already at the previous stop tag.
     if (lf_tag_compare(env->current_tag, env->stop_tag) >= 0) {
@@ -661,6 +684,7 @@ void _lf_request_stop(environment_t *env) {
 /**
  * Trigger 'reaction'.
  *
+ * @param env Environment within which we are executing.
  * @param reaction The reaction.
  * @param worker_number The ID of the worker that is making this call. 0 should be
  *  used if there is only one worker (e.g., when the program is using the
@@ -668,6 +692,8 @@ void _lf_request_stop(environment_t *env) {
  *  worker number does not make sense (e.g., the caller is not a worker thread).
  */
 void _lf_trigger_reaction(environment_t* env, reaction_t* reaction, int worker_number) {
+    assert(env != GLOBAL_ENVIRONMENT);
+
 #ifdef MODAL_REACTORS
         // Check if reaction is disabled by mode inactivity
         if (_lf_mode_is_active(reaction->mode)) {
@@ -688,8 +714,10 @@ void _lf_trigger_reaction(environment_t* env, reaction_t* reaction, int worker_n
  * and for the federated execution, waiting for a proper coordinated start.
  *
  * This assumes the mutex lock is held by the caller.
+ * @param env Environment within which we are executing.
  */
 void _lf_initialize_start_tag(environment_t *env) {
+    assert(env != GLOBAL_ENVIRONMENT);
 
     // Add reactions invoked at tag (0,0) (including startup reactions) to the reaction queue
     _lf_trigger_startup_reactions(env);
@@ -771,10 +799,15 @@ int worker_thread_count = 0;
  * The mutex should NOT be locked when this function is called. It might acquire
  * the mutex when scheduling the reactions that are triggered as a result of
  * executing the deadline violation handler on the 'reaction', if it exists.
+ * @param env Environment within which we are executing.
+ * @param worker_number The ID of the worker.
+ * @param reaction The reaction whose deadline has been violated.
  *
  * @return true if a deadline violation occurred. false otherwise.
  */
 bool _lf_worker_handle_deadline_violation_for_reaction(environment_t *env, int worker_number, reaction_t* reaction) {
+    assert(env != GLOBAL_ENVIRONMENT);
+
     bool violation_occurred = false;
     // If the reaction has a deadline, compare to current physical time
     // and invoke the deadline violation reaction instead of the reaction function
@@ -812,6 +845,9 @@ bool _lf_worker_handle_deadline_violation_for_reaction(environment_t *env, int w
  * The mutex should NOT be locked when this function is called. It might acquire
  * the mutex when scheduling the reactions that are triggered as a result of
  * executing the STP violation handler on the 'reaction', if it exists.
+ * @param env Environment within which we are executing.
+ * @param worker_number The ID of the worker.
+ * @param reaction The reaction whose STP offset has been violated.
  *
  * @return true if an STP violation occurred. false otherwise.
  */
@@ -870,6 +906,9 @@ bool _lf_worker_handle_STP_violation_for_reaction(environment_t* env, int worker
  * the mutex when scheduling the reactions that are triggered as a result of
  * executing the deadline or STP violation handler(s) on the 'reaction', if they
  * exist.
+ * @param env Environment within which we are executing.
+ * @param worker_number The ID of the worker.
+ * @param reaction The reaction.
  *
  * @return true if a violation occurred. false otherwise.
  */
@@ -887,6 +926,9 @@ bool _lf_worker_handle_violations(environment_t *env, int worker_number, reactio
  * The mutex should NOT be locked when this function is called. It might acquire
  * the mutex when scheduling the reactions that are triggered as a result of
  * executing 'reaction'.
+ * @param env Environment within which we are executing.
+ * @param worker_number The ID of the worker.
+ * @param reaction The reaction to invoke.
  */
 void _lf_worker_invoke_reaction(environment_t *env, int worker_number, reaction_t* reaction) {
     LF_PRINT_LOG("Worker %d: Invoking reaction %s at elapsed tag " PRINTF_TAG ".",
@@ -907,9 +949,12 @@ void _lf_worker_invoke_reaction(environment_t *env, int worker_number, reaction_
  * The main looping logic of each LF worker thread.
  * This function assumes the caller holds the mutex lock.
  *
+ * @param env Environment within which we are executing.
  * @param worker_number The number assigned to this worker thread
  */
 void _lf_worker_do_work(environment_t *env, int worker_number) {
+    assert(env != GLOBAL_ENVIRONMENT);
+
     // Keep track of whether we have decremented the idle thread count.
     // Obtain a reaction from the scheduler that is ready to execute
     // (i.e., it is not blocked by concurrently executing reactions
@@ -951,9 +996,13 @@ void _lf_worker_do_work(environment_t *env, int worker_number) {
  * Worker thread for the thread pool.
  * This acquires the mutex lock and releases it to wait for time to
  * elapse or for asynchronous events and also releases it to execute reactions.
+ * @param arg Environment within which the worker should execute.
  */
 void* worker(void* arg) {
     environment_t *env = (environment_t* ) arg;
+
+    assert(env != GLOBAL_ENVIRONMENT);
+
     lf_mutex_lock(&env->mutex);
     int worker_number = worker_thread_count++;
     LF_PRINT_LOG("Worker thread %d started.", worker_number);
@@ -984,8 +1033,11 @@ void* worker(void* arg) {
 /**
  * If DEBUG logging is enabled, prints the status of the event queue,
  * the reaction queue, and the executing queue.
+ * @param env Environment within which we are executing.
  */
 void lf_print_snapshot(environment_t* env) {
+    assert(env != GLOBAL_ENVIRONMENT);
+
     if(LOG_LEVEL > LOG_LEVEL_LOG) {
         LF_PRINT_DEBUG(">>> START Snapshot");
         LF_PRINT_DEBUG("Pending:");
@@ -1000,6 +1052,8 @@ void lf_print_snapshot(environment_t* env) {
 
 // Start threads in the thread pool.
 void start_threads(environment_t* env) {
+    assert(env != GLOBAL_ENVIRONMENT);
+
     LF_PRINT_LOG("Starting %u worker threads in environment", env->num_workers);
     for (unsigned int i = 0; i < env->num_workers; i++) {
         if (lf_thread_create(&env->thread_ids[i], worker, env) != 0) {
@@ -1010,7 +1064,6 @@ void start_threads(environment_t* env) {
 
 /**
  * @brief Determine the number of workers.
- *
  */
 void determine_number_of_workers(void) {
     // If _lf_number_of_workers is 0, it means that it was not provided on
@@ -1169,13 +1222,16 @@ int lf_reactor_c_main(int argc, const char* argv[]) {
 
 /**
  * @brief Notify of new event by broadcasting on a condition variable. 
+ * @param env Environment within which we are executing.
  */
 int lf_notify_of_event(environment_t* env) {
+    assert(env != GLOBAL_ENVIRONMENT);
     return lf_cond_broadcast(&env->event_q_changed);
 }
 
 /**
  * @brief Enter critical section by locking the global mutex.
+ * @param env Environment within which we are executing or GLOBAL_ENVIRONMENT.
  */
 int lf_critical_section_enter(environment_t* env) {
     if (env == GLOBAL_ENVIRONMENT) {
@@ -1187,6 +1243,7 @@ int lf_critical_section_enter(environment_t* env) {
 
 /**
  * @brief Leave a critical section by unlocking the global mutex.
+ * @param env Environment within which we are executing or GLOBAL_ENVIRONMENT.
  */
 int lf_critical_section_exit(environment_t* env) {
     if (env == GLOBAL_ENVIRONMENT) {

--- a/core/threaded/scheduler_GEDF_NP.c
+++ b/core/threaded/scheduler_GEDF_NP.c
@@ -215,6 +215,7 @@ void _lf_sched_wait_for_work(lf_scheduler_t* scheduler, size_t worker_number) {
  * This has to be called before other functions of the scheduler can be used.
  * If the scheduler is already initialized, this will be a no-op.
  *
+ * @param env Environment within which we are executing.
  * @param number_of_workers Indicate how many workers this scheduler will be
  *  managing.
  * @param option Pointer to a `sched_params_t` struct containing additional
@@ -225,6 +226,8 @@ void lf_sched_init(
     size_t number_of_workers,
     sched_params_t* params
 ) {
+    assert(env != GLOBAL_ENVIRONMENT);
+
     LF_PRINT_DEBUG("Scheduler: Initializing with %zu workers", number_of_workers);
     if(!init_sched_instance(env, &env->scheduler, number_of_workers, params)) {
         // Already initialized

--- a/core/threaded/scheduler_GEDF_NP_CI.c
+++ b/core/threaded/scheduler_GEDF_NP_CI.c
@@ -371,6 +371,7 @@ void _lf_sched_wait_for_work(lf_scheduler_t* scheduler, size_t worker_number) {
  * This has to be called before other functions of the scheduler can be used.
  * If the scheduler is already initialized, this will be a no-op.
  *
+ * @param env Environment within which we are executing.
  * @param number_of_workers Indicate how many workers this scheduler will be
  *  managing.
  * @param option Pointer to a `sched_params_t` struct containing additional
@@ -381,6 +382,8 @@ void lf_sched_init(
     size_t number_of_workers,
     sched_params_t* params
 ) {
+    assert(env != GLOBAL_ENVIRONMENT);
+
     LF_PRINT_DEBUG("Scheduler: Initializing with %zu workers", number_of_workers);
     if(!init_sched_instance(env, &env->scheduler, number_of_workers, params)) {
         // Already initialized

--- a/core/threaded/scheduler_NP.c
+++ b/core/threaded/scheduler_NP.c
@@ -259,6 +259,7 @@ void _lf_sched_wait_for_work(lf_scheduler_t* scheduler, size_t worker_number) {
  * This has to be called before other functions of the scheduler can be used.
  * If the scheduler is already initialized, this will be a no-op.
  *
+ * @param env Environment within which we are executing.
  * @param number_of_workers Indicate how many workers this scheduler will be
  *  managing.
  * @param option Pointer to a `sched_params_t` struct containing additional
@@ -269,6 +270,8 @@ void lf_sched_init(
     size_t number_of_workers,
     sched_params_t* params
 ) {
+    assert(env != GLOBAL_ENVIRONMENT);
+
     LF_PRINT_DEBUG("Scheduler: Initializing with %zu workers", number_of_workers);
         
     // This scheduler is unique in that it requires `num_reactions_per_level` to

--- a/core/threaded/scheduler_adaptive.c
+++ b/core/threaded/scheduler_adaptive.c
@@ -705,6 +705,8 @@ static void data_collection_end_tag(
 
 ///////////////////// Scheduler Init and Destroy API /////////////////////////
 void lf_sched_init(environment_t* env, size_t number_of_workers, sched_params_t* params) {
+    assert(env != GLOBAL_ENVIRONMENT);
+
     // TODO: Instead of making this a no-op, crash the program. If this gets called twice, then that
     // is a bug that should be fixed.
     if(!init_sched_instance(env, &env->scheduler, number_of_workers, params)) {

--- a/core/threaded/scheduler_instance.c
+++ b/core/threaded/scheduler_instance.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include "scheduler_instance.h"
 #include "reactor_common.h"
 #include "lf_types.h"
@@ -8,8 +9,10 @@ bool init_sched_instance(
     environment_t * env,
     lf_scheduler_t** instance,
     size_t number_of_workers,
-    sched_params_t* params) {
+    sched_params_t* params
+) {
     
+    assert(env != GLOBAL_ENVIRONMENT);
     lf_assert(env, "`init_sched_instance` called without env pointer being set");
 
     // Check if the instance is already initialized

--- a/include/core/environment.h
+++ b/include/core/environment.h
@@ -44,8 +44,18 @@ typedef struct lf_scheduler_t lf_scheduler_t;
 typedef struct trace_t trace_t;
 typedef struct mode_environment_t mode_environment_t;
 
-
+/**
+ * @brief The global environment.
+ * Some operations are not specific to a particular scheduling enclave and therefore
+ * have no associated environment. When invoking a function such as lf_critical_section_enter,
+ * which requires an environment argument, it may be possible to pass this GLOBAL_ENVIRONMENT.
+ * For lf_critical_section_enter, for example, this may acquire a global mutex instead of
+ * a mutex specific to a particular scheduling enclave. Most functions that take environment
+ * arguments, however, cannot accept the GLOBAL_ENVIRONMENT argument, and passing it will
+ * result in an assertion violation.
+ */
 #define GLOBAL_ENVIRONMENT NULL
+
 /**
  * @brief Execution environment.
  * This struct contains information about the execution environment.

--- a/include/core/lf_token.h
+++ b/include/core/lf_token.h
@@ -360,6 +360,7 @@ token_freed _lf_done_using(lf_token_t* token);
  * @brief Free token copies made for mutable inputs.
  * This function should be called at the beginning of each time step
  * to avoid memory leaks.
+ * @param env Environment in which we are executing.
  */
 void _lf_free_token_copies(struct environment_t* env);
 

--- a/python/include/pythontarget.h
+++ b/python/include/pythontarget.h
@@ -74,7 +74,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 extern PyObject *globalPythonModule;
 extern PyObject *globalPythonModuleDict;
 extern PyObject* global_pickler;
-extern environment_t* global_environment;
+extern environment_t* top_level_environment;
 
 //////////////////////////////////////////////////////////////
 /////////////  schedule Functions (to schedule an action)

--- a/python/lib/python_tag.c
+++ b/python/lib/python_tag.c
@@ -43,7 +43,7 @@ PyObject* py_lf_tag(PyObject *self, PyObject *args) {
     if (t == NULL) {
         return NULL;
     }
-    t->tag = lf_tag(global_environment);
+    t->tag = lf_tag(top_level_environment);
     return (PyObject *) t;
 }
 

--- a/python/lib/python_time.c
+++ b/python/lib/python_time.c
@@ -41,14 +41,14 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Return the logical time in nanoseconds.
  */
 PyObject* py_lf_time_logical(PyObject *self, PyObject *args) {
-    return PyLong_FromLongLong(lf_time_logical(global_environment));
+    return PyLong_FromLongLong(lf_time_logical(top_level_environment));
 }
 
 /**
  * Return the elapsed logical time in nanoseconds.
  */
 PyObject* py_lf_time_logical_elapsed(PyObject *self, PyObject *args) {
-    return PyLong_FromLongLong(lf_time_logical_elapsed(global_environment));
+    return PyLong_FromLongLong(lf_time_logical_elapsed(top_level_environment));
 }
 
 /**

--- a/python/lib/pythontarget.c
+++ b/python/lib/pythontarget.c
@@ -56,7 +56,7 @@ PyObject *globalPythonModuleDict = NULL;
 // Import pickle to enable native serialization
 PyObject* global_pickler = NULL;
 
-environment_t* global_environment = NULL;
+environment_t* top_level_environment = NULL;
 
 
 //////////// schedule Function(s) /////////////
@@ -158,7 +158,7 @@ void _lf_request_stop(environment_t* env);
  * Stop execution at the conclusion of the current logical time.
  */
 PyObject* py_request_stop(PyObject *self, PyObject *args) {
-    _lf_request_stop(global_environment);
+    _lf_request_stop(top_level_environment);
 
     Py_INCREF(Py_None);
     return Py_None;
@@ -264,7 +264,7 @@ PyObject* py_main(PyObject* self, PyObject* py_args) {
     }
 
     // Store a reference to the top-level environment
-    int num_environments = _lf_get_environments(&global_environment);
+    int num_environments = _lf_get_environments(&top_level_environment);
     lf_assert(num_environments == 1, "Python target only supports programs with a single environment/enclave");
 
     LF_PRINT_DEBUG("Initialized the Python interpreter.");

--- a/python/lib/pythontarget.c
+++ b/python/lib/pythontarget.c
@@ -263,7 +263,7 @@ PyObject* py_main(PyObject* self, PyObject* py_args) {
         }
     }
 
-    // Store a reference to the global environment
+    // Store a reference to the top-level environment
     int num_environments = _lf_get_environments(&global_environment);
     lf_assert(num_environments == 1, "Python target only supports programs with a single environment/enclave");
 

--- a/util/audio_loop_linux.c
+++ b/util/audio_loop_linux.c
@@ -342,7 +342,13 @@ int lf_play_audio_waveform(lf_waveform_t* waveform, float emphasis, instant_t st
     // occur.
     while (index_offset >= AUDIO_BUFFER_SIZE) {
         pthread_cond_wait(&lf_audio_cond, &lf_audio_mutex);
-        time_offset = lf_time_logical() - next_buffer_start_time;
+        // next_buffer_start_time has been incremented by BUFFER_DURATION_NS.
+        time_offset = start_time - next_buffer_start_time;
+        // time_offset should be >= 0, but just in case:
+        if (time_offset < 0) {
+            time_offset = 0;
+            result = 1;
+        }
         index_offset = (time_offset * SAMPLE_RATE) / BILLION;
     }
     

--- a/util/audio_loop_mac.c
+++ b/util/audio_loop_mac.c
@@ -260,7 +260,13 @@ int lf_play_audio_waveform(lf_waveform_t* waveform, float emphasis, instant_t st
     // occur.
     while (index_offset >= AUDIO_BUFFER_SIZE) {
         pthread_cond_wait(&lf_audio_cond, &lf_audio_mutex);
-        time_offset = lf_time_logical() - next_buffer_start_time;
+        // next_buffer_start_time has been incremented by BUFFER_DURATION_NS.
+        time_offset = start_time - next_buffer_start_time;
+        // time_offset should be >= 0, but just in case:
+        if (time_offset < 0) {
+            time_offset = 0;
+            result = 1;
+        }
         index_offset = (time_offset * SAMPLE_RATE) / BILLION;
     }
     


### PR DESCRIPTION
This PR documents GLOBAL_ENVIRONMENT and inserts assertions where it should not be used so that we get assertion failures instead of segmentation faults.

It also renames global_environment to top_level_environment, which more accurate because it does not match GLOBAL_ENVIRONMENT.

This PR also fixes a bug in the audio utility that was calling lf_time_logical(), which now requires an environment argument. In any case, the call was incorrect and not needed.