### PR TITLE
Do not link with thread library when we are compiling for Zephyr

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -74,10 +74,12 @@ if(DEFINED _LF_CLOCK_SYNC_ON)
   endif()
 endif()
 
-# Link with thread library
+# Link with thread library. But if we are targeting the Zephyr RTOS
 if(DEFINED LF_THREADED OR DEFINED LF_TRACE)
-    find_package(Threads REQUIRED)
-    target_link_libraries(core PUBLIC Threads::Threads)
+    if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Zephyr")
+        find_package(Threads REQUIRED)
+        target_link_libraries(core PUBLIC Threads::Threads)
+    endif()
 endif()
 
 # Macro for translating a command-line argument into compile definition for

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -74,7 +74,7 @@ if(DEFINED _LF_CLOCK_SYNC_ON)
   endif()
 endif()
 
-# Link with thread library. But if we are targeting the Zephyr RTOS
+# Link with thread library, unless if we are targeting the Zephyr RTOS
 if(DEFINED LF_THREADED OR DEFINED LF_TRACE)
     if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Zephyr")
         find_package(Threads REQUIRED)


### PR DESCRIPTION
Another small fix. When compiling for certain boards I get a linker error when it tries to link with the thread library. I do not think it is necessary to link this when we are linking with the Zephyr RTOS