### PR TITLE
Fix argparse for fedsd

### DIFF
--- a/util/tracing/README.md
+++ b/util/tracing/README.md
@@ -23,8 +23,9 @@ directory.
 ```
     sudo make install
 ```
-Will install the tracing executables to `/usr/local/bin` to install them to a different location, use the `INSTALL_PREFIX` flag, e.g.
+Will install the tracing executables to the `bin` directory under `/usr/local/`. To install them to a different location, use the `INSTALL_PREFIX` flag, e.g.
 
 ```
-  make install INSTALL_PREFIX=~/.local/bin
+  make install INSTALL_PREFIX=~/.local/
 ```
+which will install the executables under `~/.local/bin/`.

--- a/util/tracing/visualization/README.md
+++ b/util/tracing/visualization/README.md
@@ -32,8 +32,8 @@ Once the federation stopped executing, running `fedsd` will operate on all the `
 ```bash
 fedsd
 ```
-It is also possible to operate on specific files. In such a case, run `fedsd` with `-r` flag to provide the RTI trace file, and `-f` flag to privide the list of federates
-trace files. Bith argumenets are optional.
+It is also possible to operate on specific files. In such a case, run `fedsd` with `-r` flag to provide the RTI trace file, and `-f` flag to provide the list of federate.
+
 ```bash
 fedsd -r <rti.lft> -f <federate__f1.lft> <federate__f2.lft>
 ```

--- a/util/tracing/visualization/fedsd.py
+++ b/util/tracing/visualization/fedsd.py
@@ -98,7 +98,7 @@ import subprocess
 parser = argparse.ArgumentParser(description='Set of the lft trace files to render.')
 parser.add_argument('-r','--rti', type=str, 
                     help='RTI\'s lft trace file.')
-parser.add_argument('-f','--federates', nargs='+', action='append',
+parser.add_argument('-f','--federates', nargs='+',
                     help='List of the federates\' lft trace files.')
 
 # Events matching at the sender and receiver ends depend on whether they are tagged


### PR DESCRIPTION
The docs are not up-to-date, fedsd doesnt work with `fedsd *.lft`, you have to do `fedsd -r rti.lft -f fed1.lft fed2.lft`.

This fixes the argparse setup so that the command line parsing works properly. Previously it turned the list of federate lfts into a double list [[lft1, fft2, ...,]] which crashed the rest of the script