### PR TITLE
RP2040 support based on low-level platform API

### DIFF
--- a/low_level_platform/impl/src/lf_rp2040_support.c
+++ b/low_level_platform/impl/src/lf_rp2040_support.c
@@ -134,16 +134,14 @@ int _lf_interruptable_sleep_until_locked(environment_t* env, instant_t wakeup_ti
   sem_reset(&_lf_sem_irq_event, 0);
   // create us boot wakeup time
   target = from_us_since_boot((uint64_t)(wakeup_time / 1000));
-  // Enable interrupts. NOTE: It would be nice to use the macro LF_CRITICAL_SECTION_EXIT,
-  // but there seems to be no way to #include "util.h" that works in this file.
+  // Enable interrupts.
   lf_critical_section_exit(env);
   // blocked sleep
   // return on timeout or on processor event
   if (sem_acquire_block_until(&_lf_sem_irq_event, target)) {
     ret_code = -1;
   }
-  // Disable interrupts. NOTE: It would be nice to use the macro LF_CRITICAL_SECTION_ENTER,
-  // but there seems to be no way to #include "util.h" that works in this file.
+  // Disable interrupts.
   lf_critical_section_enter(env);
   return ret_code;
 }

--- a/low_level_platform/impl/src/lf_rp2040_support.c
+++ b/low_level_platform/impl/src/lf_rp2040_support.c
@@ -134,15 +134,17 @@ int _lf_interruptable_sleep_until_locked(environment_t* env, instant_t wakeup_ti
   sem_reset(&_lf_sem_irq_event, 0);
   // create us boot wakeup time
   target = from_us_since_boot((uint64_t)(wakeup_time / 1000));
-  // allow interrupts
-  LF_CRITICAL_SECTION_EXIT(env);
+  // Enable interrupts. NOTE: It would be nice to use the macro LF_CRITICAL_SECTION_EXIT,
+  // but there seems to be no way to #include "util.h" that works in this file.
+  lf_critical_section_exit(env);
   // blocked sleep
   // return on timeout or on processor event
   if (sem_acquire_block_until(&_lf_sem_irq_event, target)) {
     ret_code = -1;
   }
-  // remove interrupts
-  LF_CRITICAL_SECTION_ENTER(env);
+  // Disable interrupts. NOTE: It would be nice to use the macro LF_CRITICAL_SECTION_ENTER,
+  // but there seems to be no way to #include "util.h" that works in this file.
+  lf_critical_section_enter(env);
   return ret_code;
 }
 


### PR DESCRIPTION
This PR removes the use of macros defined in util.h because #including util.h does not work.
To build RP2040 code, we also need the [companion PR](https://github.com/lf-lang/lingua-franca/pull/2303).