### PR TITLE
Port search removal

### DIFF
--- a/core/federated/RTI/main.c
+++ b/core/federated/RTI/main.c
@@ -73,7 +73,7 @@ const char *rti_trace_file_name = "rti.lft";
  */
 void termination() {
     if (rti.base.tracing_enabled) {
-        stop_trace(rti.base.trace);
+        stop_trace_locked(rti.base.trace);
         lf_print("RTI trace file saved.");
     }   
     lf_print("RTI is exiting.");

--- a/core/federated/RTI/main.c
+++ b/core/federated/RTI/main.c
@@ -67,16 +67,25 @@ static rti_remote_t rti;
  */
 const char *rti_trace_file_name = "rti.lft";
 
+/** Indicator that normal termination has occurred. */
+bool normal_termination = false;
+
 /**
- * @brief A clean termination of the RTI will write the trace file, if tracing is
- * enabled, before exiting.
+ * @brief Function to run upon abnormal termination.
+ * This function will be invoked both after main() returns, and when a signal
+ * that results in terminating the process, such as SIGINT.  In the former
+ * case, it should do nothing.  In the latter case, it will attempt to write
+ * the trace file, but without acquiring a mutex lock, so the resulting files
+ * may be incomplete or even corrupted.
  */
 void termination() {
-    if (rti.base.tracing_enabled) {
-        stop_trace_locked(rti.base.trace);
-        lf_print("RTI trace file saved.");
+    if (!normal_termination) {
+        if (rti.base.tracing_enabled) {
+            stop_trace_locked(rti.base.trace);
+            lf_print("RTI trace file saved.");
+        }
+        lf_print("RTI is exiting abnormally.");
     }   
-    lf_print("RTI is exiting.");
 }
 
 void usage(int argc, const char* argv[]) {
@@ -290,6 +299,13 @@ int main(int argc, const char* argv[]) {
 
     int socket_descriptor = start_rti_server(rti.user_specified_port);
     wait_for_federates(socket_descriptor);
+    normal_termination = true;
+    if (rti.base.tracing_enabled) {
+        // No need for a mutex lock because all threads have exited.
+        stop_trace_locked(rti.base.trace);
+        lf_print("RTI trace file saved.");
+    }
+
     free_scheduling_nodes(rti.base.scheduling_nodes, rti.base.number_of_scheduling_nodes);
     lf_print("RTI is exiting.");
     return 0;

--- a/core/federated/RTI/main.c
+++ b/core/federated/RTI/main.c
@@ -86,7 +86,7 @@ void usage(int argc, const char* argv[]) {
     lf_print("  -n, --number_of_federates <n>");
     lf_print("   The number of federates in the federation that this RTI will control.\n");
     lf_print("  -p, --port <n>");
-    lf_print("   The port number to use for the RTI. Must be larger than 0 and smaller than %d. Default is %d.\n", UINT16_MAX, STARTING_PORT);
+    lf_print("   The port number to use for the RTI. Must be larger than 0 and smaller than %d. Default is %d.\n", UINT16_MAX, DEFAULT_PORT);
     lf_print("  -c, --clock_sync [off|init|on] [period <n>] [exchanges-per-interval <n>]");
     lf_print("   The status of clock synchronization for this federate.");
     lf_print("       - off: Clock synchronization is off.");

--- a/core/federated/RTI/main.c
+++ b/core/federated/RTI/main.c
@@ -71,12 +71,13 @@ const char *rti_trace_file_name = "rti.lft";
 bool normal_termination = false;
 
 /**
- * @brief Function to run upon abnormal termination.
- * This function will be invoked both after main() returns, and when a signal
+ * @brief Function to run upon termination.
+ * This function will be invoked both after main() returns and when a signal
  * that results in terminating the process, such as SIGINT.  In the former
  * case, it should do nothing.  In the latter case, it will attempt to write
  * the trace file, but without acquiring a mutex lock, so the resulting files
- * may be incomplete or even corrupted.
+ * may be incomplete or even corrupted.  But this is better than just failing
+ * to write the data we have collected so far.
  */
 void termination() {
     if (!normal_termination) {

--- a/core/federated/RTI/main.c
+++ b/core/federated/RTI/main.c
@@ -254,6 +254,12 @@ int main(int argc, const char* argv[]) {
 
     // Catch the Ctrl-C signal, for a clean exit that does not lose the trace information
     signal(SIGINT, exit);
+#ifdef SIGPIPE
+    // Ignore SIGPIPE errors, which terminate the entire application if
+    // socket write() fails because the reader has closed the socket.
+    // Instead, cause an EPIPE error to be set when write() fails.
+    signal(SIGPIPE, SIG_IGN);
+#endif // SIGPIPE
     if (atexit(termination) != 0) {
         lf_print_warning("Failed to register termination function!");
     }

--- a/core/federated/RTI/main.c
+++ b/core/federated/RTI/main.c
@@ -277,7 +277,7 @@ int main(int argc, const char* argv[]) {
     // Allocate memory for the federates
     rti.base.scheduling_nodes = (scheduling_node_t**)calloc(rti.base.number_of_scheduling_nodes, sizeof(scheduling_node_t*));
     for (uint16_t i = 0; i < rti.base.number_of_scheduling_nodes; i++) {
-        federate_info_t *fed_info = (federate_info_t *) malloc(sizeof(federate_info_t));
+        federate_info_t *fed_info = (federate_info_t *) calloc(1, sizeof(federate_info_t));
         initialize_federate(fed_info, i);
         rti.base.scheduling_nodes[i] = (scheduling_node_t *) fed_info;
     }

--- a/core/federated/RTI/rti_common.c
+++ b/core/federated/RTI/rti_common.c
@@ -317,9 +317,7 @@ void update_min_delays_upstream(scheduling_node_t* node) {
 
         // Put the results onto the node's struct.
         node->num_min_delays = count;
-        // FIXME: What should the newly allocated `min_delays` be initialized to?
-        //  currently it could be any value.
-        node->min_delays = (minimum_delay_t*)malloc(count * sizeof(minimum_delay_t));
+        node->min_delays = (minimum_delay_t*)calloc(count, sizeof(minimum_delay_t));
         LF_PRINT_DEBUG("++++ Node %hu(is in ZDC: %d\n", node->id, node->flags & IS_IN_ZERO_DELAY_CYCLE);
         int k = 0;
         for (int i = 0; i < rti_common->number_of_scheduling_nodes; i++) {

--- a/core/federated/RTI/rti_common.c
+++ b/core/federated/RTI/rti_common.c
@@ -317,6 +317,8 @@ void update_min_delays_upstream(scheduling_node_t* node) {
 
         // Put the results onto the node's struct.
         node->num_min_delays = count;
+        // FIXME: What should the newly allocated `min_delays` be initialized to?
+        //  currently it could be any value.
         node->min_delays = (minimum_delay_t*)malloc(count * sizeof(minimum_delay_t));
         LF_PRINT_DEBUG("++++ Node %hu(is in ZDC: %d\n", node->id, node->flags & IS_IN_ZERO_DELAY_CYCLE);
         int k = 0;

--- a/core/federated/RTI/rti_local.c
+++ b/core/federated/RTI/rti_local.c
@@ -35,7 +35,7 @@ static rti_local_t * rti_local;
 lf_mutex_t rti_mutex;
 
 void initialize_local_rti(environment_t *envs, int num_envs) {
-    rti_local = (rti_local_t*)malloc(sizeof(rti_local_t));
+    rti_local = (rti_local_t*)calloc(1, sizeof(rti_local_t));
     LF_ASSERT(rti_local, "Out of memory");
 
     initialize_rti_common(&rti_local->base);
@@ -47,7 +47,7 @@ void initialize_local_rti(environment_t *envs, int num_envs) {
     // Allocate memory for the enclave_info objects
     rti_local->base.scheduling_nodes = (scheduling_node_t**)calloc(num_envs, sizeof(scheduling_node_t*));
     for (int i = 0; i < num_envs; i++) {
-        enclave_info_t *enclave_info = (enclave_info_t *) malloc(sizeof(enclave_info_t));
+        enclave_info_t *enclave_info = (enclave_info_t *) calloc(1, sizeof(enclave_info_t));
         initialize_enclave_info(enclave_info, i, &envs[i]);
         rti_local->base.scheduling_nodes[i] = (scheduling_node_t *) enclave_info;
 

--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -1007,7 +1007,7 @@ void handle_federate_resign(federate_info_t *my_fed) {
     // an orderly shutdown.
     // close(my_fed->socket); //  from unistd.h
 
-    lf_print("Federate %d has resigned.", my_fed->enclave.id);
+    lf_print("RTI: Federate %d has resigned.", my_fed->enclave.id);
 
     // Check downstream federates to see whether they should now be granted a TAG.
     // To handle cycles, need to create a boolean array to keep

--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -128,10 +128,10 @@ int create_server(int32_t specified_port, uint16_t port, socket_type_t socket_ty
             sizeof(server_fd));
 
     // Try repeatedly to bind to the specified port.
-    int count = 0;
-    while (result != 0 && count++ < PORT_KNOCKING_LIMIT) {
+    int count = 1;
+    while (result != 0 && count++ < PORT_BIND_RETRY_LIMIT) {
         lf_print("RTI failed to get port %d. Will try again.", port);
-        lf_sleep(PORT_MAX_TRIES);
+        lf_sleep(PORT_BIND_RETRY_INTERVAL);
         server_fd.sin_port = htons(port);
         result = bind(
                 socket_descriptor,

--- a/core/federated/RTI/rti_remote.h
+++ b/core/federated/RTI/rti_remote.h
@@ -187,9 +187,7 @@ extern int lf_critical_section_exit(environment_t* env);
 /**
  * Create a server and enable listening for socket connections.
  *
- * @note This function is similar to create_server(...) in
- * federate.c. However, it contains logs that are specific
- * to the RTI.
+ * @note This function is different from create_server(...) in federate.c.
  *
  * @param port The port number to use.
  * @param socket_type The type of the socket for the server (TCP or UDP).

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -115,7 +115,7 @@ federation_metadata_t federation_metadata = {
     .rti_user = NULL
 };
 
-void create_server(int specified_port, int id) {
+void create_server(int specified_port) {
     assert(specified_port <= UINT16_MAX && specified_port >= 0);
     uint16_t port = (uint16_t)specified_port;
     LF_PRINT_LOG("Creating a socket server on port %d.", port);
@@ -166,7 +166,7 @@ void create_server(int specified_port, int id) {
     // which according to the Mac man page is limited to 128.
     listen(socket_descriptor, 128);
 
-    lf_print("Server for communicating with other federates started using port %d.", _fed.server_port);
+    LF_PRINT_LOG("Server for communicating with other federates started using port %d.", _fed.server_port);
 
     // Send the server port number to the RTI
     // on an MSG_TYPE_ADDRESS_ADVERTISEMENT message (@see net_common.h).
@@ -2279,7 +2279,7 @@ void terminate_execution(environment_t* env) {
     assert(env != GLOBAL_ENVIRONMENT);
 
     // For an abnormal termination (e.g. a SIGINT), we need to send a
-    // MSG_TYPE_RESIGN message to the RTI, but we should not trace it.
+    // MSG_TYPE_RESIGN message to the RTI, but we should not acquire a mutex.
     if (_fed.socket_TCP_RTI >= 0) {
         if (_lf_normal_termination) {
             lf_mutex_lock(&outbound_socket_mutex);

--- a/core/reactor.c
+++ b/core/reactor.c
@@ -397,6 +397,7 @@ int lf_reactor_c_main(int argc, const char* argv[]) {
         if (_lf_do_step(env)) {
             while (next(env) != 0);
         }
+        _lf_normal_termination = true;
         return 0;
     } else {
         return -1;

--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -1728,7 +1728,7 @@ void termination(void) {
     environment_t *env;
     int num_envs = _lf_get_environments(&env);
     // Invoke the code generated termination function. It terminates the federated related services. 
-    // It should only be called for the top-level environment, which, after convention, is the first environment.
+    // It should only be called for the top-level environment, which, by convention, is the first environment.
     terminate_execution(env);
 
     // In order to free tokens, we perform the same actions we would have for a new time step.

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -1239,6 +1239,10 @@ int lf_reactor_c_main(int argc, const char* argv[]) {
             LF_PRINT_LOG("---- All worker threads exited successfully.");
         }
     }
+    _lf_normal_termination = true;
+    // Invoke termination function here before freeing the local RTI.
+    termination();
+    
 #if defined LF_ENCLAVES
     free_local_rti();
 #endif

--- a/include/core/federated/federate.h
+++ b/include/core/federated/federate.h
@@ -273,11 +273,12 @@ void _lf_logical_tag_complete(tag_t);
 
 /**
  * Connect to the RTI at the specified host and port and return
- * the socket descriptor for the connection. If this fails, the
+ * the socket descriptor for the connection. If this fails, wait CONNECT_RETRY_INTERVAL
+ * and try again.  If it fails after CONNECT_MAX_RETRIES, the
  * program exits. If it succeeds, it sets the _fed.socket_TCP_RTI global
  * variable to refer to the socket for communicating with the RTI.
  * @param hostname A hostname, such as "localhost".
- * @param port_number A port number.
+ * @param port_number A port number, or 0 to use the default port.
  */
 void connect_to_rti(const char*, int);
 
@@ -296,10 +297,10 @@ void connect_to_rti(const char*, int);
 void* listen_to_federates(void*);
 
 /**
- * Create a server to listen to incoming physical
- * connections from remote federates. This function
+ * Create a server to listen to incoming p2p connection (physical
+ * connections or decentralized connections) from remote federates. This function
  * only handles the creation of the server socket.
- * The reserved port for the server socket is then
+ * The bound port for the server socket is then
  * sent to the RTI by sending an MSG_TYPE_ADDRESS_ADVERTISEMENT message
  * (@see net_common.h). This function expects no response
  * from the RTI.
@@ -307,19 +308,22 @@ void* listen_to_federates(void*);
  * If a port is specified by the user, that will be used
  * as the only possibility for the server. This function
  * will fail if that port is not available. If a port is not
- * specified, the STARTING_PORT (@see net_common.h) will be used.
+ * specified, the DEFAULT_PORT + 1 + id will be attempted,
  * The function will keep incrementing the port in this case
- * until the number of tries reaches PORT_RANGE_LIMIT.
+ * until the number of tries reaches PORT_BIND_RETRY_LIMIT (@see net_common.h).
  *
  * @note This function is similar to create_server(...) in rti.c.
  * However, it contains specific log messages for the peer to
  * peer connections between federates. It also additionally
  * sends an address advertisement (MSG_TYPE_ADDRESS_ADVERTISEMENT) message to the
- * RTI informing it of the port.
+ * RTI informing it of the port.  Finally, it tries multiple ports
+ * because the port used by a federate is not as important as the port used
+ * by the RTI.
  *
  * @param specified_port The specified port by the user.
+ * @param id The id of the federate (to help find a unique port).
  */
-void create_server(int specified_port);
+void create_server(int specified_port, int id);
 
 /**
  * Thread to accept connections from other federates that send this federate

--- a/include/core/federated/federate.h
+++ b/include/core/federated/federate.h
@@ -305,22 +305,14 @@ void* listen_to_federates(void*);
  * (@see net_common.h). This function expects no response
  * from the RTI.
  *
- * If a port is specified by the user, that will be used
- * as the only possibility for the server. This function
- * will fail if that port is not available. If a port is not
- * specified, the DEFAULT_PORT + 1 + id will be attempted,
- * The function will keep incrementing the port in this case
- * until the number of tries reaches PORT_BIND_RETRY_LIMIT (@see net_common.h).
+ * If a port is specified by the user, that will be used.
+ * Otherwise, a random port will be assigned.  If the bind fails,
+ * it will retry after PORT_BIND_RETRY_INTERVAL until it has tried
+ * PORT_BIND_RETRY_LIMIT times. Then it will fail.
  *
- * @note This function is similar to create_server(...) in rti.c.
- * However, it contains specific log messages for the peer to
- * peer connections between federates. It also additionally
- * sends an address advertisement (MSG_TYPE_ADDRESS_ADVERTISEMENT) message to the
- * RTI informing it of the port.  Finally, it tries multiple ports
- * because the port used by a federate is not as important as the port used
- * by the RTI.
+ * @note This function is different from create_server(...) in rti.c.
  *
- * @param specified_port The specified port by the user.
+ * @param specified_port The specified port by the user or 0 to use a random port.
  * @param id The id of the federate (to help find a unique port).
  */
 void create_server(int specified_port, int id);

--- a/include/core/federated/federate.h
+++ b/include/core/federated/federate.h
@@ -313,9 +313,8 @@ void* listen_to_federates(void*);
  * @note This function is different from create_server(...) in rti.c.
  *
  * @param specified_port The specified port by the user or 0 to use a random port.
- * @param id The id of the federate (to help find a unique port).
  */
-void create_server(int specified_port, int id);
+void create_server(int specified_port);
 
 /**
  * Thread to accept connections from other federates that send this federate

--- a/include/core/federated/network/net_common.h
+++ b/include/core/federated/network/net_common.h
@@ -243,13 +243,14 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define PORT_BIND_RETRY_LIMIT 100
 
 /**
- * Default starting port number for the RTI and federates' socket server.
+ * Default port number for the RTI and base number for federates' socket server.
  * Unless a specific port has been specified by the LF program in the "at"
- * for the RTI, when the federates start up, they will attempt
- * to open a socket server on this port. If that port is not available (e.g.,
- * another RTI is running or has recently exited), then it will try again
- * after waiting PORT_MAX_TRIES. It will try repeatedly until
- * it reaches PORT_KNOCKING_LIMIT attempts, at which point it will fail.
+ * for the RTI or on the command line, when the RTI starts up, it will attempt
+ * to open a socket server on this port. The federates start attempting to bind
+ * to ports one greater than this plus the federate ID, and if that port is not,
+ * then they try incrementing the port number with up to PORT_BIND_RETRY_LIMIT
+ * attempts.  The RTI will try repeatedly on the same port number with a delay
+ * of PORT_BIND_RETRY_INTERVAL and a maximum number of attempts of PORT_BIND_RETRY_LIMIT.
  */
 #define DEFAULT_PORT 15045u
 

--- a/include/core/federated/network/net_common.h
+++ b/include/core/federated/network/net_common.h
@@ -243,14 +243,10 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define PORT_BIND_RETRY_LIMIT 100
 
 /**
- * Default port number for the RTI and base number for federates' socket server.
+ * Default port number for the RTI.
  * Unless a specific port has been specified by the LF program in the "at"
  * for the RTI or on the command line, when the RTI starts up, it will attempt
- * to open a socket server on this port. The federates start attempting to bind
- * to ports one greater than this plus the federate ID, and if that port is not,
- * then they try incrementing the port number with up to PORT_BIND_RETRY_LIMIT
- * attempts.  The RTI will try repeatedly on the same port number with a delay
- * of PORT_BIND_RETRY_INTERVAL and a maximum number of attempts of PORT_BIND_RETRY_LIMIT.
+ * to open a socket server on this port.
  */
 #define DEFAULT_PORT 15045u
 

--- a/include/core/reactor_common.h
+++ b/include/core/reactor_common.h
@@ -19,6 +19,9 @@ extern bool _lf_execution_started;
 extern bool keepalive_specified;
 extern interval_t _lf_fed_STA_offset;
 
+/** Flag used to disable cleanup operations on normal termination. */
+extern bool _lf_normal_termination;
+
 extern int default_argc;
 extern const char** default_argv;
 

--- a/include/core/trace.h
+++ b/include/core/trace.h
@@ -435,6 +435,10 @@ void tracepoint_reaction_deadline_missed(trace_t* trace, reaction_t *reaction, i
  * close the files.
  */
 void stop_trace(trace_t* trace);
+
+/**
+ * Version of stop_trace() that does not lock the trace mutex.
+ */
 void stop_trace_locked(trace_t* trace);
 
 ////////////////////////////////////////////////////////////

--- a/lingua-franca-ref.txt
+++ b/lingua-franca-ref.txt
@@ -1,1 +1,1 @@
-master
+port-search-removal


### PR DESCRIPTION
This PR removes the port search done by the RTI if it cannot bind to the specified or default port.  This never worked and resulted in federates taking a long time to fail as they searched over possible ports.  There is a companion PR in lingua-franca.

This PR also fixes two issues that can cause the RTI to deadlock during shutdown, particularly if a task is kill with a SIGINT during execution.  Both of these issues had been previously found by @erlingrj, but fixed only the federate side, not on the RTI side.  

The first is that if a write to a socket fails because of a broken pipe, a SIGPIPE signal is issued, and, by default, the process is terminated.  The reason for this is that a common use of sockets is to pipe one process's output to another, e.g. `foo | bar`, and if the second process crashes, you want the first process to exit.  However, in the RTI (and the federates), there is a mutex lock that is held when writing to an outgoing socket (to prevent multiple threads from writing simultaneously to the socket).  So, what can happen is that the process acquires the mutex and calls write(), but then write() fails, and before it can be return, a registered termination function is called.  That termination function tries to acquire the same mutex in order to close the sockets. The result is a deadlock.

The second problem is similar, but only occurs if tracing is turned on.  When a process exits the termination function tries to acquire a lock to flush tracing output, but that lock may be held by a thread that has exited anomalously while in a critical section. 

It is possible that either of these problems could cause CI tests to hang rather than time out.  When they time out, the CI tools try to kill the process with a SIGINT, and hence could trigger one of the above deadlocks, thereby failing to kill the process.  The CI job will then run for the full six hours before being cancelled.

This PR also simplifies what is done when an abnormal termination occurs, e.g. SIGINT. In particular, it avoids acquiring any mutex locks and does not bother freeing memory (the memory will be freed by the OS anyway).  The reason for freeing memory on normal termination is so that valgrind or similar tools can be used to check for memory leaks, but checking for memory leaks in a program that gets terminated with Control-C is not reasonable.