### PR TITLE
Making MIN_SLEEP_DURATION a platform variable and Add busy wait

### DIFF
--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -28,6 +28,8 @@
 #include "reactor_common.h"
 #include "watchdog.h"
 
+#include "platform/lf_unix_clock_support.h"
+
 #ifdef FEDERATED
 #include "federate.h"
 #endif

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -241,6 +241,9 @@ bool wait_until(instant_t logical_time, lf_cond_t* condition) {
     if (wait_duration < MIN_SLEEP_DURATION) {
       LF_PRINT_DEBUG("Wait time " PRINTF_TIME " is less than MIN_SLEEP_DURATION " PRINTF_TIME ". Skipping wait.",
                      wait_duration, MIN_SLEEP_DURATION);
+      while (lf_time_physical() < wait_until_time) {
+        //Busy wait
+      }
       return true;
     }
 

--- a/include/core/reactor_common.h
+++ b/include/core/reactor_common.h
@@ -42,7 +42,7 @@
  * to prevent unnecessary delays caused by simply setting up and
  * performing the wait.
  */
-#define MIN_SLEEP_DURATION USEC(10)
+// #define MIN_SLEEP_DURATION USEC(10)
 
 //////////////////////  Global Variables  //////////////////////
 

--- a/low_level_platform/api/platform/lf_unix_clock_support.h
+++ b/low_level_platform/api/platform/lf_unix_clock_support.h
@@ -1,6 +1,8 @@
 #include <time.h>
 #include <errno.h>
 
+extern instant_t MIN_SLEEP_DURATION;
+
 /**
  * @brief Convert a _lf_time_spec_t ('tp') to an instant_t representation in
  * nanoseconds.

--- a/low_level_platform/impl/src/lf_unix_clock_support.c
+++ b/low_level_platform/impl/src/lf_unix_clock_support.c
@@ -6,6 +6,8 @@
 #include "logging.h"
 #include "platform/lf_unix_clock_support.h"
 
+instant_t MIN_SLEEP_DURATION;
+
 instant_t convert_timespec_to_ns(struct timespec tp) { return ((instant_t)tp.tv_sec) * BILLION + tp.tv_nsec; }
 
 struct timespec convert_ns_to_timespec(instant_t t) {
@@ -23,6 +25,7 @@ void _lf_initialize_clock() {
   }
 
   lf_print("---- System clock resolution: %ld nsec", res.tv_nsec);
+  MIN_SLEEP_DURATION = NSEC(res.tv_nsec);
 }
 
 /**


### PR DESCRIPTION
As discussed in #332, I have moved forward to make the following changes for the threaded runtime:

- If the wait duration is less than `MIN_SLEEP_DURATION` the `wait_until` function busy waits until `wait_until_time` is reached. 
- `MIN_SLEEP_DURATION` was defined as an arbitrary constant of 10 usec, I changed that to be a platform variable such that the value of `MIN_SLEEP_DURATION` is equal to underlying system's clock resolution. 