### PR TITLE
Trace deadline violations

### DIFF
--- a/core/reactor.c
+++ b/core/reactor.c
@@ -164,6 +164,7 @@ int _lf_do_step(environment_t* env) {
         // Deadline violation has occurred.
         violation = true;
         // Invoke the local handler, if there is one.
+        tracepoint_reaction_starts(env, reaction, 0);
         reaction_function_t handler = reaction->deadline_violation_handler;
         if (handler != NULL) {
           (*handler)(reaction->self);
@@ -171,6 +172,7 @@ int _lf_do_step(environment_t* env) {
           // triggered reactions into the queue.
           schedule_output_reactions(env, reaction, 0);
         }
+        tracepoint_reaction_ends(env, reaction, 0);
       }
     }
 

--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -824,6 +824,7 @@ void schedule_output_reactions(environment_t* env, reaction_t* reaction, int wor
         violation = true;
         // Invoke the local handler, if there is one.
         reaction_function_t handler = downstream_to_execute_now->deadline_violation_handler;
+        tracepoint_reaction_starts(env, downstream_to_execute_now, worker);
         if (handler != NULL) {
           // Assume the mutex is still not held.
           (*handler)(downstream_to_execute_now->self);
@@ -832,6 +833,7 @@ void schedule_output_reactions(environment_t* env, reaction_t* reaction, int wor
           // triggered reactions into the queue or execute them directly if possible.
           schedule_output_reactions(env, downstream_to_execute_now, worker);
         }
+        tracepoint_reaction_ends(env, downstream_to_execute_now, worker);
       }
     }
     if (!violation) {

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -729,6 +729,7 @@ bool _lf_worker_handle_deadline_violation_for_reaction(environment_t* env, int w
       tracepoint_reaction_deadline_missed(env, reaction, worker_number);
       violation_occurred = true;
       // Invoke the local handler, if there is one.
+      tracepoint_reaction_starts(env, reaction, worker_number);
       reaction_function_t handler = reaction->deadline_violation_handler;
       if (handler != NULL) {
         LF_PRINT_LOG("Worker %d: Deadline violation. Invoking deadline handler.", worker_number);
@@ -739,6 +740,7 @@ bool _lf_worker_handle_deadline_violation_for_reaction(environment_t* env, int w
         schedule_output_reactions(env, reaction, worker_number);
         // Remove the reaction from the executing queue.
       }
+      tracepoint_reaction_ends(env, reaction, worker_number);
     }
   }
   return violation_occurred;

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -1112,6 +1112,7 @@ int lf_reactor_c_main(int argc, const char* argv[]) {
         // run on the main thread, rather than creating a new thread.
         // This is important for bare-metal platforms, who can't
         // afford to have the main thread sit idle.
+        env->thread_ids[j] = lf_thread_self();
         continue;
       }
       if (lf_thread_create(&env->thread_ids[j], worker, env) != 0) {

--- a/include/api/schedule.h
+++ b/include/api/schedule.h
@@ -195,24 +195,4 @@ trigger_handle_t lf_schedule_value(void* action, interval_t extra_delay, void* v
  */
 trigger_handle_t lf_schedule_trigger(environment_t* env, trigger_t* trigger, interval_t delay, lf_token_t* token);
 
-/**
- * @brief Check the deadline of the currently executing reaction against the
- * current physical time.
- *
- * If the deadline has passed, invoke the deadline
- * handler (if invoke_deadline_handler parameter is set true) and return true.
- * Otherwise, return false.
- *
- * This function is intended to be used within a reaction that has been invoked without a deadline
- * violation, but that wishes to check whether the deadline gets violated _during_ the execution of
- * the reaction. This can be used, for example, to implement a timeout mechanism that bounds the
- * execution time of a reaction, for example to realize an "anytime" computation.
- *
- * @param self The self struct of the reactor.
- * @param invoke_deadline_handler When this is set true, also invoke deadline
- *  handler if the deadline has passed.
- * @return True if the specified deadline has passed and false otherwise.
- */
-bool lf_check_deadline(void* self, bool invoke_deadline_handler);
-
 #endif // API_H

--- a/include/core/tracepoint.h
+++ b/include/core/tracepoint.h
@@ -103,7 +103,7 @@ int register_user_trace_event(void* self, char* description);
  * @param worker The thread number of the worker thread or 0 for single-threaded execution.
  */
 #define tracepoint_reaction_starts(env, reaction, worker)                                                              \
-  call_tracepoint(reaction_starts, reaction->self, env->current_tag, worker, worker, reaction->number, NULL, NULL, 0)
+  call_tracepoint(reaction_starts, reaction->self, env->current_tag, worker, worker, reaction->number, NULL, NULL, reaction->deadline)
 
 /**
  * Trace the end of a reaction execution.

--- a/include/core/tracepoint.h
+++ b/include/core/tracepoint.h
@@ -112,7 +112,7 @@ int register_user_trace_event(void* self, char* description);
  * @param worker The thread number of the worker thread or 0 for single-threaded execution.
  */
 #define tracepoint_reaction_ends(env, reaction, worker)                                                                \
-  call_tracepoint(reaction_ends, reaction->self, env->current_tag, worker, worker, reaction->number, NULL, NULL, 0)
+  call_tracepoint(reaction_ends, reaction->self, env->current_tag, worker, worker, reaction->number, NULL, NULL, reaction->deadline)
 
 /**
  * Trace a call to schedule.

--- a/lib/schedule.c
+++ b/lib/schedule.c
@@ -85,28 +85,6 @@ trigger_handle_t lf_schedule_value(void* action, interval_t extra_delay, void* v
   return return_value;
 }
 
-/**
- * Check the deadline of the currently executing reaction against the
- * current physical time. If the deadline has passed, invoke the deadline
- * handler (if invoke_deadline_handler parameter is set true) and return true.
- * Otherwise, return false.
- *
- * @param self The self struct of the reactor.
- * @param invoke_deadline_handler When this is set true, also invoke deadline
- *  handler if the deadline has passed.
- * @return True if the specified deadline has passed and false otherwise.
- */
-bool lf_check_deadline(void* self, bool invoke_deadline_handler) {
-  reaction_t* reaction = ((self_base_t*)self)->executing_reaction;
-  if (lf_time_physical() > (lf_time_logical(((self_base_t*)self)->environment) + reaction->deadline)) {
-    if (invoke_deadline_handler) {
-      reaction->deadline_violation_handler(self);
-    }
-    return true;
-  }
-  return false;
-}
-
 trigger_handle_t lf_schedule_trigger(environment_t* env, trigger_t* trigger, interval_t extra_delay,
                                      lf_token_t* token) {
   assert(env != GLOBAL_ENVIRONMENT);

--- a/low_level_platform/impl/src/lf_arduino_support.c
+++ b/low_level_platform/impl/src/lf_arduino_support.c
@@ -170,6 +170,16 @@ typedef void* (*lf_function_t)(void*);
  */
 int lf_available_cores() { return 1; }
 
+lf_thread_t lf_thread_self() {
+  // Not implemented. Although Arduino mbed provides a ThisThread API and a
+  // get_id() function, it does not provide a way to get the current thread as a
+  // Thread object.
+  // N.B. This wrong implementation will eventually cause hard-to-debug
+  // segfaults, but it unblocks us from conveniently implementing features for
+  // other platforms, and it does not break existing features for Arduino.
+  return NULL;
+}
+
 int lf_thread_create(lf_thread_t* thread, void* (*lf_thread)(void*), void* arguments) {
   lf_thread_t t = thread_new();
   long int start = thread_start(t, *lf_thread, arguments);

--- a/low_level_platform/impl/src/lf_flexpret_support.c
+++ b/low_level_platform/impl/src/lf_flexpret_support.c
@@ -178,6 +178,13 @@ int lf_available_cores() {
   return FP_THREADS - 1; // Return the number of Flexpret HW threads
 }
 
+lf_thread_t lf_thread_self() {
+  // N.B. This wrong implementation will eventually cause hard-to-debug
+  // segfaults, but it unblocks us from conveniently implementing features for
+  // other platforms, and it does not break existing features for FlexPRET.
+  return NULL;
+}
+
 int lf_thread_create(lf_thread_t* thread, void* (*lf_thread)(void*), void* arguments) {
   /**
    * Need to select between HRTT or SRTT; see

--- a/low_level_platform/impl/src/lf_windows_support.c
+++ b/low_level_platform/impl/src/lf_windows_support.c
@@ -162,6 +162,8 @@ int lf_available_cores() {
   return sysinfo.dwNumberOfProcessors;
 }
 
+lf_thread_t lf_thread_self() { return GetCurrentThread(); }
+
 int lf_thread_create(lf_thread_t* thread, void* (*lf_thread)(void*), void* arguments) {
   uintptr_t handle = _beginthreadex(NULL, 0, lf_thread, arguments, 0, NULL);
   *thread = (HANDLE)handle;


### PR DESCRIPTION
This allows deadline violations to be traced using a format that is similar to regular reaction executions. I am not sure if we want to mainline it, but we could do so backwards-compatibly.