### PR TITLE
Add support for Linux SCHED_DEADLINE

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -122,11 +122,9 @@ if(DEFINED FEDERATED_AUTHENTICATED)
     target_link_libraries(reactor-c PUBLIC OpenSSL::SSL)
 endif()
 
-if(DEFINED FEDERATED)
-  find_library(MATH_LIBRARY m)
-  if(MATH_LIBRARY)
-    target_link_libraries(reactor-c PUBLIC ${MATH_LIBRARY})
-  endif()
+find_library(MATH_LIBRARY m)
+if(MATH_LIBRARY)
+  target_link_libraries(reactor-c PUBLIC ${MATH_LIBRARY})
 endif()
 
 # Unless specified otherwise initial event queue and reaction queue to size 10

--- a/core/federated/RTI/CMakeLists.txt
+++ b/core/federated/RTI/CMakeLists.txt
@@ -87,6 +87,12 @@ target_compile_options(${RTI_LIB} PUBLIC -Werror)
 find_package(Threads REQUIRED)
 target_link_libraries(${RTI_LIB} PUBLIC Threads::Threads)
 
+# Find math librasy and link to it
+find_library(MATH_LIBRARY m)
+if(MATH_LIBRARY)
+	target_link_libraries(${RTI_LIB} PUBLIC ${MATH_LIBRARY})
+endif()
+
 # Option for enabling federate authentication by RTI.
 option(AUTH "Federate authentication by RTI enabled." OFF)
 IF(AUTH MATCHES ON)

--- a/core/federated/RTI/rti.Dockerfile
+++ b/core/federated/RTI/rti.Dockerfile
@@ -2,7 +2,7 @@
 FROM alpine:latest
 COPY . /lingua-franca
 WORKDIR /lingua-franca/core/federated/RTI
-RUN set -ex && apk add --no-cache gcc musl-dev cmake make && \
+RUN set -ex && apk add --no-cache gcc musl-dev cmake make linux-headers && \
     mkdir container && \
     cd container && \
     cmake ../ && \

--- a/core/lf_utils.cmake
+++ b/core/lf_utils.cmake
@@ -1,6 +1,6 @@
 function(lf_enable_compiler_warnings target)
     if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
-        target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic -Werror)
+        target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic)
     elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
         target_compile_options(${target} PRIVATE /W4)
     elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")

--- a/core/utils/util.c
+++ b/core/utils/util.c
@@ -46,6 +46,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdarg.h> // Defines va_list
 #include <time.h>   // Defines nanosleep()
 #include <stdbool.h>
+#include <math.h>
 
 #ifndef NUMBER_OF_FEDERATES
 #define NUMBER_OF_FEDERATES 1
