### PR TITLE
Fixed initialization of the master worker thread id

### DIFF
--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -1112,6 +1112,7 @@ int lf_reactor_c_main(int argc, const char* argv[]) {
         // run on the main thread, rather than creating a new thread.
         // This is important for bare-metal platforms, who can't
         // afford to have the main thread sit idle.
+        env->thread_ids[j] = lf_thread_self();
         continue;
       }
       if (lf_thread_create(&env->thread_ids[j], worker, env) != 0) {

--- a/low_level_platform/impl/src/lf_arduino_support.c
+++ b/low_level_platform/impl/src/lf_arduino_support.c
@@ -174,9 +174,6 @@ lf_thread_t lf_thread_self() {
   // Not implemented. Although Arduino mbed provides a ThisThread API and a
   // get_id() function, it does not provide a way to get the current thread as a
   // Thread object.
-  // N.B. This wrong implementation will eventually cause hard-to-debug
-  // segfaults, but it unblocks us from conveniently implementing features for
-  // other platforms, and it does not break existing features for Arduino.
   return NULL;
 }
 

--- a/low_level_platform/impl/src/lf_flexpret_support.c
+++ b/low_level_platform/impl/src/lf_flexpret_support.c
@@ -179,9 +179,7 @@ int lf_available_cores() {
 }
 
 lf_thread_t lf_thread_self() {
-  // N.B. This wrong implementation will eventually cause hard-to-debug
-  // segfaults, but it unblocks us from conveniently implementing features for
-  // other platforms, and it does not break existing features for FlexPRET.
+  // Not implemented.
   return NULL;
 }
 


### PR DESCRIPTION
Fixes https://github.com/lf-lang/reactor-c/issues/452

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added platform-specific `lf_thread_self()` function for improved thread handling across multiple platforms, including Arduino, FlexPRET, and Windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->