### PR TITLE
Further cleanup of assertions

### DIFF
--- a/core/environment.c
+++ b/core/environment.c
@@ -45,7 +45,7 @@ static void environment_init_threaded(environment_t* env, int num_workers) {
 #if !defined(LF_SINGLE_THREADED)
     env->num_workers = num_workers;
     env->thread_ids = (lf_thread_t*)calloc(num_workers, sizeof(lf_thread_t));
-    LF_ASSERT(env->thread_ids, "Out of memory");
+    LF_ASSERT_NON_NULL(env->thread_ids);
     env->barrier.requestors = 0;
     env->barrier.horizon = FOREVER_TAG;
     
@@ -77,16 +77,16 @@ static void environment_init_modes(environment_t* env, int num_modes, int num_st
 #ifdef MODAL_REACTORS
     if (num_modes > 0) {
         mode_environment_t* modes = (mode_environment_t *) calloc(1, sizeof(mode_environment_t));
-        LF_ASSERT(modes, "Out of memory");
+        LF_ASSERT_NON_NULL(modes);
         modes->modal_reactor_states = (reactor_mode_state_t**) calloc(num_modes, sizeof(reactor_mode_state_t*));
-        LF_ASSERT(modes->modal_reactor_states, "Out of memory");
+        LF_ASSERT_NON_NULL(modes->modal_reactor_states);
         modes->modal_reactor_states_size = num_modes;
         modes->triggered_reactions_request = 0;
 
         modes->state_resets_size = num_state_resets;
         if (modes->state_resets_size > 0) {
             modes->state_resets = (mode_state_variable_reset_data_t *) calloc(modes->state_resets_size, sizeof(mode_state_variable_reset_data_t));
-            LF_ASSERT(modes->state_resets, "Out of memory");
+            LF_ASSERT_NON_NULL(modes->state_resets);
         } else {
             modes->state_resets = NULL;
         }
@@ -106,7 +106,7 @@ static void environment_init_federated(environment_t* env, int num_is_present_fi
 #ifdef FEDERATED_DECENTRALIZED
     if (num_is_present_fields > 0) {
         env->_lf_intended_tag_fields = (tag_t**) calloc(num_is_present_fields, sizeof(tag_t*));
-        LF_ASSERT(env->_lf_intended_tag_fields, "Out of memory");
+        LF_ASSERT_NON_NULL(env->_lf_intended_tag_fields);
         env->_lf_intended_tag_fields_size = num_is_present_fields;
     } else {
         env->_lf_intended_tag_fields = NULL;
@@ -192,7 +192,7 @@ int environment_init(
 ) {
 
     env->name = malloc(strlen(name) + 1);  // +1 for the null terminator
-    LF_ASSERT(env->name, "Out of memory");
+    LF_ASSERT_NON_NULL(env->name);
     strcpy(env->name, name);
     
     env->id = id;
@@ -201,7 +201,7 @@ int environment_init(
     env->timer_triggers_size=num_timers;
     if(env->timer_triggers_size > 0) {
         env->timer_triggers = (trigger_t **) calloc(num_timers, sizeof(trigger_t));
-        LF_ASSERT(env->timer_triggers, "Out of memory");
+        LF_ASSERT_NON_NULL(env->timer_triggers);
     } else {
         env->timer_triggers = NULL;
     }
@@ -209,7 +209,7 @@ int environment_init(
     env->startup_reactions_size=num_startup_reactions;
     if (env->startup_reactions_size > 0) {
         env->startup_reactions = (reaction_t **) calloc(num_startup_reactions, sizeof(reaction_t));
-        LF_ASSERT(env->startup_reactions, "Out of memory");
+        LF_ASSERT_NON_NULL(env->startup_reactions);
     } else {
         env->startup_reactions = NULL;
     }
@@ -217,7 +217,7 @@ int environment_init(
     env->shutdown_reactions_size=num_shutdown_reactions;
     if(env->shutdown_reactions_size > 0) {
         env->shutdown_reactions = (reaction_t **) calloc(num_shutdown_reactions, sizeof(reaction_t));
-        LF_ASSERT(env->shutdown_reactions, "Out of memory");
+        LF_ASSERT_NON_NULL(env->shutdown_reactions);
     } else {
         env->shutdown_reactions = NULL;
     }
@@ -225,7 +225,7 @@ int environment_init(
     env->reset_reactions_size=num_reset_reactions;
     if (env->reset_reactions_size > 0) {
         env->reset_reactions = (reaction_t **) calloc(num_reset_reactions, sizeof(reaction_t));
-        LF_ASSERT(env->reset_reactions, "Out of memory");
+        LF_ASSERT_NON_NULL(env->reset_reactions);
     } else {
         env->reset_reactions = NULL;
     }
@@ -235,9 +235,9 @@ int environment_init(
 
     if (env->is_present_fields_size > 0) {
         env->is_present_fields = (bool**)calloc(num_is_present_fields, sizeof(bool*));
-        LF_ASSERT(env->is_present_fields, "Out of memory");
+        LF_ASSERT_NON_NULL(env->is_present_fields);
         env->is_present_fields_abbreviated = (bool**)calloc(num_is_present_fields, sizeof(bool*));
-        LF_ASSERT(env->is_present_fields_abbreviated, "Out of memory");
+        LF_ASSERT_NON_NULL(env->is_present_fields_abbreviated);
     } else {
         env->is_present_fields = NULL;
         env->is_present_fields_abbreviated = NULL;

--- a/core/threaded/scheduler_adaptive.c
+++ b/core/threaded/scheduler_adaptive.c
@@ -716,13 +716,13 @@ void lf_sched_init(environment_t* env, size_t number_of_workers, sched_params_t*
     
     lf_scheduler_t* scheduler = env->scheduler;
     scheduler->custom_data = (custom_scheduler_data_t *) calloc(1, sizeof(custom_scheduler_data_t));
-    LF_ASSERT(scheduler->custom_data, "Out of memory");
+    LF_ASSERT_NON_NULL(scheduler->custom_data);
     scheduler->custom_data->worker_states = (worker_states_t *) calloc(1, sizeof(worker_states_t));
-    LF_ASSERT(scheduler->custom_data->worker_states, "Out of memory");
+    LF_ASSERT_NON_NULL(scheduler->custom_data->worker_states);
     scheduler->custom_data->worker_assignments = (worker_assignments_t *) calloc(1, sizeof(worker_assignments_t));
-    LF_ASSERT(scheduler->custom_data->worker_assignments, "Out of memory");
+    LF_ASSERT_NON_NULL(scheduler->custom_data->worker_assignments);
     scheduler->custom_data->data_collection = (data_collection_t *) calloc(1, sizeof(data_collection_t));
-    LF_ASSERT(scheduler->custom_data->data_collection, "Out of memory");
+    LF_ASSERT_NON_NULL(scheduler->custom_data->data_collection);
 
     worker_states_init(scheduler, number_of_workers);
     worker_assignments_init(scheduler, number_of_workers, params);

--- a/core/trace.c
+++ b/core/trace.c
@@ -59,7 +59,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 trace_t* trace_new(environment_t* env, const char * filename) {
     trace_t * trace = (trace_t *) calloc(1, sizeof(trace_t));
-    LF_ASSERT(trace, "Out of memory");
+    LF_ASSERT_NON_NULL(trace);
 
     trace->_lf_trace_stop=1;
     trace->env = env;
@@ -69,7 +69,7 @@ trace_t* trace_new(environment_t* env, const char * filename) {
 
     // Allocate memory for the filename on the trace struct
     trace->filename = (char*) malloc(len * sizeof(char));
-    LF_ASSERT(trace->filename, "Out of memory");
+    LF_ASSERT_NON_NULL(trace->filename);
 
     // Copy it to the struct
     strncpy(trace->filename, filename, len);

--- a/include/core/utils/util.h
+++ b/include/core/utils/util.h
@@ -281,6 +281,8 @@ void lf_register_print_function(print_message_function_t* function, int log_leve
  * evaluate to false (zero).
  * These are optimized to execute the condition argument but not
  * check the result if the NDEBUG flag is defined.
+ * The NDEBUG flag will be defined if the user specifies `build-type: Release`
+ * in the target properties of the LF program.
  * 
  * LF_ASSERT_NON_NULL can be used to verify that a pointer is not NULL.
  * It differs from LF_ASSERT in that it does nothing at all if the NDEBUG flag is defined.


### PR DESCRIPTION
This PR uses LF_ASSERT_NON_NULL after malloc/calloc.