### PR TITLE
Run one worker on main thread

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -93,7 +93,7 @@ endif()
 
 # Link with thread library, unless we are on the Zephyr platform.
 if(NOT DEFINED LF_SINGLE_THREADED OR DEFINED LF_TRACE)
-    if (NOT PLATFORM_ZEPHYR)
+    if (NOT (PLATFORM_ZEPHYR OR ${CMAKE_SYSTEM_NAME} STREQUAL "Rp2040"))
         find_package(Threads REQUIRED)
         target_link_libraries(reactor-c PUBLIC Threads::Threads)
     endif()

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -93,7 +93,7 @@ endif()
 
 # Link with thread library, unless we are on the Zephyr platform.
 if(NOT DEFINED LF_SINGLE_THREADED OR DEFINED LF_TRACE)
-    if (NOT (PLATFORM_ZEPHYR OR ${CMAKE_SYSTEM_NAME} STREQUAL "Rp2040"))
+    if (NOT (PLATFORM_ZEPHYR OR PLATFORM_RP2040))
         find_package(Threads REQUIRED)
         target_link_libraries(reactor-c PUBLIC Threads::Threads)
     endif()

--- a/core/platform/CMakeLists.txt
+++ b/core/platform/CMakeLists.txt
@@ -24,6 +24,7 @@ elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Zephyr")
     set(PLATFORM_ZEPHYR true)
 elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Rp2040")
     list(APPEND REACTORC_COMPILE_DEFS PLATFORM_RP2040)
+    set(PLATFORM_RP2040 true)
 endif()
 
 # Prepend all sources with platform

--- a/core/platform/lf_rp2040_support.c
+++ b/core/platform/lf_rp2040_support.c
@@ -308,7 +308,7 @@ int lf_cond_wait(lf_cond_t* cond) {
     return 0;
 }
 
