### PR TITLE
Enclave request stop

### DIFF
--- a/core/federated/RTI/enclave.c
+++ b/core/federated/RTI/enclave.c
@@ -31,7 +31,6 @@ void initialize_enclave(enclave_t* e, uint16_t id) {
     e->downstream = NULL;
     e->num_downstream = 0;
     e->mode = REALTIME;
-    e->requested_stop = false;
 
     // Initialize the next event condition variable.
     lf_cond_init(&e->next_event_condition, &rti_mutex);

--- a/core/federated/RTI/enclave.h
+++ b/core/federated/RTI/enclave.h
@@ -59,9 +59,6 @@ typedef struct enclave_t {
     int* downstream;        // Array of downstream federate ids.
     int num_downstream;     // Size of the array of downstream federates.
     execution_mode_t mode;  // FAST or REALTIME.
-    bool requested_stop;    // Indicates that the federate has requested stop or has replied
-                            // to a request for stop from the RTI. Used to prevent double-counting
-                            // a federate when handling lf_request_stop().
     lf_cond_t next_event_condition; // Condition variable used by enclaves to notify an enclave
                                     // that it's call to next_event_tag() should unblock.
 } enclave_t;

--- a/core/federated/RTI/enclave.h
+++ b/core/federated/RTI/enclave.h
@@ -1,3 +1,16 @@
+/**
+ * @file
+ * @author Edward A. Lee (eal@berkeley.edu)
+ * @author Soroush Bateni (soroush@utdallas.edu)
+ * @author Erling Jellum (erling.r.jellum@ntnu.no)
+ * @author Chadlia Jerad (chadlia.jerad@ensi-uma.tn)
+ * @copyright (c) 2020-2023, The University of California at Berkeley
+ * License in [BSD 2-clause](https://github.com/lf-lang/reactor-c/blob/main/LICENSE.md)
+ * @brief Declarations for runtime infrastructure (RTI) for scheduling enclaves and distributed Lingua Franca programs.
+ * This file declares RTI features that are used by scheduling enclaves as well as federated
+ * LF programs.
+ */
+
 #ifndef ENCLAVE_H
 #define ENCLAVE_H
 

--- a/core/federated/RTI/rti_lib.c
+++ b/core/federated/RTI/rti_lib.c
@@ -598,11 +598,11 @@ void _lf_rti_broadcast_stop_time_to_federates_locked() {
 }
 
 void mark_federate_requesting_stop(federate_t* fed) {
-    if (!fed->enclave.requested_stop) {
+    if (!fed->requested_stop) {
         // Assume that the federate
         // has requested stop
         _f_rti->num_enclaves_handling_stop++;
-        fed->enclave.requested_stop = true;
+        fed->requested_stop = true;
     }
     if (_f_rti->num_enclaves_handling_stop == _f_rti->number_of_enclaves) {
         // We now have information about the stop time of all
@@ -625,7 +625,7 @@ void handle_stop_request_message(federate_t* fed) {
 
     // Check whether we have already received a stop_tag
     // from this federate
-    if (fed->enclave.requested_stop) {
+    if (fed->requested_stop) {
         // Ignore this request
         lf_mutex_unlock(&rti_mutex);
         return;
@@ -666,7 +666,7 @@ void handle_stop_request_message(federate_t* fed) {
     // if we do not have a stop_time already for them.
     for (int i = 0; i < _f_rti->number_of_enclaves; i++) {
         federate_t *f = _f_rti->enclaves[i];
-        if (f->enclave.id != fed->enclave.id && f->enclave.requested_stop == false) {
+        if (f->enclave.id != fed->enclave.id && f->requested_stop == false) {
             if (f->enclave.state == NOT_CONNECTED) {
                 mark_federate_requesting_stop(f);
                 continue;
@@ -1530,6 +1530,7 @@ void* respond_to_erroneous_connections(void* nothing) {
 
 void initialize_federate(federate_t* fed, uint16_t id) {
     initialize_enclave(&(fed->enclave), id);
+    fed->requested_stop = false;
     fed->socket = -1;      // No socket.
     fed->clock_synchronization_enabled = true;
     fed->in_transit_message_tags = initialize_in_transit_message_q();

--- a/core/federated/RTI/rti_lib.c
+++ b/core/federated/RTI/rti_lib.c
@@ -566,7 +566,7 @@ bool _lf_rti_stop_granted_already_sent_to_federates = false;
  *
  * This function assumes the caller holds the _RTI.rti_mutex lock.
  */
-void _lf_rti_broadcast_stop_time_to_federates_already_locked() {
+void _lf_rti_broadcast_stop_time_to_federates_locked() {
     if (_lf_rti_stop_granted_already_sent_to_federates == true) {
         return;
     }
@@ -607,7 +607,7 @@ void mark_federate_requesting_stop(federate_t* fed) {
     if (_f_rti->num_enclaves_handling_stop == _f_rti->number_of_enclaves) {
         // We now have information about the stop time of all
         // federates.
-        _lf_rti_broadcast_stop_time_to_federates_already_locked();
+        _lf_rti_broadcast_stop_time_to_federates_locked();
     }
 }
 

--- a/core/federated/RTI/rti_lib.h
+++ b/core/federated/RTI/rti_lib.h
@@ -258,15 +258,6 @@ void handle_logical_tag_complete(federate_t* fed);
 void handle_next_event_tag(federate_t* fed);
 
 /////////////////// STOP functions ////////////////////
-/**
- * Once the RTI has seen proposed tags from all connected federates,
- * it will broadcast a MSG_TYPE_STOP_GRANTED carrying the _RTI.max_stop_tag.
- * This function also checks the most recently received NET from
- * each federate and resets that be no greater than the _RTI.max_stop_tag.
- *
- * This function assumes the caller holds the _RTI.rti_mutex lock.
- */
-void _lf_rti_broadcast_stop_time_to_federates_already_locked();
 
 /**
  * Mark a federate requesting stop.

--- a/core/federated/RTI/rti_lib.h
+++ b/core/federated/RTI/rti_lib.h
@@ -177,6 +177,11 @@ typedef struct federation_rti_t {
      * Boolean indicating that authentication is enabled.
      */
     bool authentication_enabled;
+
+    /**
+     * Boolean indicating that a stop request is already in progress.
+     */
+    bool stop_in_progress;
 } federation_rti_t;
 
 /**

--- a/core/federated/RTI/rti_lib.h
+++ b/core/federated/RTI/rti_lib.h
@@ -49,6 +49,9 @@ typedef enum socket_type_t {
  */
 typedef struct federate_t {
     enclave_t enclave;
+    bool requested_stop;    // Indicates that the federate has requested stop or has replied
+                            // to a request for stop from the RTI. Used to prevent double-counting
+                            // a federate when handling lf_request_stop().
     lf_thread_t thread_id;    // The ID of the thread handling communication with this federate.
     int socket;             // The TCP socket descriptor for communicating with this federate.
     struct sockaddr_in UDP_addr;           // The UDP address for the federate.

--- a/core/federated/RTI/rti_lib.h
+++ b/core/federated/RTI/rti_lib.h
@@ -2,10 +2,13 @@
  * @file
  * @author Edward A. Lee (eal@berkeley.edu)
  * @author Soroush Bateni (soroush@utdallas.edu)
+ * @author Erling Jellum (erling.r.jellum@ntnu.no)
+ * @author Chadlia Jerad (chadlia.jerad@ensi-uma.tn)
  * @copyright (c) 2020-2023, The University of California at Berkeley
  * License in [BSD 2-clause](https://github.com/lf-lang/reactor-c/blob/main/LICENSE.md)
  * @brief Declarations for runtime infrastructure (RTI) for distributed Lingua Franca programs.
- *
+ * This file extends enclave.h with RTI features that are specific to federations and are not
+ * used by scheduling enclaves.
  */
 
 #ifndef RTI_LIB_H

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -1688,7 +1688,7 @@ void wait_until_port_status_known(environment_t* env, int port_ID, interval_t ST
  *  scalar and 0 for no payload.
  * @return A handle to the event, or 0 if no event was scheduled, or -1 for error.
  */
-static trigger_handle_t schedule_message_received_from_network_already_locked(
+static trigger_handle_t schedule_message_received_from_network_locked(
         environment_t* env,
         trigger_t* trigger,
         tag_t tag,
@@ -2068,7 +2068,7 @@ void handle_tagged_message(environment_t* env, int socket, int fed_id) {
         }
 
         LF_PRINT_LOG("Calling schedule with tag " PRINTF_TAG ".", intended_tag.time - start_time, intended_tag.microstep);
-        schedule_message_received_from_network_already_locked(env, action->trigger, intended_tag, message_token);
+        schedule_message_received_from_network_locked(env, action->trigger, intended_tag, message_token);
     }
 
 
@@ -2302,7 +2302,7 @@ void _lf_fd_send_stop_request_to_rti(environment_t* env) {
     }
     LF_PRINT_LOG("Requesting the whole program to stop.");
     // Raise a logical time barrier at the current tag.
-    _lf_increment_global_tag_barrier_already_locked(env, env->current_tag);
+    _lf_increment_global_tag_barrier_locked(env, env->current_tag);
 
     // Send a stop request with the current tag to the RTI
     unsigned char buffer[MSG_TYPE_STOP_REQUEST_LENGTH];
@@ -2440,7 +2440,7 @@ void handle_stop_request_message(environment_t* env) {
 
     // Raise a barrier at current tag
     // because we are sending it to the RTI
-    _lf_increment_global_tag_barrier_already_locked(env, tag_to_stop);
+    _lf_increment_global_tag_barrier_locked(env, tag_to_stop);
 
     // A subsequent call to lf_request_stop will be a no-op.
     _fed.sent_a_stop_request_to_rti = true;

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -1059,7 +1059,7 @@ void connect_to_rti(const char* hostname, int port) {
         // Get address structure matching hostname and hints criteria, and
         // set port to the port number provided in str. There should only 
         // ever be one matching address structure, and we connect to that.
-        int server = getaddrinfo(hostname, &str, &hints, &res);
+        int server = getaddrinfo(hostname, (const char*)&str, &hints, &res);
         if (server != 0) {
             lf_print_error_and_exit("No host for RTI matching given hostname: %s", hostname);
         }
@@ -2309,7 +2309,7 @@ void _lf_fd_send_stop_request_to_rti(tag_t stop_tag) {
     tracepoint_federate_to_rti(_fed.trace, send_STOP_REQ, _lf_my_fed_id, &env->current_tag);
     write_to_socket_errexit_with_mutex(_fed.socket_TCP_RTI, MSG_TYPE_STOP_REQUEST_LENGTH,
             buffer, &outbound_socket_mutex,
-            "Failed to send stop time " PRINTF_TIME " to the RTI.", env->current_tag.time - start_time);
+            "Failed to send stop time " PRINTF_TIME " to the RTI.", stop_tag.time - start_time);
     lf_mutex_unlock(&outbound_socket_mutex);
     _fed.sent_a_stop_request_to_rti = true;
 }
@@ -2356,7 +2356,7 @@ void handle_stop_granted_message() {
                     env[i].stop_tag.time - start_time,
                     env[i].stop_tag.microstep);
 
-        _lf_decrement_tag_barrier_locked(env[i]);
+        _lf_decrement_tag_barrier_locked(&env[i]);
         // We signal instead of broadcast under the assumption that only
         // one worker thread can call wait_until at a given time because
         // the call to wait_until is protected by a mutex lock

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -1101,7 +1101,7 @@ void connect_to_rti(const char* hostname, int port) {
                 lf_print_error_and_exit("Failed to connect to the RTI after %d retries. Giving up.",
                                      CONNECT_NUM_RETRIES);
             }
-            lf_print("Could not connect to RTI at %s. Will try again every %d seconds.",
+            lf_print("Could not connect to RTI at %s. Will try again every %lld seconds.",
                    hostname, CONNECT_RETRY_INTERVAL / BILLION);
             // Wait CONNECT_RETRY_INTERVAL nanoseconds.
             if (lf_sleep(CONNECT_RETRY_INTERVAL) != 0) {
@@ -2306,7 +2306,7 @@ void _lf_fd_send_stop_request_to_rti(tag_t stop_tag) {
         return;
     }
     // Trace the event when tracing is enabled
-    tracepoint_federate_to_rti(_fed.trace, send_STOP_REQ, _lf_my_fed_id, &env->current_tag);
+    tracepoint_federate_to_rti(_fed.trace, send_STOP_REQ, _lf_my_fed_id, &stop_tag);
     write_to_socket_errexit_with_mutex(_fed.socket_TCP_RTI, MSG_TYPE_STOP_REQUEST_LENGTH,
             buffer, &outbound_socket_mutex,
             "Failed to send stop time " PRINTF_TIME " to the RTI.", stop_tag.time - start_time);

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -1635,7 +1635,7 @@ void wait_until_port_status_known(environment_t* env, int port_ID, interval_t ST
     // for the current tag could have been received in time
     // but not the the body of the message.
     // Wait on the tag barrier based on the current tag. 
-    _lf_wait_ontag_barrier(env, env->current_tag);
+    _lf_wait_on_tag_barrier(env, env->current_tag);
 
     // Done waiting
     // If the status of the port is still unknown, assume it is absent.

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -2388,9 +2388,9 @@ void handle_stop_request_message() {
     lf_mutex_unlock(&outbound_socket_mutex);
 
     extern lf_mutex_t global_mutex;
-    extern bool stop_requested;
+    extern bool lf_stop_requested;
     lf_mutex_lock(&global_mutex);
-    if (stop_requested) {
+    if (lf_stop_requested) {
         already_blocked = true;
     }
     lf_mutex_unlock(&global_mutex);

--- a/core/reactor.c
+++ b/core/reactor.c
@@ -360,7 +360,7 @@ int lf_reactor_c_main(int argc, const char* argv[]) {
         signal(SIGINT, exit);
 #endif
         // Create and initialize the environment
-        _lf_create_environments();
+        _lf_create_environments();   // code-generated function
         environment_t *env;
         int num_environments = _lf_get_environments(&env);
         lf_assert(num_environments == 1,

--- a/core/reactor.c
+++ b/core/reactor.c
@@ -306,12 +306,11 @@ int next(environment_t* env) {
     return _lf_do_step(env);
 }
 
-/**
- * Stop execution at the conclusion of the next microstep.
- * @param env Environment in which we are executing
- */
-void _lf_request_stop(environment_t *env) {
-    assert(env != GLOBAL_ENVIRONMENT);
+void lf_request_stop() {
+    // There is only one enclave, so get its environment.
+    environment_t *env;
+    int num_environments = _lf_get_environments(&env);
+    assert(num_environments == 1);
 
 	tag_t new_stop_tag;
 	new_stop_tag.time = env->current_tag.time;

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -200,6 +200,7 @@ int _lf_wait_ontag_barrier(environment_t* env, tag_t proposed_tag) {
             proposed_tag = env->stop_tag;
         }
     }
+    LF_PRINT_LOG("Finished waiting on barrier for tag " PRINTF_TAG ".", proposed_tag.time - start_time, proposed_tag.microstep);
     return result;
 }
 
@@ -588,12 +589,9 @@ void lf_request_stop() {
 
 #ifdef FEDERATED
     _lf_fd_send_stop_request_to_rti(max_current_tag);
-    // Do not set stop_requested
-    // since the RTI might grant a
-    // later stop tag than the current
-    // tag. The above code has raised
-    // a barrier no greater than the requested
-    // stop tag for each enclave.
+    // Do not set stop_requested because the RTI might grant a
+    // later stop tag than the current tag. The above code has raised
+    // a barrier no greater than the requested stop tag for each enclave.
 #else
     // In a non-federated program, the stop_tag will be the next microstep after max_current_tag.
     // Iterate over environments to set their stop tag and release their barrier.

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -562,17 +562,17 @@ void _lf_next_locked(environment_t *env) {
 /**
  * @brief True if stop has been requested so it doesn't get re-requested.
  */
-bool stop_requested = false;
+bool lf_stop_requested = false;
 
 // See reactor.h for docs.
 void lf_request_stop() {
     // If a requested stop is pending, return without doing anything.
     lf_mutex_lock(&global_mutex);
-    if (stop_requested) {
+    if (lf_stop_requested) {
         lf_mutex_unlock(&global_mutex);
         return;
     }
-    stop_requested = true;
+    lf_stop_requested = true;
     lf_mutex_unlock(&global_mutex);
 
     // Iterate over scheduling enclaves to find their maximum current tag
@@ -591,7 +591,7 @@ void lf_request_stop() {
     }
 
 #ifdef FEDERATED
-    // In the federated case, do not set stop_requested because the RTI might grant a
+    // In the federated case, do not set lf_stop_requested because the RTI might grant a
     // later stop tag than the current tag. The above code has raised
     // a barrier no greater than the requested stop tag for each enclave.
     if (_lf_fd_send_stop_request_to_rti(max_current_tag) != 0) {

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -558,8 +558,22 @@ void _lf_next_locked(environment_t *env) {
     _lf_pop_events(env);
 }
 
+/**
+ * @brief True if stop has been requested so it doesn't get re-requested.
+ */
+bool stop_requested = false;
+
 // See reactor.h for docs.
 void lf_request_stop() {
+    // If a requested stop is pending, return without doing anything.
+    lf_mutex_lock(&global_mutex);
+    if (stop_requested) {
+        lf_mutex_unlock(&global_mutex);
+        return;
+    }
+    stop_requested = true;
+    lf_mutex_unlock(&global_mutex);
+
     // Iterate over scheduling enclaves to find their maximum current tag
     // and set a barrier for tag advancement for each enclave.
     tag_t max_current_tag = NEVER_TAG;

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -562,7 +562,7 @@ void _lf_next_locked(environment_t *env) {
 /**
  * @brief True if stop has been requested so it doesn't get re-requested.
  */
-static bool stop_requested = false;
+bool stop_requested = false;
 
 // See reactor.h for docs.
 void lf_request_stop() {

--- a/include/api/set.h
+++ b/include/api/set.h
@@ -213,14 +213,11 @@ do { \
 #endif // CTARGET_SET
 
 // For simplicity and backward compatability, dont require the environment-pointer when calling the timing API.
-// Since this is always done from the context of a reaction `self` is in scope and is a pointer to the self-struct
+// As long as this is done from the context of a reaction, `self` is in scope and is a pointer to the self-struct
 // of the current reactor. 
 #define lf_tag() lf_tag(self->base.environment)
 #define get_current_tag() get_current_tag(self->base.environment)
 #define get_microstep() get_microstep(self->base.environment)
-
-#define lf_request_stop() _lf_request_stop(self->base.environment)
-
 #define lf_time_logical() lf_time_logical(self->base.environment)
 #define lf_time_logical_elapsed() lf_time_logical_elapsed(self->base.environment)
 #define get_elapsed_logical_time() get_elapsed_logical_time(self->base.environment)

--- a/include/core/federated/federate.h
+++ b/include/core/federated/federate.h
@@ -173,10 +173,10 @@ typedef struct federate_instance_t {
 
     /**
      * Used to prevent the federate from sending a REQUEST_STOP
-     * message multiple times to the RTI.
+     * message if it has already received a stop request from the RTI.
      * This variable should only be accessed while holding a mutex lock.
      */
-    bool sent_a_stop_request_to_rti;
+    bool received_stop_request_from_rti;
 
     /**
      * A record of the most recently sent LTC (logical tag complete) message.

--- a/include/core/federated/federate.h
+++ b/include/core/federated/federate.h
@@ -436,14 +436,8 @@ int send_timed_message(environment_t*,
  * and _lf_rti_socket_TCP is valid. It then sends the current logical
  * time to the RTI and waits for the RTI to respond with a specified
  * time. It starts a thread to listen for messages from the RTI.
- * It then waits for physical time to match the specified time,
- * sets current logical time to the time returned by the RTI,
- * and then returns. If --fast was specified, then this does
- * not wait for physical time to match the logical start time
- * returned by the RTI.
- * @param env The environment in which we are executing
  */
-void synchronize_with_other_federates(environment_t* env);
+void synchronize_with_other_federates();
 
 /**
  * Wait until the status of network port "port_ID" is known.

--- a/include/core/federated/federate.h
+++ b/include/core/federated/federate.h
@@ -174,7 +174,7 @@ typedef struct federate_instance_t {
     /**
      * Used to prevent the federate from sending a REQUEST_STOP
      * message multiple times to the RTI.
-     * This variable should only be accessed while holding the mutex lock.
+     * This variable should only be accessed while holding a mutex lock.
      */
     bool sent_a_stop_request_to_rti;
 

--- a/include/core/reactor.h
+++ b/include/core/reactor.h
@@ -524,7 +524,7 @@ trigger_handle_t _lf_schedule_value(lf_action_base_t* action, interval_t extra_d
 trigger_handle_t _lf_schedule_copy(lf_action_base_t* action, interval_t offset, void* value, size_t length);
 
 // See reactor.h for doc.
-void _lf_fd_send_stop_request_to_rti(tag_t stop_tag);
+int _lf_fd_send_stop_request_to_rti(tag_t stop_tag);
 
 /**
  * @brief Will update the argument to point to the beginning of the array of environments in this program

--- a/include/core/reactor.h
+++ b/include/core/reactor.h
@@ -315,20 +315,18 @@ void lf_set_stp_offset(interval_t offset);
 /**
  * Print a snapshot of the priority queues used during execution
  * (for debugging).
- * @param env The environment in which we are execution
+ * @param env The environment in which we are executing.
  */
 void lf_print_snapshot(environment_t* env);
 
 /**
  * Request a stop to execution as soon as possible.
- * In a non-federated execution, this will occur
- * at the conclusion of the current logical time.
- * In a federated execution, it will likely occur at
- * a later logical time determined by the RTI so that
- * all federates stop at the same logical time.
- * @param env The environment in which we are execution
+ * In a non-federated execution with only a single enclave, this will occur
+ * one microstep later than the current tag. In a federated execution or when
+ * there is more than one enclave, it will likely occur at a later tag determined
+ * by the RTI so that all federates and enclaves stop at the same tag.
  */
-void _lf_request_stop(environment_t *env);
+void lf_request_stop();
 
 /**
  * Allocate zeroed-out memory and record the allocated memory on
@@ -525,12 +523,8 @@ trigger_handle_t _lf_schedule_value(lf_action_base_t* action, interval_t extra_d
  */
 trigger_handle_t _lf_schedule_copy(lf_action_base_t* action, interval_t offset, void* value, size_t length);
 
-/**
- * For a federated execution, send a STOP_REQUEST message
- * to the RTI.
- * @param env The environment in which we are executing
- */
-void _lf_fd_send_stop_request_to_rti(environment_t* env);
+// See reactor.h for doc.
+void _lf_fd_send_stop_request_to_rti(tag_t stop_tag);
 
 /**
  * @brief Will update the argument to point to the beginning of the array of environments in this program

--- a/include/core/threaded/reactor_threaded.h
+++ b/include/core/threaded/reactor_threaded.h
@@ -15,7 +15,7 @@ void enqueue_network_input_control_reactions(environment_t* env);
  * @param env The environment in which we are executing
  */
 void enqueue_network_output_control_reactions(environment_t* env);
-void _lf_increment_global_tag_barrier_already_locked(environment_t *env, tag_t future_tag);
+void _lf_increment_global_tag_barrier_locked(environment_t *env, tag_t future_tag);
 void _lf_increment_global_tag_barrier(environment_t *env, tag_t future_tag);
 void _lf_decrement_global_tag_barrier_locked(environment_t* env);
 int _lf_wait_on_global_tag_barrier(environment_t* env, tag_t proposed_tag);

--- a/include/core/threaded/reactor_threaded.h
+++ b/include/core/threaded/reactor_threaded.h
@@ -76,7 +76,7 @@ void _lf_increment_tag_barrier_locked(environment_t *env, tag_t future_tag);
 void _lf_decrement_tag_barrier_locked(environment_t* env);
 
 int _lf_wait_ontag_barrier(environment_t* env, tag_t proposed_tag);
-void synchronize_with_other_federates(environment_t* env);
+void synchronize_with_other_federates(void);
 bool wait_until(environment_t* env, instant_t logical_time_ns, lf_cond_t* condition);
 tag_t get_next_event_tag(environment_t* env);
 tag_t send_next_event_tag(environment_t* env, tag_t tag, bool wait_for_reply);

--- a/include/core/threaded/reactor_threaded.h
+++ b/include/core/threaded/reactor_threaded.h
@@ -75,7 +75,7 @@ void _lf_increment_tag_barrier_locked(environment_t *env, tag_t future_tag);
  */
 void _lf_decrement_tag_barrier_locked(environment_t* env);
 
-int _lf_wait_ontag_barrier(environment_t* env, tag_t proposed_tag);
+int _lf_wait_on_tag_barrier(environment_t* env, tag_t proposed_tag);
 void synchronize_with_other_federates(void);
 bool wait_until(environment_t* env, instant_t logical_time_ns, lf_cond_t* condition);
 tag_t get_next_event_tag(environment_t* env);

--- a/include/core/threaded/reactor_threaded.h
+++ b/include/core/threaded/reactor_threaded.h
@@ -23,7 +23,7 @@ void enqueue_network_output_control_reactions(environment_t* env);
  * prevent any further advances. This function will increment the
  * total number of pending barrier requests. For each call to this
  * function, there should always be a subsequent call to
- * _lf_decrementtag_barrier_locked()
+ * _lf_decrement_tag_barrier_locked()
  * to release the barrier.
  *
  * If there is already a barrier raised at a tag later than future_tag, this
@@ -45,10 +45,10 @@ void enqueue_network_output_control_reactions(environment_t* env);
  * If future_tag is in the past (or equals to current logical time), the runtime
  * will freeze advancement of logical time.
  */
-void _lf_incrementtag_barrier(environment_t *env, tag_t future_tag);
+void _lf_increment_tag_barrier(environment_t *env, tag_t future_tag);
 
 /**
- * @brief Version of _lf_incrementtag_barrier to call when the caller holds the mutex.
+ * @brief Version of _lf_increment_tag_barrier to call when the caller holds the mutex.
  * This version does not acquire the mutex belonging to env.
  * 
  * @param env Environment within which we are executing.
@@ -57,7 +57,7 @@ void _lf_incrementtag_barrier(environment_t *env, tag_t future_tag);
  * If future_tag is in the past (or equals to current logical time), the runtime
  * will freeze advancement of logical time.
  */
-void _lf_incrementtag_barrier_locked(environment_t *env, tag_t future_tag);
+void _lf_increment_tag_barrier_locked(environment_t *env, tag_t future_tag);
 
 /**
  * Decrement the total number of pending barrier requests for the environment tag barrier.
@@ -73,7 +73,7 @@ void _lf_incrementtag_barrier_locked(environment_t *env, tag_t future_tag);
  *
  * @param env The environment in which we are executing.
  */
-void _lf_decrementtag_barrier_locked(environment_t* env);
+void _lf_decrement_tag_barrier_locked(environment_t* env);
 
 int _lf_wait_ontag_barrier(environment_t* env, tag_t proposed_tag);
 void synchronize_with_other_federates(environment_t* env);

--- a/python/lib/pythontarget.c
+++ b/python/lib/pythontarget.c
@@ -151,7 +151,7 @@ int lf_reactor_c_main(int argc, const char *argv[]);
  * Prototype for lf_request_stop().
  * @see reactor.h
  */
-int lf_request_stop(environment_t* env);
+void lf_request_stop(void);
 
 ///////////////// Other useful functions /////////////////////
 /**

--- a/python/lib/pythontarget.c
+++ b/python/lib/pythontarget.c
@@ -151,14 +151,14 @@ int lf_reactor_c_main(int argc, const char *argv[]);
  * Prototype for lf_request_stop().
  * @see reactor.h
  */
-void _lf_request_stop(environment_t* env);
+int lf_request_stop(environment_t* env);
 
 ///////////////// Other useful functions /////////////////////
 /**
  * Stop execution at the conclusion of the current logical time.
  */
 PyObject* py_request_stop(PyObject *self, PyObject *args) {
-    _lf_request_stop(top_level_environment);
+    lf_request_stop();
 
     Py_INCREF(Py_None);
     return Py_None;
@@ -294,7 +294,7 @@ static PyMethodDef GEN_NAME(MODULE_NAME,_methods)[] = {
   {"schedule_copy", py_schedule_copy, METH_VARARGS, NULL},
   {"tag", py_lf_tag, METH_NOARGS, NULL},
   {"tag_compare", py_tag_compare, METH_VARARGS, NULL},
-  {"request_stop", py_request_stop, METH_NOARGS, NULL},
+  {"request_stop", py_request_stop, METH_NOARGS, "Request stop"},
   {NULL, NULL, 0, NULL}
 };
 


### PR DESCRIPTION
This PR reworks lf_request_stop() to work with enclaves. It no longer requires an environment argument and it should also work with federations.