@@ -213,4 +214,13 @@ void lf_print_error_system_failure(const char* format, ...) {
 void lf_register_print_function(print_message_function_t* function, int log_level) {
   print_message_function = function;
   print_message_level = log_level;
+}
+
+static double _round(double d) { return floor(d + 0.5); }
+
+int map_value(int value, int src_min, int src_max, int dest_min, int dest_max) {
+  // Perform the linear mapping. Since we are working with integers, it is
+  // important to multiply before we divide
+  double slope = 1.0 * (dest_max - dest_min) / (src_max - src_min);
+  return dest_min + _round(slope * (value - src_min));
 }

--- a/include/core/utils/util.h
+++ b/include/core/utils/util.h
@@ -194,4 +194,9 @@ void lf_vprint_error_and_exit(const char* format, va_list args) ATTRIBUTE_FORMAT
  */
 #define LF_CRITICAL_SECTION_EXIT(env) LF_ASSERT(!lf_critical_section_exit(env), "Could not exit critical section")
 
+/**
+ * @brief Maps a value from source range   into a destination priority range.
+ */
+int map_value(int value, int src_min, int src_max, int dest_min, int dest_max);
+
 #endif /* UTIL_H */

--- a/low_level_platform/api/low_level_platform.h
+++ b/low_level_platform/api/low_level_platform.h
@@ -182,6 +182,15 @@ int lf_thread_set_cpu(lf_thread_t thread, size_t cpu_number);
 int lf_thread_set_priority(lf_thread_t thread, int priority);
 
 /**
+ * @brief Get the priority of a thread
+ * Priority ranges from LF_SCHED_PRIORITY_MIN to LF_SCHED_PRIORITY_MAX
+ *
+ * @param thread The thread.
+ * @return The priority of the thread
+ */
+int lf_thread_get_priority(lf_thread_t thread);
+
+/**
  * @brief Set the scheduling policy of a thread. This is based on the scheduling
  * concept from Linux explained here: https://man7.org/linux/man-pages/man7/sched.7.html
  * A scheduling policy is specific to a thread/worker. We have three policies

--- a/low_level_platform/api/low_level_platform.h
+++ b/low_level_platform/api/low_level_platform.h
@@ -149,12 +149,15 @@ typedef enum {
   LF_SCHED_FAIR,      // Non real-time scheduling policy. Corresponds to SCHED_OTHER
   LF_SCHED_TIMESLICE, // Real-time, time-slicing priority-based policty. Corresponds to SCHED_RR.
   LF_SCHED_PRIORITY,  // Real-time, priority-only based scheduling. Corresponds to SCHED_FIFO.
+  LF_SCHED_DEADLINE,  // Real-time, priority-only based scheduling. Corresponds to SCHED_DEADLINE.
 } lf_scheduling_policy_type_t;
 
 typedef struct {
   lf_scheduling_policy_type_t policy; // The scheduling policy
   int priority;                       // The priority, if applicable
-  interval_t time_slice;              // The time-slice allocated, if applicable.
+  interval_t time_slice;              // The time-slice/run-time applicable to TIMESLICE and DEADLINE
+  interval_t deadline;                // Only relevant for DEADLINE
+  interval_t period;                  // Only relevant for DEADLINE
 } lf_scheduling_policy_t;
 
 /**

--- a/low_level_platform/api/low_level_platform.h
+++ b/low_level_platform/api/low_level_platform.h
@@ -78,7 +78,7 @@ int lf_critical_section_exit(environment_t* env);
 
 // Worker priorities range from 0 to 99 where 99 is the highest priority.
 #define LF_SCHED_MAX_PRIORITY 99
-#define LF_SCHED_MIN_PRIORITY 0
+#define LF_SCHED_MIN_PRIORITY 1
 
 // To support the single-threaded runtime, we need the following functions. They
 //  are not required by the threaded runtime and is thus hidden behind a #ifdef.

--- a/low_level_platform/api/platform/lf_platform_util.h
+++ b/low_level_platform/api/platform/lf_platform_util.h
@@ -1,8 +1,0 @@
-#ifndef LF_PLATFORM_UTIL_H
-#define LF_PLATFORM_UTIL_H
-/**
- * @brief Maps a value from source range   into a destination priority range.
- */
-int map_value(int value, int src_min, int src_max, int dest_min, int dest_max);
-
-#endif

--- a/low_level_platform/api/platform/lf_platform_util.h
+++ b/low_level_platform/api/platform/lf_platform_util.h
@@ -1,8 +1,8 @@
 #ifndef LF_PLATFORM_UTIL_H
 #define LF_PLATFORM_UTIL_H
 /**
- * @brief Maps a priority into a destination priority range.
+ * @brief Maps a value from source range   into a destination priority range.
  */
-int map_priorities(int priority, int dest_min, int dest_max);
+int map_value(int value, int src_min, int src_max, int dest_min, int dest_max);
 
 #endif

--- a/low_level_platform/impl/CMakeLists.txt
+++ b/low_level_platform/impl/CMakeLists.txt
@@ -107,6 +107,7 @@ lf_enable_compiler_warnings(lf-low-level-platform-impl)
 
 target_link_libraries(lf-low-level-platform-impl PRIVATE lf::low-level-platform-api)
 target_link_libraries(lf-low-level-platform-impl PUBLIC lf-logging-api)
+target_include_directories(lf-low-level-platform-impl PRIVATE ${LF_ROOT}/include/core/utils)
 
 target_compile_definitions(lf-low-level-platform-impl PUBLIC PLATFORM_${CMAKE_SYSTEM_NAME})
 message(STATUS "Applying preprocessor definitions to low-level-platform...")

--- a/low_level_platform/impl/src/lf_linux_support.c
+++ b/low_level_platform/impl/src/lf_linux_support.c
@@ -133,10 +133,31 @@ int lf_thread_set_priority(lf_thread_t thread, int priority) {
     return -1;
   }
 
-  final_priority = map_priorities(priority, min_pri, max_pri);
+  final_priority = map_value(priority, LF_SCHED_MIN_PRIORITY, LF_SCHED_MAX_PRIORITY, min_pri, max_pri);
   if (final_priority < 0) {
     return -1;
   }
+
+  return pthread_setschedprio(thread, final_priority);
+}
+
+int lf_thread_get_priority(lf_thread_t thread) {
+  int posix_policy, min_pri, max_pri, final_priority, res;
+  struct sched_param schedparam;
+
+  // Get the current scheduling policy
+  res = pthread_getschedparam(thread, &posix_policy, &schedparam);
+  if (res != 0) {
+    return res;
+  }
+
+  min_pri = sched_get_priority_min(posix_policy);
+  max_pri = sched_get_priority_max(posix_policy);
+  if (min_pri == -1 || max_pri == -1) {
+    return -1;
+  }
+
+  final_priority = map_value(schedparam.sched_priority, min_pri, max_pri, LF_SCHED_MIN_PRIORITY, LF_SCHED_MAX_PRIORITY);
 
   return pthread_setschedprio(thread, final_priority);
 }

