### PR TITLE
 Fix Segfault for Python 3.11

### DIFF
--- a/python/lib/pythontarget.c
+++ b/python/lib/pythontarget.c
@@ -437,7 +437,7 @@ void destroy_action_capsule(PyObject* capsule) {
 PyObject* convert_C_port_to_py(void* port, int width) {
     // Create the port struct in Python
     PyObject* cap =
-        (PyObject*)PyObject_GC_New(generic_port_capsule_struct, &py_port_capsule_t);
+        (PyObject*)PyObject_New(generic_port_capsule_struct, &py_port_capsule_t);
     if (cap == NULL) {
         lf_print_error_and_exit("Failed to convert port.");
     }
@@ -506,7 +506,7 @@ PyObject* convert_C_action_to_py(void* action) {
     trigger_t* trigger = ((lf_action_base_t*)action)->trigger;
 
     // Create the action struct in Python
-    PyObject* cap = (PyObject*)PyObject_GC_New(generic_action_capsule_struct, &py_action_capsule_t);
+    PyObject* cap = (PyObject*)PyObject_New(generic_action_capsule_struct, &py_action_capsule_t);
     if (cap == NULL) {
         lf_print_error_and_exit("Failed to convert action.");
     }


### PR DESCRIPTION
**Issue**
Segfault due to Python 3.11 changes to object layout and memory allocation methods.

**Background**
Python 3.11 introduced changes to optimize CPython. One of the significant changes, as mentioned in [this PR](https://github.com/python/cpython/pull/29879), modifies the object layout to place pointers to dict and values immediately before the GC header. This change potentially affected the memory layout of custom python objects.

Before:
![Untitled1](https://github.com/lf-lang/reactor-c/assets/77720778/51753a16-2c86-4a72-bca1-17d018df5986)
After:
![Untitled2](https://github.com/lf-lang/reactor-c/assets/77720778/50a69609-c62e-4ece-8c67-b70eb53492da)
Moreover, this commit removed ```_PyObject_GC_Calloc``` and ```_PyObject_GC_Malloc```, affecting the memory allocation for objects that participate in garbage collection.


**Solution**
 The new memory allocation relies on ```PyObject_New``` instead of ```PyObject_GC_New```.