### PR TITLE
Add address query reply message

### DIFF
--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -721,8 +721,9 @@ void handle_address_query(uint16_t fed_id) {
   // the port number because it has not yet received an MSG_TYPE_ADDRESS_ADVERTISEMENT message
   // from this federate. In that case, it will respond by sending -1.
 
-  // Response message is also of type MSG_TYPE_ADDRESS_QUERY.
-  buffer[0] = MSG_TYPE_ADDRESS_QUERY;
+  // Response message is MSG_TYPE_ADDRESS_QUERY_REPLY.
+  buffer[0] = MSG_TYPE_ADDRESS_QUERY_REPLY;
+
 
   // Encode the port number.
   federate_info_t* remote_fed = GET_FED_INFO(remote_fed_id);

--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -724,7 +724,6 @@ void handle_address_query(uint16_t fed_id) {
   // Response message is MSG_TYPE_ADDRESS_QUERY_REPLY.
   buffer[0] = MSG_TYPE_ADDRESS_QUERY_REPLY;
 
-
   // Encode the port number.
   federate_info_t* remote_fed = GET_FED_INFO(remote_fed_id);
 

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -1710,7 +1710,7 @@ void lf_connect_to_federate(uint16_t remote_federate_id) {
                                    remote_federate_id);
 
     if (buffer[0] != MSG_TYPE_ADDRESS_QUERY_REPLY) {
-      // Unexpected reply.  Could be that RTI has failed and sent a resignation.
+      // Unexpected reply. Could be that RTI has failed and sent a resignation.
       if (buffer[0] == MSG_TYPE_FAILED) {
         lf_print_error_and_exit("RTI has failed.");
       } else {

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -1709,7 +1709,7 @@ void lf_connect_to_federate(uint16_t remote_federate_id) {
                                    "Failed to read the requested port number for federate %d from RTI.",
                                    remote_federate_id);
 
-    if (buffer[0] != MSG_TYPE_ADDRESS_QUERY) {
+    if (buffer[0] != MSG_TYPE_ADDRESS_QUERY_REPLY) {
       // Unexpected reply.  Could be that RTI has failed and sent a resignation.
       if (buffer[0] == MSG_TYPE_FAILED) {
         lf_print_error_and_exit("RTI has failed.");

--- a/include/core/federated/network/net_common.h
+++ b/include/core/federated/network/net_common.h
@@ -528,12 +528,20 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Byte identifying a address query message, sent by a federate to RTI
  * to ask for another federate's address and port number.
  * The next two bytes are the other federate's ID.
- * The reply from the RTI will a port number (an int32_t), which is -1
+ */
+#define MSG_TYPE_ADDRESS_QUERY 13
+
+/**
+ * Byte identifying a address query message reply, sent by a RTI to a federate
+ * to reply with a remote federate's address and port number.
+ * The reply from the RTI will be a port number (an int32_t), which is -1
  * if the RTI does not know yet (it has not received MSG_TYPE_ADDRESS_ADVERTISEMENT from
  * the other federate), followed by the IP address of the other
  * federate (an IPV4 address, which has length INET_ADDRSTRLEN).
+ * The next four bytes (or sizeof(int32_t)) will be the port number.
+ * The next four bytes (or sizeof(in_addr), which is uint32_t) will be the ip address.
  */
-#define MSG_TYPE_ADDRESS_QUERY 13
+#define MSG_TYPE_ADDRESS_QUERY_REPLY 14
 
 /**
  * Byte identifying a message advertising the port for the TCP connection server
@@ -543,7 +551,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * The sending federate will not wait for a response from the RTI and assumes its
  * request will be processed eventually by the RTI.
  */
-#define MSG_TYPE_ADDRESS_ADVERTISEMENT 14
+#define MSG_TYPE_ADDRESS_ADVERTISEMENT 15
 
 /**
  * Byte identifying a first message that is sent by a federate directly to another federate
@@ -554,7 +562,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * federate does not expect this federate or federation to connect, it will respond
  * instead with MSG_TYPE_REJECT.
  */
-#define MSG_TYPE_P2P_SENDING_FED_ID 15
+#define MSG_TYPE_P2P_SENDING_FED_ID 16
 
 /**
  * Byte identifying a message to send directly to another federate.
@@ -565,7 +573,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * The four bytes after will be the length of the message.
  * The ramaining bytes are the message.
  */
-#define MSG_TYPE_P2P_MESSAGE 16
+#define MSG_TYPE_P2P_MESSAGE 17
 
 /**
  * Byte identifying a timestamped message to send directly to another federate.
@@ -582,7 +590,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * The next four bytes will be the microstep of the sender.
  * The ramaining bytes are the message.
  */
-#define MSG_TYPE_P2P_TAGGED_MESSAGE 17
+#define MSG_TYPE_P2P_TAGGED_MESSAGE 18
 
 ////////////////////////////////////////////////
 /**


### PR DESCRIPTION
This PR reopens #369 

In decentralized coordination, the federate sends MSG_TYPE_ADDRESS_QUERY to the RTI with the payload being the ID of the federate it wishes to connect to.

Then, the RTI will reply with the remote federate's port number and IP address, using the same message header MSG_TYPE_ADDRESS_QUERY.

I suggest the reply message header to be changed from MSG_TYPE_ADDRESS_QUERY to MSG_TYPE_ADDRESS_QUERY_REPLY.

I just pushed the MSG_TYPE number down. Since 18 was empty, didn't need to push down all the numbers. Future work will to make it in enums.

Since this changes the protocol after this merge, the RTI must be rebuilt.