### PR TITLE
Fixes to prevent memory leaks in RTI

### DIFF
--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -1747,10 +1747,17 @@ void clock_sync_subtract_offset(instant_t* t) { (void)t; }
 void free_scheduling_nodes(scheduling_node_t** scheduling_nodes, uint16_t number_of_scheduling_nodes) {
   for (uint16_t i = 0; i < number_of_scheduling_nodes; i++) {
     scheduling_node_t* node = scheduling_nodes[i];
-    if (node->upstream != NULL)
+    if (node->upstream != NULL) {
       free(node->upstream);
-    if (node->downstream != NULL)
+      free(node->upstream_delay);
+    }
+    if (node->min_delays != NULL) {
+      free(node->min_delays);
+    }
+    if (node->downstream != NULL) {
       free(node->downstream);
+    }
+    free(node);
   }
   free(scheduling_nodes);
 }

--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -1686,8 +1686,6 @@ void wait_for_federates(int socket_descriptor) {
     lf_print("RTI: Federate %d thread exited.", fed->enclave.id);
   }
 
-  lf_thread_join(responder_thread, &thread_exit_status);
-
   rti_remote->all_federates_exited = true;
 
   // Shutdown and close the socket that is listening for incoming connections

--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -1686,6 +1686,8 @@ void wait_for_federates(int socket_descriptor) {
     lf_print("RTI: Federate %d thread exited.", fed->enclave.id);
   }
 
+  lf_thread_join(responder_thread, &thread_exit_status);
+
   rti_remote->all_federates_exited = true;
 
   // Shutdown and close the socket that is listening for incoming connections

--- a/core/utils/pqueue_tag.c
+++ b/core/utils/pqueue_tag.c
@@ -147,7 +147,7 @@ void pqueue_tag_remove(pqueue_tag_t* q, pqueue_tag_element_t* e) { pqueue_remove
 void pqueue_tag_remove_up_to(pqueue_tag_t* q, tag_t t) {
   tag_t head = pqueue_tag_peek_tag(q);
   while (lf_tag_compare(head, FOREVER_TAG) < 0 && lf_tag_compare(head, t) <= 0) {
-    pqueue_tag_pop(q);
+    pqueue_tag_pop_tag(q);
     head = pqueue_tag_peek_tag(q);
   }
 }


### PR DESCRIPTION
This PR resolves memory leaks from the RTI. I attached the output file from Valgrind.
[valgrind-out-before.txt](https://github.com/user-attachments/files/15921773/valgrind-out-before.txt)

With this PR, most of the leakages have disappeared.

[valgrind-out-after.txt](https://github.com/user-attachments/files/15944384/valgrind-out-after.txt)

Specifically, now the function `pqueue_tag_remove_up_to` frees dynamically allocated elements. Also, memory allocated for storing each node's `upstream` and `min_delays` is explicitly freed when the RTI terminates.

Valgrind reports two remaining issues. The two threads shown below are not explicitly joined.
https://github.com/lf-lang/reactor-c/blob/587a8f9498b69bc82f404e432f881d7bb0bcf383/core/federated/RTI/rti_remote.c#L666

This thread is created in the function [handle_stop_request_message](https://github.com/lf-lang/reactor-c/blob/587a8f9498b69bc82f404e432f881d7bb0bcf383/core/federated/RTI/rti_remote.c#L606) to set a timeout to wait for `MSG_TYPE_STOP_REQUEST_REPLY` messages. Thus, this thread cannot be joined in the function `handle_stop_request_message` and I didn't come up with joining this function.

https://github.com/lf-lang/reactor-c/blob/587a8f9498b69bc82f404e432f881d7bb0bcf383/core/federated/RTI/rti_remote.c#L1677

This thread is responsible for responding to erroneous connection requests. Thus, this thread should not be joined.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved thread management by adding a thread join for `responder_thread` to ensure proper synchronization.
  - Enhanced memory management by correcting memory deallocation in `free_scheduling_nodes`.

- **Refactor**
  - Updated function calls within priority queue operations to improve performance and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->