### PR TITLE
Update trace-plugin API

### DIFF
--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -1038,26 +1038,26 @@ int process_args(int argc, const char* argv[]) {
  * core runtime.
  */
 #ifdef LF_TRACE
-static void check_version(version_t version) {
+static void check_version(const version_t* version) {
 #ifdef LF_SINGLE_THREADED
-  LF_ASSERT(version.build_config.single_threaded == TRIBOOL_TRUE ||
-                version.build_config.single_threaded == TRIBOOL_DOES_NOT_MATTER,
+  LF_ASSERT(version->build_config.single_threaded == TRIBOOL_TRUE ||
+                version->build_config.single_threaded == TRIBOOL_DOES_NOT_MATTER,
             "expected single-threaded version");
 #else
-  LF_ASSERT(version.build_config.single_threaded == TRIBOOL_FALSE ||
-                version.build_config.single_threaded == TRIBOOL_DOES_NOT_MATTER,
+  LF_ASSERT(version->build_config.single_threaded == TRIBOOL_FALSE ||
+                version->build_config.single_threaded == TRIBOOL_DOES_NOT_MATTER,
             "expected multi-threaded version");
 #endif
 #ifdef NDEBUG
-  LF_ASSERT(version.build_config.build_type_is_debug == TRIBOOL_FALSE ||
-                version.build_config.build_type_is_debug == TRIBOOL_DOES_NOT_MATTER,
+  LF_ASSERT(version->build_config.build_type_is_debug == TRIBOOL_FALSE ||
+                version->build_config.build_type_is_debug == TRIBOOL_DOES_NOT_MATTER,
             "expected release version");
 #else
-  LF_ASSERT(version.build_config.build_type_is_debug == TRIBOOL_TRUE ||
-                version.build_config.build_type_is_debug == TRIBOOL_DOES_NOT_MATTER,
+  LF_ASSERT(version->build_config.build_type_is_debug == TRIBOOL_TRUE ||
+                version->build_config.build_type_is_debug == TRIBOOL_DOES_NOT_MATTER,
             "expected debug version");
 #endif
-  LF_ASSERT(version.build_config.log_level == LOG_LEVEL || version.build_config.log_level == INT_MAX,
+  LF_ASSERT(version->build_config.log_level == LOG_LEVEL || version->build_config.log_level == INT_MAX,
             "expected log level %d", LOG_LEVEL);
   // assert(!version.core_version_name || strcmp(version.core_version_name, CORE_SHA) == 0); // TODO: provide CORE_SHA
 }

--- a/trace/api/trace.h
+++ b/trace/api/trace.h
@@ -1,6 +1,10 @@
 #ifndef TRACE_H
 #define TRACE_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include <stdint.h>
 #include <stdbool.h>
 
@@ -10,7 +14,7 @@
  * @brief Return a description of the compile-time properties of the current
  * plugin.
  */
-version_t lf_version_tracing();
+const version_t* lf_version_tracing();
 
 /**
  * Identifier for what is in the object table.
@@ -81,5 +85,9 @@ void lf_tracing_tracepoint(int worker, trace_record_nodeps_t* tr);
  * calling this procedure is undefined behavior.
  */
 void lf_tracing_global_shutdown();
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // TRACE_H

--- a/trace/impl/src/trace_impl.c
+++ b/trace/impl/src/trace_impl.c
@@ -24,6 +24,17 @@ static lf_platform_mutex_ptr_t trace_mutex;
 static trace_t trace;
 static int process_id;
 static int64_t start_time;
+static version_t version = {.build_config =
+                                {
+                                    .single_threaded = TRIBOOL_DOES_NOT_MATTER,
+#ifdef NDEBUG
+                                    .build_type_is_debug = TRIBOOL_FALSE,
+#else
+                                    .build_type_is_debug = TRIBOOL_TRUE,
+#endif
+                                    .log_level = LOG_LEVEL,
+                                },
+                            .core_version_name = NULL};
 
 // PRIVATE HELPERS ***********************************************************
 
@@ -192,21 +203,7 @@ static void stop_trace(trace_t* trace) {
 
 // IMPLEMENTATION OF VERSION API *********************************************
 
-version_t lf_version_tracing() {
-  return (version_t){
-      .build_config =
-          (build_config_t){
-              .single_threaded = TRIBOOL_DOES_NOT_MATTER,
-#ifdef NDEBUG
-              .build_type_is_debug = TRIBOOL_FALSE,
-#else
-              .build_type_is_debug = TRIBOOL_TRUE,
-#endif
-              .log_level = LOG_LEVEL,
-          },
-      .core_version_name = NULL,
-  };
-}
+const version_t* lf_version_tracing() { return &version; }
 
 // IMPLEMENTATION OF TRACE API ***********************************************
 


### PR DESCRIPTION
When using CCpp and clang the current trace API yielded the following C-linkage warning:
```
/home/erling/dev/xronos/lf-trace-example/src-gen/SimpleCCpp/trace/api/trace.h/home/erling/dev/xronos/lf-trace-example/src-gen/SimpleCCpp/trace/api/trace.h:13::1311::11 : warning: warning: 'lf_version_tracing' has C-linkage specified, but returns user-defined type 'version_t' which is incompatible with C [-Wreturn-type-c-linkage]'lf_version_tracing' has C-linkage specified, but returns user-defined type 'version_t' which is incompatible with C [-Wreturn-type-c-linkage]

version_t lf_version_tracing();
          ^version_t lf_version_tracing();
```

This is solved by instead returning a const pointer to the version struct.  The version struct is then instead a constant global variable in the trace plugins. As this changes the trace plugin API this requires updating any external trace plugins also