--- a/low_level_platform/impl/src/lf_platform_util.c
+++ b/low_level_platform/impl/src/lf_platform_util.c
@@ -1,16 +1,10 @@
 #include "low_level_platform.h"
 #include "platform/lf_platform_util.h"
 
-int map_priorities(int priority, int dest_min, int dest_max) {
-  // Check if priority is within the legal range
-  if (priority < LF_SCHED_MIN_PRIORITY || priority > LF_SCHED_MAX_PRIORITY) {
-    return -1;
-  }
-
+int map_value(int value, int src_min, int src_max, int dest_min, int dest_max) {
   // Perform the linear mapping. Since we are working with integers, it is
   // important to multiply before we divide
-  return dest_min + (((priority - LF_SCHED_MIN_PRIORITY) * (dest_max - dest_min)) /
-                     (LF_SCHED_MAX_PRIORITY - LF_SCHED_MIN_PRIORITY));
+  return dest_min + (((value - src_min) * (dest_max - dest_min)) / (src_max - src_min));
 }
 
 #ifndef PLATFORM_ZEPHYR // on Zephyr, this is handled separately

--- a/low_level_platform/impl/src/lf_platform_util.c
+++ b/low_level_platform/impl/src/lf_platform_util.c
@@ -1,11 +1,5 @@
 #include "low_level_platform.h"
-#include "platform/lf_platform_util.h"
-
-int map_value(int value, int src_min, int src_max, int dest_min, int dest_max) {
-  // Perform the linear mapping. Since we are working with integers, it is
-  // important to multiply before we divide
-  return dest_min + (((value - src_min) * (dest_max - dest_min)) / (src_max - src_min));
-}
+#include <stdio.h>
 
 #ifndef PLATFORM_ZEPHYR // on Zephyr, this is handled separately
 #ifndef LF_SINGLE_THREADED

--- a/low_level_platform/impl/src/lf_zephyr_support.c
+++ b/low_level_platform/impl/src/lf_zephyr_support.c
@@ -170,7 +170,8 @@ int lf_thread_set_priority(lf_thread_t thread, int priority) {
     return -1;
   }
 
-  final_priority = map_priorities(priority, CONFIG_NUM_PREEMPT_PRIORITIES - 1, 0);
+  final_priority =
+      map_value(priority, LF_SCHED_MIN_PRIORITY, LF_SCHED_MAX_PRIORITY, CONFIG_NUM_PREEMPT_PRIORITIES - 1, 0);
   if (final_priority < 0) {
     return -1;
   }

--- a/low_level_platform/impl/src/lf_zephyr_support.c
+++ b/low_level_platform/impl/src/lf_zephyr_support.c
@@ -33,8 +33,8 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "platform/lf_zephyr_support.h"
 #include "platform/lf_zephyr_board_support.h"
-#include "platform/lf_platform_util.h"
 #include "low_level_platform.h"
+#include "util.h"
 #include "tag.h"
 
 #include <zephyr/kernel.h>
@@ -200,6 +200,7 @@ int lf_thread_set_scheduling_policy(lf_thread_t thread, lf_scheduling_policy_t* 
     break;
   }
   case LF_SCHED_FAIR:
+  case LF_SCHED_DEADLINE: // TODO: Provide Zephyr implementation for this.
   default:
     return -1;
     break;

--- a/test/Tests.cmake
+++ b/test/Tests.cmake
@@ -38,7 +38,7 @@ foreach(FILE ${TEST_FILES})
     target_link_libraries(${NAME} PRIVATE lf::low-level-platform-impl)
     target_link_libraries(
         ${NAME} PRIVATE
-        ${CoreLib} ${Lib}
+        ${CoreLib} ${Lib} m
     )
     target_include_directories(${NAME} PRIVATE ${TEST_DIR})
     # Warnings as errors

--- a/test/general/utils/map_value_test.c
+++ b/test/general/utils/map_value_test.c
@@ -1,0 +1,35 @@
+#include <stdio.h>
+#include <assert.h>
+#include <string.h>
+
+#include "platform/lf_platform_util.h"
+
+int main() {
+  int res;
+
+  // Simple
+  res = map_value(50, 0, 100, 0, 10);
+  if (res != 5) {
+    return -1;
+  }
+
+  // To a bigger range
+  res = map_value(50, 0, 100, 0, 200);
+  if (res != 100) {
+    return -1;
+  }
+
+  // To an inverted range
+  res = map_value(8, 0, 10, 10, 0);
+  if (res != 2) {
+    return -1;
+  }
+
+  // TO a range involving positive and negative
+  res = map_value(8, 0, 10, 20, -20);
+  if (res != -12) {
+    return -1;
+  }
+
+  return 0;
+}

--- a/test/general/utils/map_value_test.c
+++ b/test/general/utils/map_value_test.c
@@ -1,8 +1,7 @@
 #include <stdio.h>
 #include <assert.h>
 #include <string.h>
-
-#include "platform/lf_platform_util.h"
+#include "util.h"
 
 int main() {
   int res;

--- a/test/scheduling/scheduling_api_test.c
+++ b/test/scheduling/scheduling_api_test.c
@@ -30,7 +30,7 @@ int main() {
       lf_print_error_and_exit("lf_thread_set_scheduling_policy FIFO failed with %d", res);
     }
     if (lf_thread_get_priority(lf_thread_self()) != 99) {
-      lf_print_error_and_exit("lf_thread_get_priority failed got %d", res);
+      lf_print_error_and_exit("lf_thread_get_priority failed got %d expected 99", res);
     }
   }
 
@@ -45,7 +45,7 @@ int main() {
       lf_print_error_and_exit("lf_thread_set_scheduling_policy RR failed with %d", res);
     }
     if (lf_thread_get_priority(lf_thread_self()) != 99) {
-      lf_print_error_and_exit("lf_thread_get_priority failed got %d", res);
+      lf_print_error_and_exit("lf_thread_get_priority failed got %d expected 99", res);
     }
   }
 
