### PR TITLE
Memory leak in Python target fixed

### DIFF
--- a/core/lf_token.c
+++ b/core/lf_token.c
@@ -143,11 +143,11 @@ void _lf_free_token_value(lf_token_t* token) {
         }
         // If Python Target is not enabled and destructor is NULL
         // Token values should be freed
-#ifndef _PYTHON_TARGET_ENABLED
         else {
+#ifndef _PYTHON_TARGET_ENABLED
             free(token->value);
-        }
 #endif
+        }
         token->value = NULL;
     }
 }

--- a/core/lf_token.c
+++ b/core/lf_token.c
@@ -138,7 +138,6 @@ void _lf_free_token_value(lf_token_t* token) {
         LF_PRINT_DEBUG("_lf_free_token_value: Freeing allocated memory for payload (token value): %p",
             token->value);
         // First check the token's destructor field and invoke it if it is not NULL.
-        // in which case token's destructor should be invoked.
         if (token->type->destructor != NULL) {
             token->type->destructor(token->value);
         }

--- a/core/lf_token.c
+++ b/core/lf_token.c
@@ -142,7 +142,7 @@ void _lf_free_token_value(lf_token_t* token) {
         if (token->type->destructor != NULL) {
             token->type->destructor(token->value);
         }
-        // If Python Target is enabled and destructor is NULL
+        // If Python Target is not enabled and destructor is NULL
         // Token values should be freed
 #ifndef _PYTHON_TARGET_ENABLED
         else {

--- a/core/lf_token.c
+++ b/core/lf_token.c
@@ -137,7 +137,7 @@ void _lf_free_token_value(lf_token_t* token) {
         // Free the value field (the payload).
         LF_PRINT_DEBUG("_lf_free_token_value: Freeing allocated memory for payload (token value): %p",
             token->value);
-        // First check whether the token value field is not NULL
+        // First check the token's destructor field and invoke it if it is not NULL.
         // in which case token's destructor should be invoked.
         if (token->type->destructor != NULL) {
             token->type->destructor(token->value);

--- a/python/include/python_port.h
+++ b/python/include/python_port.h
@@ -98,4 +98,5 @@ typedef struct {
     FEDERATED_CAPSULE_EXTENSION
 } generic_port_capsule_struct;
 
+void python_count_decrement(void* py_object);
 #endif

--- a/python/lib/python_port.c
+++ b/python/lib/python_port.c
@@ -99,7 +99,7 @@ PyObject* py_port_set(PyObject* self, PyObject* args) {
 
     if (val) {
         LF_PRINT_DEBUG("Setting value %p.", val);
-        Py_XDECREF(port->value);
+        python_count_decrement(port->value);
 
         // 1. Call lf_new_token function to create a new token
         // 2. Set destructor and assign value to the port 

--- a/python/lib/python_port.c
+++ b/python/lib/python_port.c
@@ -100,10 +100,7 @@ PyObject* py_port_set(PyObject* self, PyObject* args) {
     if (val) {
         LF_PRINT_DEBUG("Setting value %p.", val);
         python_count_decrement(port->value);
-
-        // 1. Call lf_new_token function to create a new token
-        // 2. Set destructor and assign value to the port 
-        // Py_INCREF(val) is unnecessary 
+       
         lf_token_t* token = lf_new_token((void*)port, val, 1);
         lf_set_destructor(port, python_count_decrement);
         lf_set_token(port, token);

--- a/python/lib/python_port.c
+++ b/python/lib/python_port.c
@@ -43,9 +43,9 @@ PyTypeObject py_port_capsule_t;
 
 //////////// destructor Function(s) /////////////
 /**
- * Called when putting token to the recycling bin. This function decreases the 
- * reference count of PyObject and allows python to collect garbage later.
- * @param py_object A PyObject with count 1*
+ * Decrease the reference count of PyObject. When the reference count hits zero,
+ * Python can free its memory.
+ * @param py_object A PyObject with count 1 or greater.
  */
 void python_count_decrement(void* py_object) {
     Py_XDECREF((PyObject*)py_object);

--- a/python/lib/python_port.c
+++ b/python/lib/python_port.c
@@ -56,9 +56,8 @@ void python_count_decrement(void* py_object) {
  * @param py_object A PyObject with count 1 or greater.
  */
 void output_port_destructor(void* py_object) {
-    while (Py_REFCNT(py_object) >= 0) {
-        Py_XDECREF((PyObject*)py_object);
-    }
+   Py_XDECREF((PyObject*)py_object);
+   Py_XDECREF((PyObject*)py_object);
 }
 
 //////////// set Function(s) /////////////
@@ -108,11 +107,11 @@ PyObject* py_port_set(PyObject* self, PyObject* args) {
 
     if (val) {
         LF_PRINT_DEBUG("Setting value %p.", val);
-        Py_INCREF(val);
-        python_count_decrement(port->value);
+        //Py_INCREF(val);
+        //python_count_decrement(port->value);
        
         lf_token_t* token = lf_new_token((void*)port, val, 1);
-        lf_set_destructor(port, output_port_destructor);
+        lf_set_destructor(port, python_count_decrement); //change python_count_decrement to output_port_destructor would fix memory leak during federated execution. 
         lf_set_token(port, token);
         Py_INCREF(val);
        

--- a/python/lib/python_port.c
+++ b/python/lib/python_port.c
@@ -98,7 +98,7 @@ PyObject* py_port_set(PyObject* self, PyObject* args) {
     }
 
     if (val) {
-        LF_PRINT_DEBUG("Setting value lol %p.", val);
+        LF_PRINT_DEBUG("Setting value %p.", val);
         Py_XDECREF(port->value);
 
         // 1. Call lf_new_token function to create a new token

--- a/python/lib/python_port.c
+++ b/python/lib/python_port.c
@@ -51,15 +51,6 @@ void python_count_decrement(void* py_object) {
     Py_XDECREF((PyObject*)py_object);
 }
 
-/**
- * Decrease the reference count of PyObject for output port.
- * @param py_object A PyObject with count 1 or greater.
- */
-void output_port_destructor(void* py_object) {
-   Py_XDECREF((PyObject*)py_object);
-   Py_XDECREF((PyObject*)py_object);
-}
-
 //////////// set Function(s) /////////////
 /**
  * Set the value and is_present field of self which is of type
@@ -106,12 +97,12 @@ PyObject* py_port_set(PyObject* self, PyObject* args) {
     }
 
     if (val) {
-        LF_PRINT_DEBUG("Setting value %p.", val);
+        LF_PRINT_DEBUG("Setting value %p with reference count %d.", val, (int) Py_REFCNT(val));
         //Py_INCREF(val);
         //python_count_decrement(port->value);
        
         lf_token_t* token = lf_new_token((void*)port, val, 1);
-        lf_set_destructor(port, python_count_decrement); //change python_count_decrement to output_port_destructor would fix memory leak during federated execution. 
+        lf_set_destructor(port, python_count_decrement);
         lf_set_token(port, token);
         Py_INCREF(val);
        

--- a/python/lib/python_port.c
+++ b/python/lib/python_port.c
@@ -36,8 +36,21 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "python_port.h"
 #include "reactor.h"
+#include "api/api.h"
+#include "api/set.h"
 
 PyTypeObject py_port_capsule_t;
+
+//////////// destructor Function(s) /////////////
+/**
+ * Called when putting token to the recycling bin. This function decreases the 
+ * reference count of PyObject and allows python to collect garbage later.
+ * @param py_object A PyObject with count 1*
+ */
+void python_count_decrement(void* py_object) {
+    Py_XDECREF((PyObject*)py_object);
+}
+
 
 //////////// set Function(s) /////////////
 /**
@@ -68,7 +81,7 @@ PyTypeObject py_port_capsule_t;
  * @param args contains:
  *      - val: The value to insert into the port struct.
  */
-PyObject* py_port_set(PyObject *self, PyObject *args) {
+PyObject* py_port_set(PyObject* self, PyObject* args) {
     generic_port_capsule_struct* p = (generic_port_capsule_struct*)self;
     PyObject* val = NULL;
 
@@ -85,13 +98,16 @@ PyObject* py_port_set(PyObject *self, PyObject *args) {
     }
 
     if (val) {
-        LF_PRINT_DEBUG("Setting value %p.", val);
+        LF_PRINT_DEBUG("Setting value lol %p.", val);
         Py_XDECREF(port->value);
-        Py_INCREF(val);
-        // Call the core lib API to set the port
-        _LF_SET(port, val);
 
-        Py_INCREF(val);
+        // 1. Call lf_new_token function to create a new token
+        // 2. Set destructor and assign value to the port 
+        // Py_INCREF(val) is unnecessary 
+        lf_token_t* token = lf_new_token((void*)port, val, 1);
+        lf_set_destructor(port, python_count_decrement);
+        lf_set_token(port, token);
+
         // Also set the values for the port capsule.
         p->value = val;
         p->is_present = true;


### PR DESCRIPTION
This pull request addresses a memory leak issue observed in the current implementation. As shown in the following screenshot, it is noticeable that with each iteration, the size of Python objects constructed using C extensions continues to grow.

![Untitled picture](https://github.com/lf-lang/reactor-c/assets/77720778/12b29507-3132-4139-98f8-6c7b29f21d7b)

This problem could be attributed to several key issues, which are as follows:

1.	PyObject Reference Count: The reference counts for the majority of `PyObjects` are not being appropriately managed. 
2.	Port Assignment: Rather than using the `_LF_SET` macro to assign values to the` generic_port_instance_struct` in the current implementation, the more suitable method would be to use `lf_set_token` and define a destructor for the token to ensure proper garbage collection.

3. Function Definition: The existing` _lf_free_token_value` function is incorrect and fails to invoke the destructor.

Comments have been added to the code within the commits to provide additional context and insight into the changes made. Other related changes have also been made in the code generator repository ([LINK](https://github.com/lf-lang/lingua-franca/pull/1873)).

Please feel free to comment if further modifications are required. Similar issues persist during the federated multiport setting. To address this, a separate PR will be submitted later.
