### PR TITLE
Fix Unintended Action Override

### DIFF
--- a/python/lib/pythontarget.c
+++ b/python/lib/pythontarget.c
@@ -542,8 +542,8 @@ PyObject* convert_C_action_to_py(void* action) {
   }
 
   // Actions in Python always use token type
-  if ((( generic_action_instance_struct*)action)->token!=NULL)
-  ((generic_action_capsule_struct*)cap)->value = (( generic_action_instance_struct*)action)->token->value;
+  if (((generic_action_instance_struct*)action)->token != NULL)
+    ((generic_action_capsule_struct*)cap)->value = ((generic_action_instance_struct*)action)->token->value;
 
   return cap;
 }

--- a/python/lib/pythontarget.c
+++ b/python/lib/pythontarget.c
@@ -542,7 +542,8 @@ PyObject* convert_C_action_to_py(void* action) {
   }
 
   // Actions in Python always use token type
-  ((generic_action_capsule_struct*)cap)->value = trigger->tmplt.token->value;
+  if ((( generic_action_instance_struct*)action)->token!=NULL)
+  ((generic_action_capsule_struct*)cap)->value = (( generic_action_instance_struct*)action)->token->value;
 
   return cap;
 }


### PR DESCRIPTION
This PR fixes the unintended action override when two actions are triggered at about the same time in issue #489. The bug was in `convert_C_action_to_py`, the token value in the trigger is suspectable to concurrency overrides. The solution was to use the token value in the action. The companion PR in lingua-franca is https://github.com/lf-lang/lingua-franca/pull/2423