### PR TITLE
First step towards versioned federation protocol

### DIFF
--- a/core/federated/RTI/rti_remote.h
+++ b/core/federated/RTI/rti_remote.h
@@ -99,10 +99,14 @@ typedef enum clock_sync_stat {
  */
 typedef struct rti_remote_t {
     rti_common_t base;
-    // Maximum start time seen so far from the federates.
+
+    /** Protocol version or -1 if not set. */
+    int32_t protocol_version;
+
+    /** Maximum start time seen so far from the federates. */
     int64_t max_start_time;
 
-    // Number of federates that have proposed start times.
+    /** Number of federates that have proposed start times. */
     int num_feds_proposed_start;
 
     /**
@@ -348,13 +352,6 @@ void* clock_synchronization_thread(void* noargs);
  *  socket descriptor for the federate.
  */
 void* federate_info_thread_TCP(void* fed);
-
-/**
- * Send a MSG_TYPE_REJECT message to the specified socket and close the socket.
- * @param socket_id Pointer to the socket ID.
- * @param error_code An error code.
- */
-void send_reject(int* socket_id, unsigned char error_code);
 
 /**
  * Wait for one incoming connection request from each federate,


### PR DESCRIPTION
This PR adds a new signal type `MSG_TYPE_FED_VERSION` to the federated protocol and deprecates `MSG_TYPE_FED_IDS`.  This signal is sent by a federate to the RTI when it first joins the federation.  The signal `MSG_TYPE_FED_VERSION` adds three bytes to indicate major, minor, and patch version numbers for the protocol.  The current version number in this PR is `0.1.0`.  If the `MSG_TYPE_FED_IDS` signal is used by the federates joining the federation, then the RTI will interpret this as version `0.0.0` and will operate in a backward compatible way.  This means that you can install the RTI from `main` or from the nightly build, and it will still work if you compile federates using the latest release instead of `main` or the nightly build.  Thus, one installation of the RTI can be used for development and for demos/etc. with the latest release.