### PR TITLE
Bugfix to avoid deadlock on STP violation

### DIFF
--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -382,6 +382,9 @@ void _lf_pop_events(environment_t *env) {
                                     event->trigger,
                                     event->intended_tag.time - start_time, event->intended_tag.microstep,
                                     env->current_tag.time - start_time, env->current_tag.microstep);
+                        // Need to update the last_known_status_tag of the port because otherwise,
+                        // the MLAA could get stuck, causing the program to lock up.
+                        event->trigger->last_known_status_tag = env->current_tag;
                     }
                 }
 #endif


### PR DESCRIPTION
When an STP violation occurs with decentralized coordination, the `last_known_status_tag` of the network input port was being left at the intended tag, but should have been updated to the tag at which the input will be handled.  This can cause a deadlock with decentralized coordination and may be causing at least some of the flaky test failures in CI.  The bug is only triggered when an STP violation occurs, and this is more likely in CI.