### PR TITLE
I-controller for wait_until lag 

### DIFF
--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -42,7 +42,8 @@ extern instant_t start_time;
  */
 #define MAX_STALL_INTERVAL MSEC(1)
 
-#define LAG_CONTROL_DIV  2
+#define KI_DIV  2
+#define KI_MUL 3
 
 /**
  * Global mutex, used for synchronizing across environments. Mainly used for token-management and tracing
@@ -251,7 +252,7 @@ bool wait_until(instant_t logical_time, lf_cond_t* condition) {
     if (wait_until_time < now) {
       return true;
     } else if (wait_until_time_with_adjustment < now && wait_until_time > now) {
-      error_control = error_control - ((now - wait_until_time_with_adjustment) / LAG_CONTROL_DIV);
+      error_control = error_control - (((now - wait_until_time_with_adjustment) * KI_MUL) / KI_DIV);
       while (wait_until_time > lf_time_physical()){}
       return true;
     }
@@ -277,7 +278,7 @@ bool wait_until(instant_t logical_time, lf_cond_t* condition) {
       
       //Calculate the lag and update the average
       instant_t lag = lf_time_physical() - wait_until_time;
-      error_control = error_control + (lag / LAG_CONTROL_DIV);
+      error_control = error_control + ((lag * KI_MUL) / KI_DIV);
       // lag = lag - ave_lag;
       // lag_count++;
       // lag = lag / lag_count;

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -238,16 +238,18 @@ bool wait_until(instant_t logical_time, lf_cond_t* condition) {
   if (!fast) {
     // Check whether we actually need to wait, or if we have already passed the timepoint.
     interval_t wait_duration = wait_until_time - lf_time_physical();
-    if (wait_duration < MIN_SLEEP_DURATION) {
-      LF_PRINT_DEBUG("Wait time " PRINTF_TIME " is less than MIN_SLEEP_DURATION " PRINTF_TIME ". Skipping wait.",
-                     wait_duration, MIN_SLEEP_DURATION);
-      return true;
-    }
+    // if (wait_duration < MIN_SLEEP_DURATION) {
+    //   LF_PRINT_DEBUG("Wait time " PRINTF_TIME " is less than MIN_SLEEP_DURATION " PRINTF_TIME ". Skipping wait.",
+    //                  wait_duration, MIN_SLEEP_DURATION);
+    //   return true;
+    // }
 
     //Subtract the average lag from the requested wait_until_time
     interval_t wait_until_time_with_lag = wait_until_time - ave_lag;
     instant_t now = lf_time_physical();
-    if (wait_until_time_with_lag < now && wait_until_time > now) {
+    if (wait_until_time < now) {
+      return true;
+    } else if (wait_until_time_with_lag < now && wait_until_time > now) {
       while (wait_until_time > lf_time_physical()){}
       return true;
     }

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -246,11 +246,12 @@ bool wait_until(instant_t logical_time, lf_cond_t* condition) {
     // }
 
     //Subtract the average lag from the requested wait_until_time
-    interval_t wait_until_time_with_adjustment = wait_until_time - (LAG_CONTROL * error_control);
+    interval_t wait_until_time_with_adjustment = wait_until_time - error_control;
     instant_t now = lf_time_physical();
     if (wait_until_time < now) {
       return true;
     } else if (wait_until_time_with_adjustment < now && wait_until_time > now) {
+      error_control = error_control - (LAG_CONTROL * (now - wait_until_time_with_adjustment));
       while (wait_until_time > lf_time_physical()){}
       return true;
     }
@@ -276,7 +277,7 @@ bool wait_until(instant_t logical_time, lf_cond_t* condition) {
       
       //Calculate the lag and update the average
       instant_t lag = lf_time_physical() - wait_until_time;
-      error_control += lag;
+      error_control += LAG_CONTROL * lag;
       // lag = lag - ave_lag;
       // lag_count++;
       // lag = lag / lag_count;

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -197,7 +197,8 @@ void lf_set_present(lf_port_base_t* port) {
 /**
  * Wait until physical time matches or exceeds the specified logical time,
  * unless -fast is given. For decentralized coordination, this function will
- * add the STA offset to the wait time.
+ * add the STA offset to the wait time. For lag control, this function will implement
+ * an I-controller to regulate the lag introduced by the underlying sleep function.
  *
  * If an event is put on the event queue during the wait, then the wait is
  * interrupted and this function returns false. It also returns false if the
@@ -222,6 +223,7 @@ void lf_set_present(lf_port_base_t* port) {
  */
 bool wait_until(instant_t logical_time, lf_cond_t* condition) {
   LF_PRINT_DEBUG("-------- Waiting until physical time matches logical time " PRINTF_TIME, logical_time);
+  // Control value for the i-controller
   static interval_t error_control = NSEC(0);
   interval_t wait_until_time = logical_time;
 #ifdef FEDERATED_DECENTRALIZED // Only apply the STA if coordination is decentralized
@@ -235,22 +237,19 @@ bool wait_until(instant_t logical_time, lf_cond_t* condition) {
   }
 #endif
   if (!fast) {
-    // Check whether we actually need to wait, or if we have already passed the timepoint.
-    interval_t wait_duration = wait_until_time - lf_time_physical();
-    // if (wait_duration < MIN_SLEEP_DURATION) {
-    //   LF_PRINT_DEBUG("Wait time " PRINTF_TIME " is less than MIN_SLEEP_DURATION " PRINTF_TIME ". Skipping wait.",
-    //                  wait_duration, MIN_SLEEP_DURATION);
-    //   return true;
-    // }
-
-    //Subtract the average lag from the requested wait_until_time
+    // Subtract the control value from the requested wait_until_time
     interval_t wait_until_time_with_adjustment = wait_until_time - error_control;
     instant_t now = lf_time_physical();
+
+    // If the requested time is already passed, return
+    // If the adjusted wait time is already passed, but the requested wait time
+    // didn't come yet, then adjust the control value and busy wait until the requested time.
     if (wait_until_time < now) {
       return true;
     } else if (wait_until_time_with_adjustment < now && wait_until_time > now) {
       error_control = error_control - (((now - wait_until_time_with_adjustment) * KI_MUL) / KI_DIV);
-      while (wait_until_time > lf_time_physical()){}
+      while (wait_until_time > lf_time_physical())
+        ;
       return true;
     }
 
@@ -271,21 +270,18 @@ bool wait_until(instant_t logical_time, lf_cond_t* condition) {
       return false;
     } else {
       // Reached timeout.
-      LF_PRINT_DEBUG("-------- Returned from wait, having waited " PRINTF_TIME " ns.", wait_duration);
-      
-      //Calculate the lag and update the average
+      LF_PRINT_DEBUG("-------- Returned from wait, having waited until " PRINTF_TIME " ns.", wait_until_time);
+
+      // Calculate the lag and update the control value
       instant_t lag = lf_time_physical() - wait_until_time;
       error_control = error_control + ((lag * KI_MUL) / KI_DIV);
-      // lag = lag - ave_lag;
-      // lag_count++;
-      // lag = lag / lag_count;
-      // ave_lag += lag; 
 
-      //Check if the wait amount was sufficient
+      // Check if the requested time is passed, if not busy wait
       if (lf_time_physical() > wait_until_time) {
         return true;
       } else {
-        while (wait_until_time > lf_time_physical()){}
+        while (wait_until_time > lf_time_physical())
+          ;
         return true;
       }
     }

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -42,9 +42,6 @@ extern instant_t start_time;
  */
 #define MAX_STALL_INTERVAL MSEC(1)
 
-#define KI_DIV  2
-#define KI_MUL 3
-
 /**
  * Global mutex, used for synchronizing across environments. Mainly used for token-management and tracing
  */

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -222,6 +222,8 @@ void lf_set_present(lf_port_base_t* port) {
  */
 bool wait_until(instant_t logical_time, lf_cond_t* condition) {
   LF_PRINT_DEBUG("-------- Waiting until physical time matches logical time " PRINTF_TIME, logical_time);
+  static interval_t ave_lag = NSEC(0);
+  static int64_t lag_count = 0;
   interval_t wait_until_time = logical_time;
 #ifdef FEDERATED_DECENTRALIZED // Only apply the STA if coordination is decentralized
   // Apply the STA to the logical time
@@ -242,12 +244,20 @@ bool wait_until(instant_t logical_time, lf_cond_t* condition) {
       return true;
     }
 
+    //Subtract the average lag from the requested wait_until_time
+    interval_t wait_until_time_with_lag = wait_until_time - ave_lag;
+    instant_t now = lf_time_physical();
+    if (wait_until_time_with_lag < now && wait_until_time > now) {
+      while (wait_until_time > lf_time_physical()){}
+      return true;
+    }
+
     // We do the sleep on the cond var so we can be awakened by the
     // asynchronous scheduling of a physical action. lf_clock_cond_timedwait
     // returns 0 if it is awakened before the timeout. Hence, we want to run
     // it repeatedly until either it returns non-zero or the current
     // physical time matches or exceeds the logical time.
-    if (lf_clock_cond_timedwait(condition, wait_until_time) != LF_TIMEOUT) {
+    if (lf_clock_cond_timedwait(condition, wait_until_time_with_lag) != LF_TIMEOUT) {
       LF_PRINT_DEBUG("-------- wait_until interrupted before timeout.");
 
       // Wait did not time out, which means that there
@@ -260,7 +270,20 @@ bool wait_until(instant_t logical_time, lf_cond_t* condition) {
     } else {
       // Reached timeout.
       LF_PRINT_DEBUG("-------- Returned from wait, having waited " PRINTF_TIME " ns.", wait_duration);
-      return true;
+      
+      //Calculate the lag and update the average
+      interval_t lag = lf_time_physical() - wait_until_time_with_lag;
+      lag = lag - ave_lag;
+      lag_count++;
+      lag = lag / lag_count;
+      ave_lag += lag; 
+
+      //Check if the wait amount was sufficient
+      if (lf_time_physical() > wait_until_time) {
+        return true;
+      } else {
+        return wait_until(logical_time, condition);
+      }
     }
   }
   return true;

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -42,7 +42,7 @@ extern instant_t start_time;
  */
 #define MAX_STALL_INTERVAL MSEC(1)
 
-#define LAG_CONTROL  0.5
+#define LAG_CONTROL_DIV  2
 
 /**
  * Global mutex, used for synchronizing across environments. Mainly used for token-management and tracing
@@ -251,7 +251,7 @@ bool wait_until(instant_t logical_time, lf_cond_t* condition) {
     if (wait_until_time < now) {
       return true;
     } else if (wait_until_time_with_adjustment < now && wait_until_time > now) {
-      error_control = error_control - (LAG_CONTROL * (now - wait_until_time_with_adjustment));
+      error_control = error_control - ((now - wait_until_time_with_adjustment) / LAG_CONTROL_DIV);
       while (wait_until_time > lf_time_physical()){}
       return true;
     }
@@ -277,7 +277,7 @@ bool wait_until(instant_t logical_time, lf_cond_t* condition) {
       
       //Calculate the lag and update the average
       instant_t lag = lf_time_physical() - wait_until_time;
-      error_control += LAG_CONTROL * lag;
+      error_control = error_control + (lag / LAG_CONTROL_DIV);
       // lag = lag - ave_lag;
       // lag_count++;
       // lag = lag / lag_count;

--- a/low_level_platform/api/platform/lf_arduino_support.h
+++ b/low_level_platform/api/platform/lf_arduino_support.h
@@ -132,7 +132,10 @@ typedef void* lf_thread_t;
 // Arduinos are embedded platforms with no tty
 #define NO_TTY
 
-#define KI_DIV  1
-#define KI_MUL 1
+/* The constants used for I-controller for lag regulation under reactor_threaded.c wait_until function.
+The lag gets multiplied by KI_MUL and divided by KI_DIV before incorporated into control value.
+Currently no lag control support in this platform. */
+#define KI_DIV 1
+#define KI_MUL 0
 
 #endif // LF_ARDUINO_SUPPORT_H

--- a/low_level_platform/api/platform/lf_arduino_support.h
+++ b/low_level_platform/api/platform/lf_arduino_support.h
@@ -132,4 +132,7 @@ typedef void* lf_thread_t;
 // Arduinos are embedded platforms with no tty
 #define NO_TTY
 
+#define KI_DIV  1
+#define KI_MUL 1
+
 #endif // LF_ARDUINO_SUPPORT_H

--- a/low_level_platform/api/platform/lf_linux_support.h
+++ b/low_level_platform/api/platform/lf_linux_support.h
@@ -52,4 +52,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #error Linux platform misses clock support
 #endif
 
+#define KI_DIV  2
+#define KI_MUL 3
+
 #endif // LF_LINUX_SUPPORT_H

--- a/low_level_platform/api/platform/lf_linux_support.h
+++ b/low_level_platform/api/platform/lf_linux_support.h
@@ -52,7 +52,9 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #error Linux platform misses clock support
 #endif
 
-#define KI_DIV  2
+/* The constants used for I-controller for lag regulation under reactor_threaded.c wait_until function.
+The lag gets multiplied by KI_MUL and divided by KI_DIV before incorporated into control value. */
+#define KI_DIV 2
 #define KI_MUL 3
 
 #endif // LF_LINUX_SUPPORT_H

--- a/low_level_platform/api/platform/lf_macos_support.h
+++ b/low_level_platform/api/platform/lf_macos_support.h
@@ -44,8 +44,12 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #else
 #include "lf_C11_threads_support.h"
 #endif
-#define KI_DIV  1
-#define KI_MUL 1
+
+/* The constants used for I-controller for lag regulation under reactor_threaded.c wait_until function.
+The lag gets multiplied by KI_MUL and divided by KI_DIV before incorporated into control value.
+Currently no lag control support in this platform. */
+#define KI_DIV 1
+#define KI_MUL 0
 
 #endif
 

--- a/low_level_platform/api/platform/lf_macos_support.h
+++ b/low_level_platform/api/platform/lf_macos_support.h
@@ -44,6 +44,9 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #else
 #include "lf_C11_threads_support.h"
 #endif
+#define KI_DIV  1
+#define KI_MUL 1
+
 #endif
 
 #endif // LF_MACOS_SUPPORT_H

--- a/low_level_platform/api/platform/lf_nrf52_support.h
+++ b/low_level_platform/api/platform/lf_nrf52_support.h
@@ -51,4 +51,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 typedef void* lf_mutex_t;
 typedef void _lf_cond_var_t;
 
+#define KI_DIV  1
+#define KI_MUL 1
+
 #endif // LF_nRF52832_SUPPORT_H

--- a/low_level_platform/api/platform/lf_nrf52_support.h
+++ b/low_level_platform/api/platform/lf_nrf52_support.h
@@ -51,7 +51,10 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 typedef void* lf_mutex_t;
 typedef void _lf_cond_var_t;
 
-#define KI_DIV  1
-#define KI_MUL 1
+/* The constants used for I-controller for lag regulation under reactor_threaded.c wait_until function.
+The lag gets multiplied by KI_MUL and divided by KI_DIV before incorporated into control value.
+Currently no lag control support in this platform. */
+#define KI_DIV 1
+#define KI_MUL 0
 
 #endif // LF_nRF52832_SUPPORT_H

--- a/low_level_platform/api/platform/lf_rp2040_support.h
+++ b/low_level_platform/api/platform/lf_rp2040_support.h
@@ -20,7 +20,10 @@
 #define LF_TIME_BUFFER_LENGTH 80
 #define _LF_TIMEOUT 1
 
-#define KI_DIV  1
-#define KI_MUL 1
+/* The constants used for I-controller for lag regulation under reactor_threaded.c wait_until function.
+The lag gets multiplied by KI_MUL and divided by KI_DIV before incorporated into control value.
+Currently no lag control support in this platform. */
+#define KI_DIV 1
+#define KI_MUL 0
 
 #endif // LF_PICO_SUPPORT_H

--- a/low_level_platform/api/platform/lf_rp2040_support.h
+++ b/low_level_platform/api/platform/lf_rp2040_support.h
@@ -20,4 +20,7 @@
 #define LF_TIME_BUFFER_LENGTH 80
 #define _LF_TIMEOUT 1
 
+#define KI_DIV  1
+#define KI_MUL 1
+
 #endif // LF_PICO_SUPPORT_H

--- a/low_level_platform/api/platform/lf_windows_support.h
+++ b/low_level_platform/api/platform/lf_windows_support.h
@@ -62,8 +62,11 @@ typedef struct {
 } lf_cond_t;
 typedef HANDLE lf_thread_t;
 
-#define KI_DIV  1
-#define KI_MUL 1
+/* The constants used for I-controller for lag regulation under reactor_threaded.c wait_until function.
+The lag gets multiplied by KI_MUL and divided by KI_DIV before incorporated into control value.
+Currently no lag control support in this platform. */
+#define KI_DIV 1
+#define KI_MUL 0
 #endif
 
 // Use 64-bit times and 32-bit unsigned microsteps

--- a/low_level_platform/api/platform/lf_windows_support.h
+++ b/low_level_platform/api/platform/lf_windows_support.h
@@ -61,6 +61,9 @@ typedef struct {
   CONDITION_VARIABLE condition;
 } lf_cond_t;
 typedef HANDLE lf_thread_t;
+
+#define KI_DIV  1
+#define KI_MUL 1
 #endif
 
 // Use 64-bit times and 32-bit unsigned microsteps

--- a/low_level_platform/api/platform/lf_zephyr_support.h
+++ b/low_level_platform/api/platform/lf_zephyr_support.h
@@ -49,6 +49,9 @@ typedef struct {
 } lf_cond_t;
 typedef struct k_thread* lf_thread_t;
 
+#define KI_DIV  1
+#define KI_MUL 1
+
 /**
  * @brief Add `value` to `*ptr` and return original value of `*ptr`
  */

--- a/low_level_platform/api/platform/lf_zephyr_support.h
+++ b/low_level_platform/api/platform/lf_zephyr_support.h
@@ -49,8 +49,11 @@ typedef struct {
 } lf_cond_t;
 typedef struct k_thread* lf_thread_t;
 
-#define KI_DIV  1
-#define KI_MUL 1
+/* The constants used for I-controller for lag regulation under reactor_threaded.c wait_until function.
+The lag gets multiplied by KI_MUL and divided by KI_DIV before incorporated into control value.
+Currently no lag control support in this platform. */
+#define KI_DIV 1
+#define KI_MUL 0
 
 /**
  * @brief Add `value` to `*ptr` and return original value of `*ptr`


### PR DESCRIPTION
This PR implements an I-controller for wait_until function internal lag, as discussed in #332. Currently the I-controller's gain is only configured for Linux based platforms, so the other platforms zero out the calculated error control value. The following is the pseudocode of the updated `wait_until` function:

```
wait_until(requested_time) {
    static control_value = 0
    adjusted_time = requested time - control value

    if (now > requested_time) return
    else if (now > adjusted_time && now < requested_time) {
        control_value = control_value - K_i * (now - adjusted_time)
        //busy wait and return

    //call lf_cond_timedwait assuming no physical action, it returns at some physical time t'
    control_value = control_value + K_i * (t' - requested_time)
    
    if (now > requested_time)
        // busy wait
    return
```
I have experimented with different `K_i` values, and it turns out `K_i = 1` causes the lag to oscillate between 60 usec and ~0, `K_i < 1` just delays the start of the oscillation, `K_i = 2` causes unstable oscillation, and `K_i = 1.5` stabilizes the lag. I'm currently not sure why 1.5 works, so if there is any insight you have it would be highly appreciated.  

