### PR TITLE
Suppress error: cast from pointer to integer of different size

### DIFF
--- a/core/utils/pqueue_tag.c
+++ b/core/utils/pqueue_tag.c
@@ -24,7 +24,10 @@
  * element is also the priority. This function is of type pqueue_get_pri_f.
  * @param element A pointer to a pqueue_tag_element_t, cast to void*.
  */
-static pqueue_pri_t pqueue_tag_get_priority(void* element) { return (pqueue_pri_t)(uintptr_t)element; }
+static pqueue_pri_t pqueue_tag_get_priority(void* element) {
+  // Suppress "error: cast from pointer to integer of different size" by casting to uintptr_t first.
+  return (pqueue_pri_t)(uintptr_t)element;
+}
 
 /**
  * @brief Callback function to determine whether two elements are equivalent.
@@ -66,7 +69,9 @@ static void pqueue_tag_print_element(void* element) {
 // Functions defined in pqueue_tag.h.
 
 int pqueue_tag_compare(pqueue_pri_t priority1, pqueue_pri_t priority2) {
-  return (lf_tag_compare(((pqueue_tag_element_t*)(uintptr_t)priority1)->tag, ((pqueue_tag_element_t*)(uintptr_t)priority2)->tag));
+  // Suppress "error: cast from pointer to integer of different size" by casting to uintptr_t first.
+  return (lf_tag_compare(((pqueue_tag_element_t*)(uintptr_t)priority1)->tag,
+                         ((pqueue_tag_element_t*)(uintptr_t)priority2)->tag));
 }
 
 pqueue_tag_t* pqueue_tag_init(size_t initial_size) {

--- a/core/utils/pqueue_tag.c
+++ b/core/utils/pqueue_tag.c
@@ -9,6 +9,7 @@
  */
 
 #include <stdlib.h>
+#include <stdint.h>
 
 #include "pqueue_tag.h"
 #include "util.h"               // For lf_print
@@ -23,7 +24,7 @@
  * element is also the priority. This function is of type pqueue_get_pri_f.
  * @param element A pointer to a pqueue_tag_element_t, cast to void*.
  */
-static pqueue_pri_t pqueue_tag_get_priority(void* element) { return (pqueue_pri_t)element; }
+static pqueue_pri_t pqueue_tag_get_priority(void* element) { return (pqueue_pri_t)(uintptr_t)element; }
 
 /**
  * @brief Callback function to determine whether two elements are equivalent.
@@ -65,7 +66,7 @@ static void pqueue_tag_print_element(void* element) {
 // Functions defined in pqueue_tag.h.
 
 int pqueue_tag_compare(pqueue_pri_t priority1, pqueue_pri_t priority2) {
-  return (lf_tag_compare(((pqueue_tag_element_t*)priority1)->tag, ((pqueue_tag_element_t*)priority2)->tag));
+  return (lf_tag_compare(((pqueue_tag_element_t*)(uintptr_t)priority1)->tag, ((pqueue_tag_element_t*)(uintptr_t)priority2)->tag));
 }
 
 pqueue_tag_t* pqueue_tag_init(size_t initial_size) {

--- a/include/core/utils/pqueue_base.h
+++ b/include/core/utils/pqueue_base.h
@@ -123,14 +123,6 @@ size_t pqueue_size(pqueue_t* q);
 int pqueue_insert(pqueue_t* q, void* d);
 
 /**
- * Move an existing entry to a different priority.
- * @param q the queue
- * @param new_pri the new priority
- * @param d the entry
- */
-void pqueue_change_priority(pqueue_t* q, pqueue_pri_t new_pri, void* d);
-
-/**
  * Pop the highest-ranking item from the queue.
  * @param q the queue
  * @return NULL on error, otherwise the entry


### PR DESCRIPTION
Closes #447.

Summary: I reviewed the `pqueue_tag` code that Edward and Byeong-gil worked on, and I determined that it was safe because I think that in practice, there are essentially no important platforms on which it will not work properly to cast a void pointer to an `unsigned long long` and back. This is because an `unsigned long long` is always at least 64 bits, and pointers in the real world are never larger than 64 bits.

Therefore, I decided to suppress the error using an intermediate cast to `uintptr_t`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved priority calculation issues in the queue by adjusting type casting for consistent handling of elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->