### PR TITLE
Guard against unconnected outputs

### DIFF
--- a/core/reactor.c
+++ b/core/reactor.c
@@ -53,12 +53,14 @@ extern instant_t start_time;
 
 /**
  * Mark the given port's is_present field as true. This is_present field
- * will later be cleaned up by _lf_start_time_step.
+ * will later be cleaned up by _lf_start_time_step. If the port is unconnected,
+ * do nothing.
  * @param env Environment in which we are executing
  * @param port A pointer to the port struct.
  */
 void _lf_set_present(lf_port_base_t* port) {
-    environment_t *env = port->source_reactor->environment;
+  if (!port->source_reactor) return;
+  environment_t *env = port->source_reactor->environment;
 	bool* is_present_field = &port->is_present;
     if (env->is_present_fields_abbreviated_size < env->is_present_fields_size) {
         env->is_present_fields_abbreviated[env->is_present_fields_abbreviated_size]

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -210,12 +210,14 @@ int _lf_wait_on_tag_barrier(environment_t* env, tag_t proposed_tag) {
 
 /**
  * Mark the given port's is_present field as true. This is_present field
- * will later be cleaned up by _lf_start_time_step.
+ * will later be cleaned up by _lf_start_time_step. If the port is unconnected,
+ * do nothing.
  * This assumes that the mutex is not held.
  * @param port A pointer to the port struct.
  */
 void _lf_set_present(lf_port_base_t* port) {
-    environment_t *env = port->source_reactor->environment;
+  if (!port->source_reactor) return;
+  environment_t *env = port->source_reactor->environment;
 	bool* is_present_field = &port->is_present;
     int ipfas = lf_atomic_fetch_add(&env->is_present_fields_abbreviated_size, 1);
     if (ipfas < env->is_present_fields_size) {


### PR DESCRIPTION
This addresses [issue 1943 in lingua-franca](https://github.com/lf-lang/lingua-franca/issues/1943), where unconnected outputs lead to segmentation fault.