### PR TITLE
Fix overflow bug affecting 32-bit Linux platforms

### DIFF
--- a/core/platform/lf_unix_clock_support.c
+++ b/core/platform/lf_unix_clock_support.c
@@ -3,6 +3,7 @@
 #include <errno.h>
 
 #include "platform.h"
+#include "util.h"
 #include "lf_unix_clock_support.h"
 
 /**

--- a/core/platform/lf_unix_clock_support.c
+++ b/core/platform/lf_unix_clock_support.c
@@ -50,6 +50,15 @@ void calculate_epoch_offset(void) {
 
 void _lf_initialize_clock() {
     calculate_epoch_offset();
+
+    struct timespec res;
+    // Adjust the clock by the epoch offset, so epoch time is always reported.
+    int return_value = clock_getres(_LF_CLOCK, (struct timespec*) &res);
+    if (return_value < 0) {
+        lf_print_error_and_exit("Could not obtain resolution for _LF_CLOCK");
+    }
+
+    lf_print("---- System clock resolution: %u nsec", res.tv_nsec);
 }
 
 /**

--- a/core/platform/lf_unix_clock_support.c
+++ b/core/platform/lf_unix_clock_support.c
@@ -53,7 +53,6 @@ void _lf_initialize_clock() {
     calculate_epoch_offset();
 
     struct timespec res;
-    // Adjust the clock by the epoch offset, so epoch time is always reported.
     int return_value = clock_getres(_LF_CLOCK, (struct timespec*) &res);
     if (return_value < 0) {
         lf_print_error_and_exit("Could not obtain resolution for _LF_CLOCK");

--- a/core/platform/lf_unix_clock_support.c
+++ b/core/platform/lf_unix_clock_support.c
@@ -17,13 +17,13 @@
 interval_t _lf_time_epoch_offset = 0LL;
 
 instant_t convert_timespec_to_ns(struct timespec tp) {
-    return tp.tv_sec * 1000000000 + tp.tv_nsec;
+    return ((instant_t) tp.tv_sec) * BILLION + tp.tv_nsec;
 }
 
 struct timespec convert_ns_to_timespec(instant_t t) {
     struct timespec tp;
-    tp.tv_sec = t / 1000000000;
-    tp.tv_nsec = (t % 1000000000);
+    tp.tv_sec = t / BILLION;
+    tp.tv_nsec = (t % BILLION);
     return tp;
 }
 

--- a/include/core/platform/lf_linux_support.h
+++ b/include/core/platform/lf_linux_support.h
@@ -34,6 +34,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <stdint.h> // For fixed-width integral types
 #include <time.h>   // For CLOCK_MONOTONIC
+#include <unistd.h> // _POSIX_TIMERS _POSIX_CLOCK_MONOTONIC
 
 // Use 64-bit times and 32-bit unsigned microsteps
 #include "lf_tag_64_32.h"
@@ -47,7 +48,15 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     #endif
 #endif
 
+#if !defined(_POSIX_TIMERS) || _POSIX_TIMERS <= 0
+    #error Linux platform misses clock support
+#endif
+
 // The underlying physical clock for Linux
-#define _LF_CLOCK CLOCK_MONOTONIC
+#if defined(_POSIX_CLOCK_MONOTONIC)
+    #define _LF_CLOCK CLOCK_MONOTONIC
+#else
+    #define _LF_CLOCK CLOCK_REALTIME
+#endif
 
 #endif // LF_LINUX_SUPPORT_H

--- a/lingua-franca-ref.txt
+++ b/lingua-franca-ref.txt
@@ -1,1 +1,1 @@
-c-remove-deprecated-schedulers
+master


### PR DESCRIPTION
This bug was reported in this issue: https://github.com/lf-lang/lingua-franca/issues/2034

Another reminder of how difficult it is to juggle time representations on different architectures. In general, unless we are dealing with a type of explicit widht, like uint64_t or instant_t, then we must consider that it might be 32-bit on a 32-bit architecture. This goes for any literal value also.