### PR TITLE
Fedsd fix self_id

### DIFF
--- a/util/tracing/visualization/fedsd.py
+++ b/util/tracing/visualization/fedsd.py
@@ -334,10 +334,8 @@ def load_and_process_csv_file(csv_file) :
     # which boils up to having 'RTI' in the 'event' column
     df = df[df['event'].str.contains('Sending|Receiving|Scheduler advancing time ends') == True]
 
+    # Determine the "self id" in the trace file based on the first 'Receiving' or 'Sending' message (or use -1, the id of the RTI, if there is none).
     id = -1
-    # Fix the parameters of the event 'Scheduler advancing time ends'
-    # where 'self_id' should not be -1, but rather the value from a sending or 
-    # receiving event
     for index, row in df.iterrows():
         if ('Sending' in row['event'] or 'Receiving' in row['event']) :
             id = row['self_id']

--- a/util/tracing/visualization/fedsd.py
+++ b/util/tracing/visualization/fedsd.py
@@ -334,9 +334,14 @@ def load_and_process_csv_file(csv_file) :
     # which boils up to having 'RTI' in the 'event' column
     df = df[df['event'].str.contains('Sending|Receiving|Scheduler advancing time ends') == True]
 
+    id = -1
     # Fix the parameters of the event 'Scheduler advancing time ends'
-    # We rely on the fact that the first row of the csv file cannot be the end of advancing time
-    id = df.iloc[-1]['self_id']
+    # where 'self_id' should not be -1, but rather the value from a sending or 
+    # receiving event
+    for index, row in df.iterrows():
+        if ('Sending' in row['event'] or 'Receiving' in row['event']) :
+            id = row['self_id']
+            break
     df['self_id'] = id
     df = df.astype({'self_id': 'int', 'partner_id': 'int'})
 


### PR DESCRIPTION
This PR fixes a bug that @jackykwok2024 reported when using `fedsd` utility with `Python` target.

Previously, we relied on the last event of a trace (after processing) not being about advancing time. A federate will send a resignation message after the last time advance. This behavior is valid in the C target, but it is not the case in the Python target. 

In this PR, `fedsd` retrieves the correct `self_id` of a federate.