### PR TITLE
Fix subtraction of wait_until_time not accounting for NEVER

### DIFF
--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -2015,7 +2015,7 @@ static void* update_ports_from_staa_offsets(void* args) {
         tag_t tag_when_started_waiting = lf_tag(env);
         for (int i = 0; i < staa_lst_size; ++i) {
             staa_t* staa_elem = staa_lst[i];
-            interval_t wait_until_time = env->current_tag.time + staa_elem->STAA + _lf_fed_STA_offset - _lf_action_delay_table[i];
+            interval_t wait_until_time = env->current_tag.time + staa_elem->STAA + _lf_fed_STA_offset - (_lf_action_delay_table[i] == NEVER ? 0 : _lf_action_delay_table[i]);
             lf_mutex_lock(&env->mutex);
             // Both before and after the wait, check that the tag has not changed
             if (a_port_is_unknown(staa_elem) && lf_tag_compare(lf_tag(env), tag_when_started_waiting) == 0 && wait_until(env, wait_until_time, &port_status_changed) && lf_tag_compare(lf_tag(env), tag_when_started_waiting) == 0) {


### PR DESCRIPTION
The subtraction of the `_lf_action_delay_table` entry from the `wait_until_time` value is causing issues. 

When the `after` keyword is used the delay is set accordingly.  But when the `after` keyword is NOT used then the _lf_action_delay_table entry gets set to `NEVER` that maps to `LLONG_MIN`. 

According to the inline documentation located shown below and located at https://github.com/lf-lang/lingua-franca/blob/0bb4bf973f24c3f484e42fa0816af3315ff6828d/core/src/main/java/org/lflang/federated/extensions/CExtensionUtils.java#L163
```
/**
   * Given a connection 'delay' expression, return a string that represents the interval_t value of
   * the additional delay that needs to be applied to the outgoing message.
   *
   * <p>The returned additional delay in absence of after on network connection (i.e., if delay is
   * passed as a null) is NEVER. This has a special meaning in C library functions that send network
   * messages that carry timestamps (@see send_timed_message and send_port_absent_to_federate in
   * lib/core/federate.c). In this case, the sender will send its current tag as the timestamp of
   * the outgoing message without adding a microstep delay. If the user has assigned an after delay
   * to the network connection (that can be zero) either as a time value (e.g., 200 msec) or as a
   * literal (e.g., a parameter), that delay in nsec will be returned.
   *
   * @param delay The delay associated with a connection.
   */
```

As the `NEVER` value is a special value within reactor-c I am assuming this is a reactor-c issue and not an LF generation issue.

I did a inline check to replace `NEVER` with 0. Let me know if a different solution is preferred. 