### PR TITLE
Increment tag after mode switch rather than set to 1

### DIFF
--- a/core/modal_models/modes.c
+++ b/core/modal_models/modes.c
@@ -507,7 +507,7 @@ void _lf_process_mode_changes(environment_t* env, reactor_mode_state_t* states[]
     if (env->modes->triggered_reactions_request) {
       // Insert a dummy event in the event queue for the next microstep to make
       // sure startup/reset reactions (if any) are triggered as soon as possible.
-      tag_t dummy_event_tag = (tag_t){.time = env->current_tag.time, .microstep = 1};
+      tag_t dummy_event_tag = (tag_t){.time = env->current_tag.time, .microstep = env->current_tag.microstep + 1};
       pqueue_tag_insert(env->event_q, (pqueue_tag_element_t*)_lf_create_dummy_events(env, dummy_event_tag));
     }
   }


### PR DESCRIPTION
This PR fixes #458.  Previously, after a mode transition, the microstep was hardwired to 1, which caused a fatal error after the mode transition when the runtime tried to advance to microstep 1 and found that it was already at microstep 1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the accuracy of mode changes processing by ensuring reactions are triggered at the appropriate microstep, enhancing the system's responsiveness and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->