### PR TITLE
Added return for non-void return function for arduino support

### DIFF
--- a/core/platform/lf_arduino_support.c
+++ b/core/platform/lf_arduino_support.c
@@ -95,7 +95,7 @@ int lf_sleep(interval_t sleep_duration) {
     do {
         _lf_clock_now(&now);
     } while ((now < wakeup));
-
+    return 0;
 }
 
 /**


### PR DESCRIPTION
lf_arduino_support.c has no return in the lf_sleep function with signature: int lf_sleep(interval_t sleep_duration)

If some warnings are treated as errors (which is done by default on a Windows 11 WSL Ubuntu 22.04 installation), the following error prevents compilation:
```
/xxx/src/core/platform/lf_arduino_support.c: In function 'lf_sleep':
/xxx/src/core/platform/lf_arduino_support.c:99:1: error: control reaches end of non-void function [-Werror=return-type]
   99 | }
      | ^
cc1: some warnings being treated as errors
```

This PR fixes that issue by adding a return 0, which resolves the compilation issue.