### PR TITLE
Use uintptr_t for unsigned int that can hold a pointer

### DIFF
--- a/core/utils/pqueue.c
+++ b/core/utils/pqueue.c
@@ -35,5 +35,5 @@ void set_reaction_position(void* reaction, size_t pos) { ((reaction_t*)reaction)
 
 void print_reaction(void* reaction) {
   reaction_t* r = (reaction_t*)reaction;
-  LF_PRINT_DEBUG("%s: index: %llx, reaction: %p", r->name, r->index, reaction);
+  LF_PRINT_DEBUG("%s: index: %" PRIxPTR ", reaction: %p", r->name, r->index, reaction);
 }

--- a/include/core/utils/pqueue_base.h
+++ b/include/core/utils/pqueue_base.h
@@ -47,9 +47,10 @@
 #define PQUEUE_BASE_H
 
 #include <stddef.h>
+#include <stdint.h>
 
 /** Priority data type. */
-typedef unsigned long long pqueue_pri_t;
+typedef uintptr_t pqueue_pri_t;
 
 /** Callback to get the priority of an element. */
 typedef pqueue_pri_t (*pqueue_get_pri_f)(void* a);


### PR DESCRIPTION
This PR addresses https://github.com/lf-lang/reactor-c/issues/447 by using an unsigned int data type that can go back and forth from a pointer.  To be useful, of course, we will need to point Lingua Franca to this updated reactor-c.