### PR TITLE
Update RTI dockerfile to match file layout change

### DIFF
--- a/core/federated/RTI/rti.Dockerfile
+++ b/core/federated/RTI/rti.Dockerfile
@@ -1,7 +1,6 @@
 # Docker file for building the image of the rti
 FROM alpine:latest
-COPY core /lingua-franca/core
-COPY include /lingua-franca/include
+COPY . /lingua-franca
 WORKDIR /lingua-franca/core/federated/RTI
 RUN set -ex && apk add --no-cache gcc musl-dev cmake make && \
     mkdir container && \

--- a/include/core/federated/network/net_common.h
+++ b/include/core/federated/network/net_common.h
@@ -483,7 +483,6 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   do {                                                                                                                 \
     buffer[0] = MSG_TYPE_STOP_REQUEST;                                                                                 \
     encode_int64(time, &(buffer[1]));                                                                                  \
-    assert(microstep >= 0);                                                                                            \
     encode_int32((int32_t)microstep, &(buffer[1 + sizeof(instant_t)]));                                                \
   } while (0)
 
@@ -501,7 +500,6 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   do {                                                                                                                 \
     buffer[0] = MSG_TYPE_STOP_REQUEST_REPLY;                                                                           \
     encode_int64(time, &(buffer[1]));                                                                                  \
-    assert(microstep >= 0);                                                                                            \
     encode_int32((int32_t)microstep, &(buffer[1 + sizeof(instant_t)]));                                                \
   } while (0)
 
@@ -518,7 +516,6 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   do {                                                                                                                 \
     buffer[0] = MSG_TYPE_STOP_GRANTED;                                                                                 \
     encode_int64(time, &(buffer[1]));                                                                                  \
-    assert(microstep >= 0);                                                                                            \
     encode_int32((int32_t)microstep, &(buffer[1 + sizeof(instant_t)]));                                                \
   } while (0)
 


### PR DESCRIPTION
This could harm reproducibility and could increase the size of the RTI image. However, reproducibility is actually not much worse than the status quo which was still copying whole directories. Also, the amount of extra stuff copied is small. In the long run this will keep us from running into further problems as we continue to refactor this repo without testing the dockerized RTI build in CI (I am assuming that it is not worthwhile to add a test for it in CI)

I have manually verified that this does build locally.