### PR TITLE
Fix for fatal error raised during shutdown when decrementing a tag barrier that is zero

### DIFF
--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -2031,20 +2031,19 @@ void handle_tagged_message(int socket, int fed_id) {
         // Before that, if the current time >= stop time, discard the message.
         // But only if the stop time is not equal to the start time!
         if (lf_tag_compare(env->current_tag, env->stop_tag) >= 0) {
-            lf_mutex_unlock(&env->mutex);
             lf_print_error("Received message too late. Already at stop tag.\n"
             		"Current tag is " PRINTF_TAG " and intended tag is " PRINTF_TAG ".\n"
             		"Discarding message.",
 					env->current_tag.time - start_time, env->current_tag.microstep,
 					intended_tag.time - start_time, intended_tag.microstep);
-            return;
+            goto release;
         }
 
         LF_PRINT_LOG("Calling schedule with tag " PRINTF_TAG ".", intended_tag.time - start_time, intended_tag.microstep);
         schedule_message_received_from_network_locked(env, action->trigger, intended_tag, message_token);
     }
 
-
+    release:
 #ifdef FEDERATED_DECENTRALIZED // Only applicable for federated programs with decentralized coordination
     // Finally, decrement the barrier to allow the execution to continue
     // past the raised barrier
@@ -2333,7 +2332,7 @@ void handle_stop_granted_message() {
                     env[i].stop_tag.time - start_time,
                     env[i].stop_tag.microstep);
 
-        _lf_decrement_tag_barrier_locked(&env[i]);
+        if (env[i].barrier.requestors) _lf_decrement_tag_barrier_locked(&env[i]);
         // We signal instead of broadcast under the assumption that only
         // one worker thread can call wait_until at a given time because
         // the call to wait_until is protected by a mutex lock


### PR DESCRIPTION
This is a follow-up to [this comment](https://github.com/lf-lang/lingua-franca/pull/1684#issuecomment-1644724836) and seems to fix an error that can be reproduced in `master` by running `PingPongDistributedPhysical` perhaps a hundred times. After making this change I have run `PingPongDistributedPhysical` more than a hundred times without errors.

The change that fixes this problem is the single-line change in `handle_stop_granted_message`; the other changes are separate.

This fix seems dangerous and looks like it can cause deadlock if increments and decrements are ordered incorrectly. However, I do not think that it will cause deadlock because it seems like the federate/RTI communication protocol is supposed to ensure that the increment happens first, if it happens at all. Furthermore, I do not see a way around a fix like this because the logic for deciding whether or not to increment the tag barrier seems nontrivial.

Although the change in `handle_tagged_message` is not necessary in order to fix this bug, I think that it does fix a separate logical error where the mutex is released but the tag barrier is not decremented when we do an early return.