### PR TITLE
Add fix to thread scheduling API

### DIFF
--- a/low_level_platform/impl/src/lf_linux_support.c
+++ b/low_level_platform/impl/src/lf_linux_support.c
@@ -88,8 +88,7 @@ int lf_thread_set_priority(lf_thread_t thread, int priority) {
 }
 
 int lf_thread_set_scheduling_policy(lf_thread_t thread, lf_scheduling_policy_t* policy) {
-  int posix_policy;
-  int res;
+  int posix_policy, res;
   struct sched_param schedparam;
 
   // Get the current scheduling policy
@@ -108,6 +107,7 @@ int lf_thread_set_scheduling_policy(lf_thread_t thread, lf_scheduling_policy_t* 
   case LF_SCHED_TIMESLICE:
     posix_policy = SCHED_RR;
     schedparam.sched_priority = sched_get_priority_max(SCHED_RR);
+    break;
   case LF_SCHED_PRIORITY:
     posix_policy = SCHED_FIFO;
     schedparam.sched_priority = sched_get_priority_max(SCHED_FIFO);

--- a/low_level_platform/impl/src/lf_linux_support.c
+++ b/low_level_platform/impl/src/lf_linux_support.c
@@ -68,7 +68,7 @@ int lf_thread_set_priority(lf_thread_t thread, int priority) {
   }
 
   // Get the current scheduling policy
-  int res = pthread_getschedparam(thread, &posix_policy, &schedparam);
+  res = pthread_getschedparam(thread, &posix_policy, &schedparam);
   if (res != 0) {
     return res;
   }

--- a/low_level_platform/impl/src/lf_platform_util.c
+++ b/low_level_platform/impl/src/lf_platform_util.c
@@ -7,9 +7,10 @@ int map_priorities(int priority, int dest_min, int dest_max) {
     return -1;
   }
 
-  // Perform the linear mapping
-  return dest_min +
-         ((dest_max - dest_min) / (LF_SCHED_MAX_PRIORITY - LF_SCHED_MIN_PRIORITY)) * (priority - LF_SCHED_MIN_PRIORITY);
+  // Perform the linear mapping. Since we are working with integers, it is
+  // important to multiply before we divide
+  return dest_min + (((priority - LF_SCHED_MIN_PRIORITY) * (dest_max - dest_min)) /
+                     (LF_SCHED_MAX_PRIORITY - LF_SCHED_MIN_PRIORITY));
 }
 
 #ifndef PLATFORM_ZEPHYR // on Zephyr, this is handled separately


### PR DESCRIPTION
Actually there were several mistakes in the original merge. It was not tested well enough and that's on me. I think we really need to add some tests for this API. A problem is that the program needs privileges to change its own scheduling policy and priority. I am not sure how easy it will be to do this in CI. But maybe not that hard.

Fixes:
- We need to initialize the priority to something valid when setting the scheduling policy. To avoid duplicating the logic of translating it from LF priority range to target platform priority range, I initially set it to max, and then call `lf_thread_set_priority`.
- There was a mistake in the function mapping the LF priority range into the target priority range. I am using integers for that, might be better with floats..
- Actually forward the pthread error codes. A problem is that we make several syscalls so you wont know exactly which failed.