### PR TITLE
Fix Unintended Action Override

### DIFF
--- a/core/lf_token.c
+++ b/core/lf_token.c
@@ -237,6 +237,7 @@ lf_token_t* _lf_new_token(token_type_t* type, void* value, size_t length) {
 }
 
 lf_token_t* _lf_get_token(token_template_t* tmplt) {
+  LF_CRITICAL_SECTION_ENTER(GLOBAL_ENVIRONMENT);
   if (tmplt->token != NULL) {
     if (tmplt->token->ref_count == 1) {
       LF_PRINT_DEBUG("_lf_get_token: Reusing template token: %p with ref_count %zu", (void*)tmplt->token,
@@ -244,15 +245,13 @@ lf_token_t* _lf_get_token(token_template_t* tmplt) {
       // Free any previous value in the token.
       _lf_free_token_value(tmplt->token);
       return tmplt->token;
-    } else {
-      // Liberate the token.
-      _lf_done_using(tmplt->token);
     }
   }
+  LF_CRITICAL_SECTION_EXIT(GLOBAL_ENVIRONMENT);
   // If we get here, we need a new token.
-  tmplt->token = _lf_new_token((token_type_t*)tmplt, NULL, 0);
-  tmplt->token->ref_count = 1;
-  return tmplt->token;
+  lf_token_t* result = _lf_new_token((token_type_t*)tmplt, NULL, 0);
+  result->ref_count = 1;
+  return result;
 }
 
 void _lf_initialize_template(token_template_t* tmplt, size_t element_size) {

--- a/core/lf_token.c
+++ b/core/lf_token.c
@@ -238,14 +238,12 @@ lf_token_t* _lf_new_token(token_type_t* type, void* value, size_t length) {
 
 lf_token_t* _lf_get_token(token_template_t* tmplt) {
   LF_CRITICAL_SECTION_ENTER(GLOBAL_ENVIRONMENT);
-  if (tmplt->token != NULL) {
-    if (tmplt->token->ref_count == 1) {
-      LF_PRINT_DEBUG("_lf_get_token: Reusing template token: %p with ref_count %zu", (void*)tmplt->token,
-                     tmplt->token->ref_count);
-      // Free any previous value in the token.
-      _lf_free_token_value(tmplt->token);
-      return tmplt->token;
-    }
+  if (tmplt->token != NULL && tmplt->token->ref_count == 1) {
+    LF_PRINT_DEBUG("_lf_get_token: Reusing template token: %p with ref_count %zu", (void*)tmplt->token,
+                   tmplt->token->ref_count);
+    // Free any previous value in the token.
+    _lf_free_token_value(tmplt->token);
+    return tmplt->token;
   }
   LF_CRITICAL_SECTION_EXIT(GLOBAL_ENVIRONMENT);
   // If we get here, we need a new token.

--- a/core/lf_token.c
+++ b/core/lf_token.c
@@ -243,6 +243,7 @@ lf_token_t* _lf_get_token(token_template_t* tmplt) {
                    tmplt->token->ref_count);
     // Free any previous value in the token.
     _lf_free_token_value(tmplt->token);
+    LF_CRITICAL_SECTION_EXIT(GLOBAL_ENVIRONMENT);
     return tmplt->token;
   }
   LF_CRITICAL_SECTION_EXIT(GLOBAL_ENVIRONMENT);

--- a/core/lf_token.c
+++ b/core/lf_token.c
@@ -236,25 +236,6 @@ lf_token_t* _lf_new_token(token_type_t* type, void* value, size_t length) {
   return result;
 }
 
-lf_token_t* _lf_get_token(token_template_t* tmplt) {
-  if (tmplt->token != NULL) {
-    if (tmplt->token->ref_count == 1) {
-      LF_PRINT_DEBUG("_lf_get_token: Reusing template token: %p with ref_count %zu", (void*)tmplt->token,
-                     tmplt->token->ref_count);
-      // Free any previous value in the token.
-      _lf_free_token_value(tmplt->token);
-      return tmplt->token;
-    } else {
-      // Liberate the token.
-      _lf_done_using(tmplt->token);
-    }
-  }
-  // If we get here, we need a new token.
-  tmplt->token = _lf_new_token((token_type_t*)tmplt, NULL, 0);
-  tmplt->token->ref_count = 1;
-  return tmplt->token;
-}
-
 void _lf_initialize_template(token_template_t* tmplt, size_t element_size) {
   assert(tmplt != NULL);
   LF_CRITICAL_SECTION_ENTER(GLOBAL_ENVIRONMENT);
@@ -285,8 +266,8 @@ lf_token_t* _lf_initialize_token_with_value(token_template_t* tmplt, void* value
   assert(tmplt != NULL);
   LF_PRINT_DEBUG("_lf_initialize_token_with_value: template %p, value %p", (void*)tmplt, value);
 
-  lf_token_t* result = _lf_get_token(tmplt);
-  result->value = value;
+  lf_token_t* result = _lf_new_token((token_type_t*)tmplt, value, 0);
+  result->ref_count = 1;
 // Count allocations to issue a warning if this is never freed.
 #if !defined NDEBUG
   LF_CRITICAL_SECTION_ENTER(GLOBAL_ENVIRONMENT);

--- a/core/lf_token.c
+++ b/core/lf_token.c
@@ -236,6 +236,25 @@ lf_token_t* _lf_new_token(token_type_t* type, void* value, size_t length) {
   return result;
 }
 
+lf_token_t* _lf_get_token(token_template_t* tmplt) {
+  if (tmplt->token != NULL) {
+    if (tmplt->token->ref_count == 1) {
+      LF_PRINT_DEBUG("_lf_get_token: Reusing template token: %p with ref_count %zu", (void*)tmplt->token,
+                     tmplt->token->ref_count);
+      // Free any previous value in the token.
+      _lf_free_token_value(tmplt->token);
+      return tmplt->token;
+    } else {
+      // Liberate the token.
+      _lf_done_using(tmplt->token);
+    }
+  }
+  // If we get here, we need a new token.
+  tmplt->token = _lf_new_token((token_type_t*)tmplt, NULL, 0);
+  tmplt->token->ref_count = 1;
+  return tmplt->token;
+}
+
 void _lf_initialize_template(token_template_t* tmplt, size_t element_size) {
   assert(tmplt != NULL);
   LF_CRITICAL_SECTION_ENTER(GLOBAL_ENVIRONMENT);
@@ -266,8 +285,8 @@ lf_token_t* _lf_initialize_token_with_value(token_template_t* tmplt, void* value
   assert(tmplt != NULL);
   LF_PRINT_DEBUG("_lf_initialize_token_with_value: template %p, value %p", (void*)tmplt, value);
 
-  lf_token_t* result = _lf_new_token((token_type_t*)tmplt, value, 0);
-  result->ref_count = 1;
+  lf_token_t* result = _lf_get_token(tmplt);
+  result->value = value;
 // Count allocations to issue a warning if this is never freed.
 #if !defined NDEBUG
   LF_CRITICAL_SECTION_ENTER(GLOBAL_ENVIRONMENT);

--- a/include/api/reaction_macros.h
+++ b/include/api/reaction_macros.h
@@ -98,6 +98,7 @@
   do {                                                                                                                 \
     lf_set_present(out);                                                                                               \
     lf_token_t* token = _lf_initialize_token_with_value((token_template_t*)out, val, len);                             \
+    out->token = token;                                                                                                \
     out->value = token->value;                                                                                         \
     out->length = len;                                                                                                 \
   } while (0)
@@ -106,6 +107,7 @@
   do {                                                                                                                 \
     lf_set_present(out);                                                                                               \
     lf_token_t* token = _lf_initialize_token_with_value((token_template_t*)out, val, len);                             \
+    out->token = token;                                                                                                \
     out->value = static_cast<decltype(out->value)>(token->value);                                                      \
     out->length = len;                                                                                                 \
   } while (0)

--- a/include/api/reaction_macros.h
+++ b/include/api/reaction_macros.h
@@ -77,6 +77,7 @@
       /* The cast "*((void**) &out->value)" is a hack to make the code */                                              \
       /* compile with non-token types where value is not a pointer. */                                                 \
       lf_token_t* token = _lf_initialize_token_with_value((token_template_t*)out, *((void**)&out->value), 1);          \
+      out->token = token;                                                                                              \
     }                                                                                                                  \
   } while (0)
 

--- a/include/core/lf_token.h
+++ b/include/core/lf_token.h
@@ -234,6 +234,17 @@ token_freed _lf_free_token(lf_token_t* token);
 lf_token_t* _lf_new_token(token_type_t* type, void* value, size_t length);
 
 /**
+ * Get a token for the specified template.
+ * If the template already has a token and the reference count is 1,
+ * then return that token. Otherwise, create a new token,
+ * make it the new template, and dissociate or free the
+ * previous template token.
+ * @param tmplt The template. // template is a C++ keyword.
+ * @return A new or recycled lf_token_t struct.
+ */
+lf_token_t* _lf_get_token(token_template_t* tmplt);
+
+/**
  * Initialize the specified template to contain a token that is an
  * array with the specified element size. If the template already has
  * a token with a reference count greater than 1 or a non-matching type,

--- a/include/core/lf_token.h
+++ b/include/core/lf_token.h
@@ -234,17 +234,6 @@ token_freed _lf_free_token(lf_token_t* token);
 lf_token_t* _lf_new_token(token_type_t* type, void* value, size_t length);
 
 /**
- * Get a token for the specified template.
- * If the template already has a token and the reference count is 1,
- * then return that token. Otherwise, create a new token,
- * make it the new template, and dissociate or free the
- * previous template token.
- * @param tmplt The template. // template is a C++ keyword.
- * @return A new or recycled lf_token_t struct.
- */
-lf_token_t* _lf_get_token(token_template_t* tmplt);
-
-/**
  * Initialize the specified template to contain a token that is an
  * array with the specified element size. If the template already has
  * a token with a reference count greater than 1 or a non-matching type,

--- a/lingua-franca-ref.txt
+++ b/lingua-franca-ref.txt
@@ -1,1 +1,1 @@
-master
+fix-concurrency


### PR DESCRIPTION
This PR is a subsequent PR for #490 to address the unintended action override concurrency bug. The companion PR in `lingua-franca` is https://github.com/lf-lang/lingua-franca/pull/2429.

## Reproduce the Bug with Tests

When actions are triggered in different threads concurrently, there is a chance that the value of a later action could override the value of a previous action. This is unintended and can be reproduced in `ConcurrentAction.lf`. #490 attempted to solve this bug, but in some CI workflows the bug was triggered at a lower probability. In 20 runs of `ConcurrentAction.lf`, most likely one will fail and the action value would be overwritten. 

A more aggressive test, `ConcurrentActionRepeat.lf` has been created to reproduce this bug. It is similar to `ConcurrentAction.lf` but runs the concurrent test 100 times. Increasing the threads that trigger the concurrent action in `ConcurrentAction.lf` would not increase the chance of triggering this bug, because the `action.schedule` are all lumped together before the actions are popped out of the event queue.

## The Concurrency Bug

The concurrency bug originates from the templating of action tokens. Each action has a template that contains a token that is used both to reuse the token and pass the value of the action. During the lifecycle of each action, there are two phases: it is first scheduled and then popped out of the event queue and executed. The first phase uses the template to reuse the token in `_lf_initialize_token_with_value` which calls `_lf_get_token`, and the second phase uses the template to pass the value of the token with `_lf_replace_template_token`. 

The unintended action override happens when `_lf_initialize_token_with_value` changes the template token when another thread is passing action value with the template token. Then the other thread's action value would read the value of the action value just scheduled, which is wrong.

## Fix Concurrency Bug

To fix the concurrency bug, we cannot have the to phases both changing the template token. Since phase 2 is heavily used in various different places to pass the token value, it is simpler to change the behavior of `_lf_initialize_token_with_value` to not modify the template token. 

The fix is to not modify the template token in `_lf_get_token` (which is called in `_lf_initialize_token_with_value`). Note that token reuse does not cause concurrency bugs since the reference count of 1 means that there is no more use of token value, hence it can be reused safely.

The current implementation has no duplicated actions in 300 runs of `ConcurrentActionRepeat.lf`.

## Derived Fix

Several other bugs were derived when the template token is not replaced during scheduling(which took quite some time to track down). Turns out that some code assumes that the template token has been replaced during `_lf_initialize_token_with_value` and uses the value and length of the template token. This can be fixed by setting the token to the port and using the value and length of the port token.