@@ -66,8 +66,9 @@ int main() {
   if (res != 0) {
     lf_print_error_and_exit("lf_thread_set_priority failed with %d", res);
   }
-  if (lf_thread_get_priority(lf_thread_self()) != 50) {
-    lf_print_error_and_exit("lf_thread_get_priority failed got %d", res);
+  res = lf_thread_get_priority(lf_thread_self());
+  if (res != 50) {
+    lf_print_error_and_exit("Line %d lf_thread_get_priority failed got %d expected 50", __LINE__, res);
   }
 
   // Try negative priority
@@ -75,8 +76,9 @@ int main() {
   if (res == 0) {
     lf_print_error_and_exit("lf_thread_set_priority should have failed for -50");
   }
-  if (lf_thread_get_priority(lf_thread_self()) != 50) {
-    lf_print_error_and_exit("lf_thread_get_priority failed got %d", res);
+  res = lf_thread_get_priority(lf_thread_self());
+  if (res != 50) {
+    lf_print_error_and_exit("Line %d lf_thread_get_priority failed got %d expected 50", __LINE__, res);
   }
 
   // Configure back to SCHED_OTHER
@@ -86,17 +88,18 @@ int main() {
     cfg.priority = 0;
     res = lf_thread_set_scheduling_policy(lf_thread_self(), &cfg);
     if (res != 0) {
-      lf_print_error_and_exit("lf_thread_set_scheduling_policy RR failed with %d", res);
+      lf_print_error_and_exit("lf_thread_set_scheduling_policy FAIR failed with %d", res);
     }
-    if (lf_thread_get_priority(lf_thread_self()) != 0) {
-      lf_print_error_and_exit("lf_thread_get_priority failed got %d", res);
+    res = lf_thread_get_priority(lf_thread_self());
+    if (res == 0) {
+      lf_print_error_and_exit("Line %d lf_thread_get_priority should fail with SCHED_FAIR %d", __LINE__, res);
     }
   }
 
   // Try pinning to non-existant CPU core.
   res = lf_thread_set_cpu(lf_thread_self(), lf_available_cores());
   if (res == 0) {
-    lf_print_error_and_exit("lf_thread_set_cpu should fail for too high CPU id");
+    lf_print_error_and_exit("Line %d lf_thread_set_cpu should fail for too high CPU id", __LINE__);
   }
 
   // Try setting nice-ness for CFS
@@ -104,10 +107,10 @@ int main() {
     lf_scheduling_policy_t cfg;
     cfg.policy = LF_SCHED_FAIR;
     cfg.time_slice = 0;
-    cfg.priority = 100;
+    cfg.priority = 5;
     res = lf_thread_set_scheduling_policy(lf_thread_self(), &cfg);
-    if (res == 0) {
-      lf_print_error_and_exit("lf_thread_set_scheduling_policy should have failed with illegal priority");
+    if (res != 0) {
+      lf_print_error_and_exit("Line %d lf_thread_set_scheduling_policy failed with %d", __LINE__, res);
     }
   }
 }


### PR DESCRIPTION
This PR adds introduces LF_SCHED_DEADLINE which is modeled after SCHED_DEADLINE in Linux. It also provides an implementation for it on Linux. There is also a scheduler in Zephyr which should correspond to this.