### PR TITLE
Fix compilation errors in `initialize-master-thread-id`

### DIFF
--- a/low_level_platform/impl/src/lf_arduino_support.c
+++ b/low_level_platform/impl/src/lf_arduino_support.c
@@ -170,6 +170,16 @@ typedef void* (*lf_function_t)(void*);
  */
 int lf_available_cores() { return 1; }
 
+lf_thread_t lf_thread_self() {
+  // Not implemented. Although Arduino mbed provides a ThisThread API and a
+  // get_id() function, it does not provide a way to get the current thread as a
+  // Thread object.
+  // N.B. This wrong implementation will eventually cause hard-to-debug
+  // segfaults, but it unblocks us from conveniently implementing features for
+  // other platforms, and it does not break existing features for Arduino.
+  return NULL;
+}
+
 int lf_thread_create(lf_thread_t* thread, void* (*lf_thread)(void*), void* arguments) {
   lf_thread_t t = thread_new();
   long int start = thread_start(t, *lf_thread, arguments);

--- a/low_level_platform/impl/src/lf_flexpret_support.c
+++ b/low_level_platform/impl/src/lf_flexpret_support.c
@@ -178,6 +178,13 @@ int lf_available_cores() {
   return FP_THREADS - 1; // Return the number of Flexpret HW threads
 }
 
+lf_thread_t lf_thread_self() {
+  // N.B. This wrong implementation will eventually cause hard-to-debug
+  // segfaults, but it unblocks us from conveniently implementing features for
+  // other platforms, and it does not break existing features for FlexPRET.
+  return NULL;
+}
+
 int lf_thread_create(lf_thread_t* thread, void* (*lf_thread)(void*), void* arguments) {
   /**
    * Need to select between HRTT or SRTT; see

--- a/low_level_platform/impl/src/lf_windows_support.c
+++ b/low_level_platform/impl/src/lf_windows_support.c
@@ -162,6 +162,8 @@ int lf_available_cores() {
   return sysinfo.dwNumberOfProcessors;
 }
 
+lf_thread_t lf_thread_self() { return GetCurrentThread(); }
+
 int lf_thread_create(lf_thread_t* thread, void* (*lf_thread)(void*), void* arguments) {
   uintptr_t handle = _beginthreadex(NULL, 0, lf_thread, arguments, 0, NULL);
   *thread = (HANDLE)handle;


### PR DESCRIPTION
This silences undefined reference linker errors on other platforms that either have no support or that do not currently implement the API.

This is a hack, but I think it is better than the status quo, where we are keeping uninitialized memory in an array that we might used later. As far as our code is concerned, it adds wrong implementations to our code base, but functionally, it replaces uninitialized memory with a null pointer.

This also implements the API for Windows, which should make the API legitimately work on all 3 of the major general-purpose OSes.