### PR TITLE
Critical sections enabled outside of the context of a reactor

### DIFF
--- a/core/federated/RTI/rti_lib.c
+++ b/core/federated/RTI/rti_lib.c
@@ -38,23 +38,11 @@ lf_mutex_t rti_mutex;
 lf_cond_t received_start_times;
 lf_cond_t sent_start_time;
 
-/**
- * Enter a critical section where logical time and the event queue are guaranteed
- * to not change unless they are changed within the critical section.
- * this can be implemented by disabling interrupts.
- * Users of this function must ensure that lf_init_critical_sections() is
- * called first and that lf_critical_section_exit() is called later.
- * @return 0 on success, platform-specific error number otherwise.
- */
-extern int lf_critical_section_enter() {
+extern int lf_critical_section_enter(environment_t* env) {
     return lf_mutex_lock(&rti_mutex);
 }
 
-/**
- * Exit the critical section entered with lf_lock_time().
- * @return 0 on success, platform-specific error number otherwise.
- */
-extern int lf_critical_section_exit() {
+extern int lf_critical_section_exit(environment_t* env) {
     return lf_mutex_unlock(&rti_mutex);
 }
 

--- a/core/federated/RTI/rti_lib.h
+++ b/core/federated/RTI/rti_lib.h
@@ -190,15 +190,17 @@ typedef struct federation_rti_t {
  * this can be implemented by disabling interrupts.
  * Users of this function must ensure that lf_init_critical_sections() is
  * called first and that lf_critical_section_exit() is called later.
+ * @param env Ignored (present for compatibility).
  * @return 0 on success, platform-specific error number otherwise.
  */
-extern int lf_critical_section_enter();
+extern int lf_critical_section_enter(environment_t* env);
 
 /**
  * Exit the critical section entered with lf_lock_time().
+ * @param env Ignored (present for compatibility).
  * @return 0 on success, platform-specific error number otherwise.
  */
-extern int lf_critical_section_exit();
+extern int lf_critical_section_exit(environment_t* env);
 
 /**
  * Create a server and enable listening for socket connections.

--- a/core/reactor.c
+++ b/core/reactor.c
@@ -396,26 +396,14 @@ int lf_reactor_c_main(int argc, const char* argv[]) {
     }
 }
 
-/**
- * @brief Notify of new event by calling the unthreaded platform API
- * @param env Environment in which we are executing.
- */
 int lf_notify_of_event(environment_t* env) {
     return _lf_unthreaded_notify_of_event();
 }
 
-/**
- * @brief Enter critical section by disabling interrupts
- * @param env Environment in which we are executing.
- */
 int lf_critical_section_enter(environment_t* env) {
     return lf_disable_interrupts_nested();
 }
 
-/**
- * @brief Leave a critical section by enabling interrupts
- * @param env Environment in which we are executing.
- */
 int lf_critical_section_exit(environment_t* env) {
     return lf_enable_interrupts_nested();
 }

--- a/include/core/federated/net_util.h
+++ b/include/core/federated/net_util.h
@@ -54,10 +54,13 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define HOST_LITTLE_ENDIAN 1
 #define HOST_BIG_ENDIAN 2
 
-/** Return true (1) if the host is big endian. Otherwise,
- *  return false.
+/** 
+ * Return true (1) if the host is big endian. Otherwise,
+ * return false.
  */
 int host_is_big_endian(void);
+
+#ifdef FEDERATED
 
 /**
  * Read the specified number of bytes from the specified socket into the
@@ -157,91 +160,103 @@ ssize_t write_to_socket_errexit(
  */
 int write_to_socket2(int socket, int num_bytes, unsigned char* buffer);
 
-/** Write the specified data as a sequence of bytes starting
- *  at the specified address. This encodes the data in little-endian
- *  order (lowest order byte first).
- *  @param data The data to write.
- *  @param buffer The location to start writing.
+#endif // FEDERATED
+
+/**
+ * Write the specified data as a sequence of bytes starting
+ * at the specified address. This encodes the data in little-endian
+ * order (lowest order byte first).
+ * @param data The data to write.
+ * @param buffer The location to start writing.
  */
 void encode_int64(int64_t data, unsigned char* buffer);
 
-/** Write the specified data as a sequence of bytes starting
- *  at the specified address. This encodes the data in little-endian
- *  order (lowest order byte first). This works for int32_t.
- *  @param data The data to write.
- *  @param buffer The location to start writing.
+/** 
+ * Write the specified data as a sequence of bytes starting
+ * at the specified address. This encodes the data in little-endian
+ * order (lowest order byte first). This works for int32_t.
+ * @param data The data to write.
+ * @param buffer The location to start writing.
  */
 void encode_int32(int32_t data, unsigned char* buffer);
 
-/** Write the specified data as a sequence of bytes starting
- *  at the specified address. This encodes the data in little-endian
- *  order (lowest order byte first). This works for uint32_t.
- *  @param data The data to write.
- *  @param buffer The location to start writing.
+/**
+ * Write the specified data as a sequence of bytes starting
+ * at the specified address. This encodes the data in little-endian
+ * order (lowest order byte first). This works for uint32_t.
+ * @param data The data to write.
+ * @param buffer The location to start writing.
  */
 void encode_uint32(uint32_t data, unsigned char* buffer);
 
-/** Write the specified data as a sequence of bytes starting
- *  at the specified address. This encodes the data in little-endian
- *  order (lowest order byte first).
- *  @param data The data to write.
- *  @param buffer The location to start writing.
+/** 
+ * Write the specified data as a sequence of bytes starting
+ * at the specified address. This encodes the data in little-endian
+ * order (lowest order byte first).
+ * @param data The data to write.
+ * @param buffer The location to start writing.
  */
 void encode_uint16(uint16_t data, unsigned char* buffer);
 
-/** If this host is little endian, then reverse the order of
- *  the bytes of the argument. Otherwise, return the argument
- *  unchanged. This can be used to convert the argument to
- *  network order (big endian) and then back again.
- *  Network transmissions, by convention, are big endian,
- *  meaning that the high-order byte is sent first.
- *  But many platforms, including my Mac, are little endian,
- *  meaning that the low-order byte is first in memory.
- *  @param src The argument to convert.
+/** 
+ * If this host is little endian, then reverse the order of
+ * the bytes of the argument. Otherwise, return the argument
+ * unchanged. This can be used to convert the argument to
+ * network order (big endian) and then back again.
+ * Network transmissions, by convention, are big endian,
+ * meaning that the high-order byte is sent first.
+ * But many platforms, including my Mac, are little endian,
+ * meaning that the low-order byte is first in memory.
+ * @param src The argument to convert.
  */
 int32_t swap_bytes_if_big_endian_int32(int32_t src);
 
-/** If this host is little endian, then reverse the order of
- *  the bytes of the argument. Otherwise, return the argument
- *  unchanged. This can be used to convert the argument to
- *  network order (big endian) and then back again.
- *  Network transmissions, by convention, are big endian,
- *  meaning that the high-order byte is sent first.
- *  But many platforms, including my Mac, are little endian,
- *  meaning that the low-order byte is first in memory.
- *  @param src The argument to convert.
+/** 
+ * If this host is little endian, then reverse the order of
+ * the bytes of the argument. Otherwise, return the argument
+ * unchanged. This can be used to convert the argument to
+ * network order (big endian) and then back again.
+ * Network transmissions, by convention, are big endian,
+ * meaning that the high-order byte is sent first.
+ * But many platforms, including my Mac, are little endian,
+ * meaning that the low-order byte is first in memory.
+ * @param src The argument to convert.
  */
 int64_t swap_bytes_if_big_endian_int64(int64_t src);
 
-/** If this host is little endian, then reverse the order of
- *  the bytes of the argument. Otherwise, return the argument
- *  unchanged. This can be used to convert the argument to
- *  network order (big endian) and then back again.
- *  Network transmissions, by convention, are big endian,
- *  meaning that the high-order byte is sent first.
- *  But many platforms, including my Mac, are little endian,
- *  meaning that the low-order byte is first in memory.
- *  @param src The argument to convert.
+/** 
+ * If this host is little endian, then reverse the order of
+ * the bytes of the argument. Otherwise, return the argument
+ * unchanged. This can be used to convert the argument to
+ * network order (big endian) and then back again.
+ * Network transmissions, by convention, are big endian,
+ * meaning that the high-order byte is sent first.
+ * But many platforms, including my Mac, are little endian,
+ * meaning that the low-order byte is first in memory.
+ * @param src The argument to convert.
  */
 uint16_t swap_bytes_if_big_endian_uint16(uint16_t src);
 
-/** Extract an int32_t from the specified byte sequence.
- *  This will swap the order of the bytes if this machine is big endian.
- *  @param bytes The address of the start of the sequence of bytes.
+/**
+ * This will swap the order of the bytes if this machine is big endian.
+ * @param bytes The address of the start of the sequence of bytes.
  */
 int32_t extract_int32(unsigned char* bytes);
 
-/** Extract a int64_t from the specified byte sequence.
- *  This will swap the order of the bytes if this machine is big endian.
- *  @param bytes The address of the start of the sequence of bytes.
+/**
+ * This will swap the order of the bytes if this machine is big endian.
+ * @param bytes The address of the start of the sequence of bytes.
  */
 int64_t extract_int64(unsigned char* bytes);
 
-/** Extract an uint16_t from the specified byte sequence.
- *  This will swap the order of the bytes if this machine is big endian.
- *  @param bytes The address of the start of the sequence of bytes.
+/** 
+ * Extract an uint16_t from the specified byte sequence.
+ * This will swap the order of the bytes if this machine is big endian.
+ * @param bytes The address of the start of the sequence of bytes.
  */
 uint16_t extract_uint16(unsigned char* bytes);
+
+#ifdef FEDERATED
 
 /**
  * Extract the core header information that all messages between
@@ -319,32 +334,28 @@ typedef struct rti_addr_info_t {
 } rti_addr_info_t;
 
 /**
- * Checks if str matches regex.
+ * Check whether str matches regex.
  * @return true if there is a match, false otherwise.
  */
 bool match_regex(const char* str, char* regex);
 
-
 /**
- * Checks if port is valid.
+ * Check whether port is valid.
  * @return true if valid, false otherwise.
  */
 bool validate_port(char* port);
 
-
 /**
- * Checks if host is valid.
+ * Check whether host is valid.
  * @return true if valid, false otherwise.
  */
 bool validate_host(const char* host);
 
-
 /**
- * Checks if user is valid.
+ * Check whether user is valid.
  * @return true if valid, false otherwise.
  */
 bool validate_user(const char* user);
-
 
 /**
  * Extract one match group from the rti_addr regex .
@@ -364,5 +375,6 @@ bool extract_match_groups(const char* rti_addr, char** rti_addr_strs, bool** rti
  */
 void extract_rti_addr_info(const char* rti_addr, rti_addr_info_t* rti_addr_info);
 
+#endif // FEDERATED
 
 #endif /* NET_UTIL_H */

--- a/include/core/platform.h
+++ b/include/core/platform.h
@@ -50,6 +50,24 @@ extern "C" {
 // Forward declarations
 typedef struct environment_t environment_t;
 
+/**
+ * @brief Notify of new event by calling the unthreaded platform API
+ * @param env Environment in which we are executing.
+ */
+int lf_notify_of_event(environment_t* env);
+
+/**
+ * @brief Enter critical section by disabling interrupts
+ * @param env Environment in which we are executing.
+ */
+int lf_critical_section_enter(environment_t* env);
+
+/**
+ * @brief Leave a critical section by enabling interrupts
+ * @param env Environment in which we are executing.
+ */
+int lf_critical_section_exit(environment_t* env);
+
 #if defined(PLATFORM_ARDUINO)
     #include "platform/lf_arduino_support.h"
 #elif defined(PLATFORM_ZEPHYR)

--- a/include/core/reactor.h
+++ b/include/core/reactor.h
@@ -547,23 +547,5 @@ void _lf_create_environments();
  * runtime. Should be routed to appropriate API calls in platform.h
 */
 
-/**
- * @brief Notify other threads of new events on the event queue.
- * 
- */
-void _lf_notify_of_event();
-
-/**
- * @brief Enter critical section. Must be paired with a
- * `_lf_critical_section_exit()`
- * 
- */
-void _lf_critical_section_enter();
-
-/**
- * @brief Leave critical section
- */
-void _lf_critical_section_exit();
-
 #endif /* REACTOR_H */
 /** @} */


### PR DESCRIPTION
This PR makes it possible for users to enter and exit critical sections and access time both inside and outside of the context of a reactor.  This enables resurrecting the MQTT examples in the example repo.

This has a [companion PR](https://github.com/lf-lang/lingua-franca/pull/1901) in lingua-franca.