### PR TITLE
Make tracing usable for debugging

### DIFF
--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -1166,6 +1166,7 @@ void termination(void) {
       }
     }
   }
+  lf_tracing_global_shutdown();
   // Skip most cleanup on abnormal termination.
   if (_lf_normal_termination) {
     _lf_free_all_tokens(); // Must be done before freeing reactors.
@@ -1188,8 +1189,6 @@ void termination(void) {
     }
 #endif
     lf_free_all_reactors();
-
-    lf_tracing_global_shutdown();
 
     // Free up memory associated with environment.
     // Do this last so that printed warnings don't access freed memory.


### PR DESCRIPTION
If traces are not flushed to files when there is an abnormal termination, such as force-quitting a deadlocked program, then they are not very useful for debugging.

Since debugging seems like an important use case of traces, they should probably be flushed to files even when there is an abnormal termination.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved termination sequence to ensure proper shutdown of tracing before reactor cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->