### PR TITLE
Run Python tests in CI and revert #293

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,13 @@ jobs:
       runtime-ref: ${{ github.ref }}
       compiler-ref: ${{ needs.fetch-lf.outputs.ref }}
 
+  lf-python:
+    needs: fetch-lf
+    uses: lf-lang/lingua-franca/.github/workflows/py-tests.yml@master
+    with:
+      reactor-c-ref: ${{ github.ref }}
+      compiler-ref: ${{ needs.fetch-lf.outputs.ref }}
+
   lf-gedf-np:
     needs: fetch-lf
     uses: lf-lang/lingua-franca/.github/workflows/c-tests.yml@master

--- a/lingua-franca-ref.txt
+++ b/lingua-franca-ref.txt
@@ -1,1 +1,1 @@
-decentralized-small-delay-bugfix
+master

--- a/python/lib/pythontarget.c
+++ b/python/lib/pythontarget.c
@@ -437,7 +437,7 @@ void destroy_action_capsule(PyObject* capsule) {
 PyObject* convert_C_port_to_py(void* port, int width) {
     // Create the port struct in Python
     PyObject* cap =
-        (PyObject*)PyObject_New(generic_port_capsule_struct, &py_port_capsule_t);
+        (PyObject*)PyObject_GC_New(generic_port_capsule_struct, &py_port_capsule_t);
     if (cap == NULL) {
         lf_print_error_and_exit("Failed to convert port.");
     }
@@ -506,7 +506,7 @@ PyObject* convert_C_action_to_py(void* action) {
     trigger_t* trigger = ((lf_action_base_t*)action)->trigger;
 
     // Create the action struct in Python
-    PyObject* cap = (PyObject*)PyObject_New(generic_action_capsule_struct, &py_action_capsule_t);
+    PyObject* cap = (PyObject*)PyObject_GC_New(generic_action_capsule_struct, &py_action_capsule_t);
     if (cap == NULL) {
         lf_print_error_and_exit("Failed to convert action.");
     }


### PR DESCRIPTION
This PR adds the Lingua Franca Python tests to the CI run. It also reverts the merge of #293 because it causes a segfault when using Python 3.10.