### PR TITLE
Use env command rather than /usr/bin/python3

### DIFF
--- a/util/tracing/visualization/fedsd.py
+++ b/util/tracing/visualization/fedsd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Utility that reports the interactions (exchanged messages) between federates and the RTI in a 
 # sequence-diagram-like format, or between enclaves in an enclaved execution.


### PR DESCRIPTION
Directly invoking /usr/bin/python3 bypasses any user setup for python and may invoke an outdated version of python. This PR uses the `env` command instead.