### PR TITLE
Use of correct federate ID in tracing of absent messages

### DIFF
--- a/core/federated/RTI/rti_lib.c
+++ b/core/federated/RTI/rti_lib.c
@@ -306,7 +306,7 @@ void handle_port_absent_message(federate_t* sending_federate, unsigned char* buf
     tag_t tag = extract_tag(&(buffer[1 + 2 * sizeof(uint16_t)]));
 
     if (_f_rti->tracing_enabled) {
-        tracepoint_rti_from_federate(_f_rti->trace, receive_PORT_ABS, federate_id, &tag);
+        tracepoint_rti_from_federate(_f_rti->trace, receive_PORT_ABS, sending_federate, &tag);
     }
 
     // Need to acquire the mutex lock to ensure that the thread handling

--- a/core/federated/RTI/rti_lib.c
+++ b/core/federated/RTI/rti_lib.c
@@ -306,7 +306,7 @@ void handle_port_absent_message(federate_t* sending_federate, unsigned char* buf
     tag_t tag = extract_tag(&(buffer[1 + 2 * sizeof(uint16_t)]));
 
     if (_f_rti->tracing_enabled) {
-        tracepoint_rti_from_federate(_f_rti->trace, receive_PORT_ABS, sending_federate, &tag);
+        tracepoint_rti_from_federate(_f_rti->trace, receive_PORT_ABS, sending_federate->enclave.id, &tag);
     }
 
     // Need to acquire the mutex lock to ensure that the thread handling

--- a/lingua-franca-ref.txt
+++ b/lingua-franca-ref.txt
@@ -1,1 +1,1 @@
-9acca40d53151aa79a5679ed1fcc675f3afb2e45
+master


### PR DESCRIPTION
This PR fixes the wrong federate id when tracing a received ABS message by the RTI.