### PR TITLE
Fix tagged message length from int32_t to uint32_t

### DIFF
--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -340,7 +340,7 @@ void handle_port_absent_message(federate_info_t* sending_federate, unsigned char
 }
 
 void handle_timed_message(federate_info_t* sending_federate, unsigned char* buffer) {
-  size_t header_size = 1 + sizeof(uint16_t) + sizeof(uint16_t) + sizeof(int32_t) + sizeof(int64_t) + sizeof(uint32_t);
+  size_t header_size = 1 + sizeof(uint16_t) + sizeof(uint16_t) + sizeof(uint32_t) + sizeof(int64_t) + sizeof(uint32_t);
   // Read the header, minus the first byte which has already been read.
   read_from_socket_fail_on_error(&sending_federate->socket, header_size - 1, &(buffer[1]), NULL,
                                  "RTI failed to read the timed message header from remote federate.");

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -509,7 +509,7 @@ static int handle_tagged_message(int* socket, int fed_id) {
   _lf_get_environments(&env);
 
   // Read the header which contains the timestamp.
-  size_t bytes_to_read =
+  size_t bytes_to_read = 
       sizeof(uint16_t) + sizeof(uint16_t) + sizeof(int32_t) + sizeof(instant_t) + sizeof(microstep_t);
   unsigned char buffer[bytes_to_read];
   if (read_from_socket_close_on_error(socket, bytes_to_read, buffer)) {

--- a/core/federated/network/net_util.c
+++ b/core/federated/network/net_util.c
@@ -413,7 +413,7 @@ void extract_header(unsigned char* buffer, uint16_t* port_id, uint16_t* federate
   // printf("DEBUG: Message for port %d of federate %d.\n", *port_id, *federate_id);
 
   // The next four bytes are the message length.
-  int32_t local_length_signed = extract_int32(&(buffer[sizeof(uint16_t) + sizeof(uint16_t)]));
+  uint32_t local_length_signed = extract_uint32(&(buffer[sizeof(uint16_t) + sizeof(uint16_t)]));
   if (local_length_signed < 0) {
     lf_print_error_and_exit("Received an invalid message length (%d) from federate %d.", local_length_signed,
                             *federate_id);

--- a/include/core/federated/network/net_common.h
+++ b/include/core/federated/network/net_common.h
@@ -386,7 +386,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Byte identifying a timestamped message to forward to another federate.
  * The next two bytes will be the ID of the destination reactor port.
  * The next two bytes are the destination federate ID.
- * The four bytes after that will be the length of the message.
+ * The four bytes after that will be the length of the message (as an unsigned 32-bit int).
  * The next eight bytes will be the timestamp of the message.
  * The next four bytes will be the microstep of the message.
  * The remaining bytes are the message.


### PR DESCRIPTION
This is a fix of #368.

The tagged message sends a message length of int32_t. The length should not be negative, so changing it to uint32_t.

It is both applied on MSG_TYPE `MSG_TYPE_TAGGED_MESSAGE` and `MSG_TYPE_P2P_TAGGED_MESSAGE`.

It also makes the maximum size of the tagged message from 2GB to 4GB.

By the way, the typescript target already writes in unsigned int 32 type.

`msg.writeUInt32LE(value.length, 5);`