### PR TITLE
Save trace file for RTI in abnormal termination

### DIFF
--- a/core/federated/RTI/main.c
+++ b/core/federated/RTI/main.c
@@ -108,6 +108,7 @@ void termination() {
             send_failed_signal(f);
         }
         if (rti.base.tracing_enabled) {
+            lf_tracing_global_shutdown();
             lf_print("RTI trace file saved.");
         }
         lf_print("RTI is exiting abnormally.");


### PR DESCRIPTION
This is a quick cleanup for a mistake in my recent tracing PR. Thanks to @byeong-gil for noticing this issue so quickly.

I tested this PR locally on FeedbackDelay5 when `Ctrl+C`'ing the program early. It seemed to fix the problem and create a non-empty RTI trace file.

Closes #373.