### PR TITLE
Fix lingua-franca-ref to point to master instead of fix-concurrency

### DIFF
--- a/lingua-franca-ref.txt
+++ b/lingua-franca-ref.txt
@@ -1,1 +1,1 @@
-fix-concurrency
+master


### PR DESCRIPTION
This PR simply points `lingua-franca-ref` to `master` instead of `fix-concurrency`.