### PR TITLE
Dont apply/subtract clock sync offset from NEVER/FOREVER

### DIFF
--- a/core/federated/clock-sync.c
+++ b/core/federated/clock-sync.c
@@ -530,15 +530,11 @@ void* listen_to_rti_UDP_thread(void* args) {
 // just empty implementations that should be optimized away.
 #if (LF_CLOCK_SYNC >= LF_CLOCK_SYNC_INIT)
 void clock_sync_add_offset(instant_t* t) {
-  if (*t != FOREVER && *t != NEVER) {
-    *t += (_lf_clock_sync_offset + _lf_clock_sync_constant_bias); 
-  }
+  *t = lf_time_add(*t, (_lf_clock_sync_offset + _lf_clock_sync_constant_bias));
 }
 
-void clock_sync_subtract_offset(instant_t* t) { 
-  if (*t != FOREVER && *t != NEVER) {
-    *t -= (_lf_clock_sync_offset + _lf_clock_sync_constant_bias); 
-  }  
+void clock_sync_subtract_offset(instant_t* t) {
+  *t = lf_time_add(*t, -(_lf_clock_sync_offset + _lf_clock_sync_constant_bias));
 }
 
 void clock_sync_set_constant_bias(interval_t offset) { _lf_clock_sync_constant_bias = offset; }

--- a/core/federated/clock-sync.c
+++ b/core/federated/clock-sync.c
@@ -529,9 +529,17 @@ void* listen_to_rti_UDP_thread(void* args) {
 // If clock synchronization is enabled, provide implementations. If not
 // just empty implementations that should be optimized away.
 #if (LF_CLOCK_SYNC >= LF_CLOCK_SYNC_INIT)
-void clock_sync_add_offset(instant_t* t) { *t += (_lf_clock_sync_offset + _lf_clock_sync_constant_bias); }
+void clock_sync_add_offset(instant_t* t) {
+  if (*t != FOREVER && *t != NEVER) {
+    *t += (_lf_clock_sync_offset + _lf_clock_sync_constant_bias); 
+  }
+}
 
-void clock_sync_subtract_offset(instant_t* t) { *t -= (_lf_clock_sync_offset + _lf_clock_sync_constant_bias); }
+void clock_sync_subtract_offset(instant_t* t) { 
+  if (*t != FOREVER && *t != NEVER) {
+    *t -= (_lf_clock_sync_offset + _lf_clock_sync_constant_bias); 
+  }  
+}
 
 void clock_sync_set_constant_bias(interval_t offset) { _lf_clock_sync_constant_bias = offset; }
 #else  // i.e. (LF_CLOCK_SYNC < LF_CLOCK_SYNC_INIT)

--- a/core/tag.c
+++ b/core/tag.c
@@ -39,20 +39,43 @@ tag_t lf_tag(void* env) {
   return ((environment_t*)env)->current_tag;
 }
 
+instant_t lf_time_add(instant_t a, interval_t b) {
+  if (a == NEVER || b == NEVER) {
+    return NEVER;
+  }
+  if (a == FOREVER || b == FOREVER) {
+    return FOREVER;
+  }
+  instant_t res = a + b;
+  // Check for overflow
+  if (res < a && b > 0) {
+    return FOREVER;
+  }
+  // Check for underflow
+  if (res > a && b < 0) {
+    return NEVER;
+  }
+  return res;
+}
+
 tag_t lf_tag_add(tag_t a, tag_t b) {
-  if (a.time == NEVER || b.time == NEVER)
-    return NEVER_TAG;
-  if (a.time == FOREVER || b.time == FOREVER)
+  instant_t res = lf_time_add(a.time, b.time);
+  if (res == FOREVER) {
     return FOREVER_TAG;
-  if (b.time > 0)
+  }
+  if (res == NEVER) {
+    return NEVER_TAG;
+  }
+
+  if (b.time > 0) {
     a.microstep = 0; // Ignore microstep of first arg if time of second is > 0.
-  tag_t result = {.time = a.time + b.time, .microstep = a.microstep + b.microstep};
-  if (result.microstep < a.microstep)
+  }
+  tag_t result = {.time = res, .microstep = a.microstep + b.microstep};
+
+  // If microsteps overflows
+  if (result.microstep < a.microstep) {
     return FOREVER_TAG;
-  if (result.time < a.time && b.time > 0)
-    return FOREVER_TAG;
-  if (result.time > a.time && b.time < 0)
-    return NEVER_TAG;
+  }
   return result;
 }
 

--- a/tag/api/tag.h
+++ b/tag/api/tag.h
@@ -105,6 +105,15 @@ tag_t lf_tag(void* env);
 tag_t lf_tag_add(tag_t a, tag_t b);
 
 /**
+ * Adds an interval to an instant, checks for overflows and underflows.
+ *
+ * @param a
+ * @param b
+ * @return instant_t
+ */
+instant_t lf_time_add(instant_t a, interval_t b);
+
+/**
  * Compare two tags. Return -1 if the first is less than
  * the second, 0 if they are equal, and +1 if the first is
  * greater than the second. A tag is greater than another if


### PR DESCRIPTION
This caused an error when a worker tried to sleep FOREVER and and applied a positive offset and the wakeup instant wrapped and got negative.

@edwardalee: Note that this is a PR into your existing clock-sync PR. It might fix the CI issue