### PR TITLE
Prevent a warning when the second timer event is after the timeout time.

### DIFF
--- a/core/lf_token.c
+++ b/core/lf_token.c
@@ -28,7 +28,7 @@ int _lf_count_token_allocations;
 
 /**
  * @brief List of tokens created within reactions that must be freed.
- * 
+ *
  * Tokens created by lf_writable_copy, which is automatically invoked
  * when an input is mutable, must have their reference count decremented
  * at the end of a tag (or the beginning of the next tag).

--- a/core/lf_token.c
+++ b/core/lf_token.c
@@ -26,7 +26,20 @@ int _lf_count_token_allocations;
 #include "platform.h" // Enter/exit critical sections
 #include "port.h"     // Defines lf_port_base_t.
 
-lf_token_t* _lf_tokens_allocated_in_reactions = NULL;
+/**
+ * @brief List of tokens created within reactions that must be freed.
+ * 
+ * Tokens created by lf_writable_copy, which is automatically invoked
+ * when an input is mutable, must have their reference count decremented
+ * at the end of a tag (or the beginning of the next tag).
+ * Otherwise, their memory could leak. If they are passed on to
+ * an output or to a call to lf_schedule during the reaction, then
+ * those will also result in incremented reference counts, enabling
+ * the token to live on until used. For example, a new token created
+ * by lf_writable_copy could become the new template token for an output
+ * via a call to lf_set.
+ */
+static lf_token_t* _lf_tokens_allocated_in_reactions = NULL;
 
 ////////////////////////////////////////////////////////////////////
 //// Global variables not visible outside this file.
@@ -197,6 +210,8 @@ lf_token_t* _lf_new_token(token_type_t* type, void* value, size_t length) {
     if (hashset_iterator_next(iterator) >= 0) {
       result = hashset_iterator_value(iterator);
       hashset_remove(_lf_token_recycling_bin, result);
+      // Make sure there isn't a previous value.
+      result->value = NULL;
       LF_PRINT_DEBUG("_lf_new_token: Retrieved token from the recycling bin: %p", (void*)result);
     }
     free(iterator);
@@ -352,8 +367,7 @@ token_freed _lf_done_using(lf_token_t* token) {
 
 void _lf_free_token_copies() {
   while (_lf_tokens_allocated_in_reactions != NULL) {
-    lf_token_t* next = _lf_tokens_allocated_in_reactions->next;
     _lf_done_using(_lf_tokens_allocated_in_reactions);
-    _lf_tokens_allocated_in_reactions = next;
+    _lf_tokens_allocated_in_reactions = _lf_tokens_allocated_in_reactions->next;
   }
 }

--- a/include/core/lf_token.h
+++ b/include/core/lf_token.h
@@ -152,20 +152,6 @@ typedef struct lf_port_base_t {
 //// Global variables
 
 /**
- * @brief List of tokens created within reactions that must be freed.
- * Tokens created by lf_writable_copy, which is automatically invoked
- * when an input is mutable, must have their reference count decremented
- * at the end of a tag (or the beginning of the next tag).
- * Otherwise, their memory could leak. If they are passed on to
- * an output or to a call to lf_schedule during the reaction, then
- * those will also result in incremented reference counts, enabling
- * the token to live on until used. For example, a new token created
- * by lf_writable_copy could become the new template token for an output
- * via a call to lf_set.
- */
-extern lf_token_t* _lf_tokens_allocated_in_reactions;
-
-/**
  * Counter used to issue a warning if memory is
  * allocated for tokens and never freed. Note that
  * every trigger will have one token allocated for


### PR DESCRIPTION
This prevents a warning when the second timer event is after the timeout time.
This also makes some semantically meaningless cleanups in lf_token.c/h.
There is a [companion PR in lingua-franca](https://github.com/lf-lang/lingua-franca/pull/2420).