-int lf_cond_timedwait(lf_cond_t* cond, instant_t absolute_time_ns) {
+int _lf_cond_timedwait(lf_cond_t* cond, instant_t absolute_time_ns) {
     absolute_time_t a = from_us_since_boot(absolute_time_ns / 1000);
     bool acquired_permit = sem_acquire_block_until(&(cond->sema), a);
     return acquired_permit ? 0 : LF_TIMEOUT;

--- a/core/platform/lf_rp2040_support.c
+++ b/core/platform/lf_rp2040_support.c
@@ -302,9 +302,9 @@ int lf_cond_signal(lf_cond_t* cond) {
 }
 
 int lf_cond_wait(lf_cond_t* cond) {
-    mutex_exit(cond->mutex);
+    lf_mutex_unlock(cond->mutex);
     sem_acquire_blocking(&(cond->sema));
-    mutex_enter_blocking(cond->mutex);
+    lf_mutex_lock(cond->mutex);
     return 0;
 }
 

--- a/core/platform/lf_rp2040_support.c
+++ b/core/platform/lf_rp2040_support.c
@@ -221,10 +221,7 @@ int _lf_single_threaded_notify_of_event() {
  * @brief Get the number of cores on the host machine.
  */
 int lf_available_cores() {
-    // Right now, runtime creates 1 main thread and 1 worker thread
-    // In the future, this may be changed to 2 (if main thread also functions
-    // as a worker thread)
-    return 1;
+    return 2;
 }
 
 static void *(*thread_1) (void *);

--- a/core/platform/lf_rp2040_support.c
+++ b/core/platform/lf_rp2040_support.c
@@ -234,11 +234,6 @@ static void* thread_1_return;
 void core1_entry() {
     thread_1_return = thread_1(thread_1_args);
     sem_release(&thread_1_done);
-
-    // infinite loop; core1 should never exit
-    while (1){
-        tight_loop_contents();
-    }
 }
 
 int lf_thread_create(lf_thread_t* thread, void *(*lf_thread) (void *), void* arguments) {

--- a/core/platform/lf_rp2040_support.c
+++ b/core/platform/lf_rp2040_support.c
@@ -314,67 +314,6 @@ int lf_cond_timedwait(lf_cond_t* cond, instant_t absolute_time_ns) {
     return acquired_permit ? 0 : LF_TIMEOUT;
 }
 
-
-// Atomics
-//  Implemented by just entering a critical section and doing the arithmetic.
-//  This is somewhat inefficient considering enclaves. Since we get a critical
-//  section in between different enclaves
-
-
-/**
- * @brief Add `value` to `*ptr` and return original value of `*ptr`
- */
-int _rp2040_atomic_fetch_add(int *ptr, int value) {
-    critical_section_enter_blocking(&_lf_atomics_crit_sec);
-    int res = *ptr;
-    *ptr += value;
-    critical_section_exit(&_lf_atomics_crit_sec);
-    return res;
-}
-/**
- * @brief Add `value` to `*ptr` and return new updated value of `*ptr`
- */
-int _rp2040_atomic_add_fetch(int *ptr, int value) {
-    critical_section_enter_blocking(&_lf_atomics_crit_sec);
-    int res = *ptr + value;
-    *ptr = res;
-    critical_section_exit(&_lf_atomics_crit_sec);
-    return res;
-}
-
-/**
- * @brief Compare and swap for boolaen value.
- * If `*ptr` is equal to `value` then overwrite it
- * with `newval`. If not do nothing. Retruns true on overwrite.
- */
-bool _rp2040_bool_compare_and_swap(bool *ptr, bool value, bool newval) {
-    critical_section_enter_blocking(&_lf_atomics_crit_sec);
-    bool res = false;
-    if (*ptr == value) {
-        *ptr = newval;
-        res = true;
-    }
-    critical_section_exit(&_lf_atomics_crit_sec);
-    return res;
-}
-
-/**
- * @brief Compare and swap for integers. If `*ptr` is equal
- * to `value`, it is updated to `newval`. The function returns
- * the original value of `*ptr`.
- */
-int  _rp2040_val_compare_and_swap(int *ptr, int value, int newval) {
-    critical_section_enter_blocking(&_lf_atomics_crit_sec);
-    int res = *ptr;
-    if (*ptr == value) {
-        *ptr = newval;
-    }
-    critical_section_exit(&_lf_atomics_crit_sec);
-    return res;
-}
-
-
-
 #endif // LF_SINGLE_THREADED
 
 

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -1190,10 +1190,10 @@ int lf_reactor_c_main(int argc, const char* argv[]) {
                     lf_print_error("Failed to join thread listening for incoming messages: %s", strerror(failure));
                 }
             }
-        	if (worker_thread_exit_status != NULL) {
+            if (worker_thread_exit_status != NULL) {
                 lf_print_error("---- Worker %d reports error code %p", j, worker_thread_exit_status);
                 ret = 1;
-        	}
+            }
         }
         
         if (ret == 0) {

--- a/include/core/platform/lf_rp2040_support.h
+++ b/include/core/platform/lf_rp2040_support.h
@@ -20,4 +20,41 @@
 #define LF_TIME_BUFFER_LENGTH 80
 #define _LF_TIMEOUT 1
 
+#ifndef LF_SINGLE_THREADED
+#warning "Threaded support on rp2040 is still experimental"
+
+typedef mutex_t lf_mutex_t;
+typedef struct {
+    semaphore_t sema;
+    mutex_t* mutex;
+} lf_cond_t;
+typedef int lf_thread_t;
+
+
+/**
+ * @brief Add `value` to `*ptr` and return original value of `*ptr`
+ */
+int _rp2040_atomic_fetch_add(int *ptr, int value);
+/**
+ * @brief Add `value` to `*ptr` and return new updated value of `*ptr`
+ */
+int _rp2040_atomic_add_fetch(int *ptr, int value);
+
+/**
+ * @brief Compare and swap for boolaen value.
+ * If `*ptr` is equal to `value` then overwrite it
+ * with `newval`. If not do nothing. Retruns true on overwrite.
+ */
+bool _rp2040_bool_compare_and_swap(bool *ptr, bool value, bool newval);
+
+/**
+ * @brief Compare and swap for integers. If `*ptr` is equal
+ * to `value`, it is updated to `newval`. The function returns
+ * the original value of `*ptr`.
+ */
+int  _rp2040_val_compare_and_swap(int *ptr, int value, int newval);
+
+
+#endif // LF_THREADED
+
 #endif // LF_PICO_SUPPORT_H

--- a/include/core/platform/lf_rp2040_support.h
+++ b/include/core/platform/lf_rp2040_support.h
@@ -23,10 +23,10 @@
 #ifndef LF_SINGLE_THREADED
 #warning "Threaded support on rp2040 is still experimental"
 
-typedef mutex_t lf_mutex_t;
+typedef recursive_mutex_t lf_mutex_t;
 typedef struct {
     semaphore_t sema;
-    mutex_t* mutex;
+    lf_mutex_t* mutex;
 } lf_cond_t;
 typedef int lf_thread_t;
 

--- a/include/core/platform/lf_rp2040_support.h
+++ b/include/core/platform/lf_rp2040_support.h
@@ -30,31 +30,6 @@ typedef struct {
 } lf_cond_t;
 typedef int lf_thread_t;
 
-
-/**
- * @brief Add `value` to `*ptr` and return original value of `*ptr`
- */
-int _rp2040_atomic_fetch_add(int *ptr, int value);
-/**
- * @brief Add `value` to `*ptr` and return new updated value of `*ptr`
- */
-int _rp2040_atomic_add_fetch(int *ptr, int value);
-
-/**
- * @brief Compare and swap for boolaen value.
- * If `*ptr` is equal to `value` then overwrite it
- * with `newval`. If not do nothing. Retruns true on overwrite.
- */
-bool _rp2040_bool_compare_and_swap(bool *ptr, bool value, bool newval);
-
-/**
- * @brief Compare and swap for integers. If `*ptr` is equal
- * to `value`, it is updated to `newval`. The function returns
- * the original value of `*ptr`.
- */
-int  _rp2040_val_compare_and_swap(int *ptr, int value, int newval);
-
-
-#endif // LF_THREADED
+#endif // LF_SINGLE_THREADED
 
 #endif // LF_PICO_SUPPORT_H


### PR DESCRIPTION
Followup to #344

On embedded platforms, we have a very limited number of threads (i.e. just two on the rp2040). Therefore, we would like the main thread to run a worker, rather than just sitting idle while other threads run workers. This PR proposes the simplest way of doing so.

One alternate approach is to make a list of threads, and a function that runs them all at once (essentially separating out the fork/join logic). I think it would look cleaner, but would involve a significant amount of extra code to create a "thread list" type. Since this "thread list" type would only be used once, I'm not sure if its worth the tradeoff.

Open to any other approaches as well.