### PR TITLE
Enable flexpret

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,13 +55,13 @@ jobs:
       compiler-ref: ${{ needs.fetch-lf.outputs.ref }}
     if: ${{ !github.event.pull_request.draft ||contains( github.event.pull_request.labels.*.name, 'zephyr') }}
 
-#  lf-default-flexpret:
-#   needs: [fetch-lf]
-#   uses: lf-lang/lingua-franca/.github/workflows/c-flexpret-tests.yml@master
-#   with:
-#     runtime-ref: ${{ github.ref }}
-#     compiler-ref: ${{ needs.fetch-lf.outputs.ref }}
-#   if: ${{ !github.event.pull_request.draft ||contains( github.event.pull_request.labels.*.name, 'flexpret') }}
+  lf-default-flexpret:
+    needs: [fetch-lf]
+    uses: lf-lang/lingua-franca/.github/workflows/c-flexpret-tests.yml@master
+    with:
+      runtime-ref: ${{ github.ref }}
+      compiler-ref: ${{ needs.fetch-lf.outputs.ref }}
+    if: ${{ !github.event.pull_request.draft ||contains( github.event.pull_request.labels.*.name, 'flexpret') }}
 
   lf-default:
     needs: [fetch-lf]


### PR DESCRIPTION
This PR renables the FlexPRET tests to verify that changes to the github action yamls in Lingua Franca has solved the FlexPRET CI issue