### PR TITLE
Put a single event on the recycle queue initially to avoid runtime malloc

### DIFF
--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -550,9 +550,8 @@ void _lf_initialize_timers(environment_t* env) {
         }
     }
     
-    // Create an extra event and put it on the recycle queue. 
-    // An LF program with n timers require n+1 events. By putting the
-    // last event on the recycle queue we avoid allocating it at runtime.
+    // To avoid runtime memory allocations for timer-driven programs
+    // the recycle queue is initialized with a single event.
     if (env->timer_triggers_size > 0) {
         event_t *e = _lf_get_new_event(env);
         _lf_recycle_event(env, e);

--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -549,6 +549,14 @@ void _lf_initialize_timers(environment_t* env) {
             _lf_initialize_timer(env, env->timer_triggers[i]);
         }
     }
+    
+    // Create an extra event and put it on the recycle queue. 
+    // An LF program with n timers require n+1 events and the last event 
+    // needs to be initialized to the event recycle queue.
+    if (env->timer_triggers_size > 0) {
+        event_t *e = _lf_get_new_event(env);
+        _lf_recycle_event(env, e);
+    }
 }
 
 /**

--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -551,8 +551,8 @@ void _lf_initialize_timers(environment_t* env) {
     }
     
     // Create an extra event and put it on the recycle queue. 
-    // An LF program with n timers require n+1 events and the last event 
-    // needs to be initialized to the event recycle queue.
+    // An LF program with n timers require n+1 events. By putting the
+    // last event on the recycle queue we avoid allocating it at runtime.
     if (env->timer_triggers_size > 0) {
         event_t *e = _lf_get_new_event(env);
         _lf_recycle_event(env, e);


### PR DESCRIPTION
An LF program with n timers need n+1 events. The last event should initially reside in the recycle queue to avoid any runtime memory allocations. This PR puts on there if the program has timers. 