### PR TITLE
LF_ASSERT: Cast to void to avoid unused warnings

### DIFF
--- a/include/core/utils/util.h
+++ b/include/core/utils/util.h
@@ -272,7 +272,7 @@ void lf_register_print_function(print_message_function_t* function, int log_leve
  * This is optimized away if the NDEBUG flag is defined.
  */
 #if defined(NDEBUG)
-#define LF_ASSERT(condition, format, ...) (condition)
+#define LF_ASSERT(condition, format, ...) (void)(condition)
 #else
 #define LF_ASSERT(condition, format, ...) \
 	do { \


### PR DESCRIPTION
@edwardalee can you test if this removes your warnings? I am not able to reproduce the warnings here with Linux, even with -Wall -Wpedantic and -Wextra 