### PR TITLE
Fix for STP violation

### DIFF
--- a/lingua-franca-ref.txt
+++ b/lingua-franca-ref.txt
@@ -1,1 +1,1 @@
-master
+another-stp-violation-fix


### PR DESCRIPTION
This fixes yet another bug reported by Jacky.

The commit message is reproduced here for convenience:

> The communication protocol remains undocumented AFAIK, but my working
assumption has been that if a federate receives a PTAG, then that means
that all messages that are expected over delayed connections have
arrived. Therefore, delayed connections are not guarded from STP
violations by the MLAA; this property is acceptable because delayed connections impose
no deadlock risk and in some cases (startup) this property is necessary to avoid
deadlocks, but it requires some special care when sending a PTAG.

Regarding **testing:** Although Jacky has provided [an example program for reproducing the issue](https://pastebin.com/ME9RqRC9), it is not obvious to me whether we should turn it into a test since the failure is not reproduced reliably without running the program for some seconds (and that is locally, on a laptop, with the `time.sleep`s removed). I do not think that our current method of running tests in GH Actions can be treated as an effective or efficient way to detect races of this kind.

The same could be said of the other STP violation that Jacky reported.

**NOTE:** Previously an irrelevant change was included in this PR that actually introduced a bug. It has since been deleted (I rebased and force-pushed).