### PR TITLE
Zephyr: Update default thread stack size to 2KB

### DIFF
--- a/include/core/platform/lf_zephyr_board_support.h
+++ b/include/core/platform/lf_zephyr_board_support.h
@@ -33,7 +33,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // Default options
 #define LF_ZEPHYR_THREAD_PRIORITY_DEFAULT 5
-#define LF_ZEPHYR_STACK_SIZE_DEFAULT 4196
+#define LF_ZEPHYR_STACK_SIZE_DEFAULT 2048
 
 // Unless the user explicitly asks for the kernel clock, then we use a counter
 //  clock because it is more precise.

--- a/include/core/platform/lf_zephyr_board_support.h
+++ b/include/core/platform/lf_zephyr_board_support.h
@@ -33,7 +33,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 // Default options
 #define LF_ZEPHYR_THREAD_PRIORITY_DEFAULT 5
-#define LF_ZEPHYR_STACK_SIZE_DEFAULT 1024
+#define LF_ZEPHYR_STACK_SIZE_DEFAULT 4196
 
 // Unless the user explicitly asks for the kernel clock, then we use a counter
 //  clock because it is more precise.


### PR DESCRIPTION
There was a test failure due to a stack overflow. I am going to think a bit about how we can approach this in a better way. For now, increase default stack size by x2.