### PR TITLE
Update clang-format to version 19.1.5

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -5,12 +5,15 @@ on: [pull_request]
 
 jobs:
   clang-format:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v2
-      - name: Install clang-tidy
+      - name: Install clang-tidy and clang-format
         run: |
           sudo apt-get update
           sudo apt-get install -y clang-tidy
+          sudo apt-get install -y pipx
+          pipx install clang-format
+          clang-format --version
       - name: Analyze
         run: make format-check

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -1951,9 +1951,9 @@ void lf_connect_to_rti(const char* hostname, int port) {
     if (result < 0)
       continue; // Connect failed.
 
-      // Have connected to an RTI, but not sure it's the right RTI.
-      // Send a MSG_TYPE_FED_IDS message and wait for a reply.
-      // Notify the RTI of the ID of this federate and its federation.
+    // Have connected to an RTI, but not sure it's the right RTI.
+    // Send a MSG_TYPE_FED_IDS message and wait for a reply.
+    // Notify the RTI of the ID of this federate and its federation.
 
 #ifdef FEDERATED_AUTHENTICATED
     LF_PRINT_LOG("Connected to an RTI. Performing HMAC-based authentication using federation ID.");

--- a/include/core/utils/impl/hashmap.h
+++ b/include/core/utils/impl/hashmap.h
@@ -19,7 +19,7 @@
 #define V void*
 #endif
 #ifndef HASH_OF
-#define HASH_OF(key) (size_t) key
+#define HASH_OF(key) (size_t)key
 #endif
 #ifndef HASHMAP
 #define HASHMAP(token) hashmap##_##token

--- a/include/core/utils/impl/pointer_hashmap.h
+++ b/include/core/utils/impl/pointer_hashmap.h
@@ -30,7 +30,7 @@
 #define HASHMAP(token) hashmap_object2int##_##token
 #define K void*
 #define V int
-#define HASH_OF(key) (size_t) key
+#define HASH_OF(key) (size_t)key
 #include "hashmap.h"
 #undef HASHMAP
 #undef K

--- a/tag/api/tag.h
+++ b/tag/api/tag.h
@@ -37,15 +37,12 @@
 #define NEVER_TAG                                                                                                      \
   (tag_t) { .time = NEVER, .microstep = NEVER_MICROSTEP }
 // Need a separate initializer expression to comply with some C compilers
-#define NEVER_TAG_INITIALIZER                                                                                          \
-  { NEVER, NEVER_MICROSTEP }
+#define NEVER_TAG_INITIALIZER {NEVER, NEVER_MICROSTEP}
 #define FOREVER_TAG                                                                                                    \
   (tag_t) { .time = FOREVER, .microstep = FOREVER_MICROSTEP }
 // Need a separate initializer expression to comply with some C compilers
-#define FOREVER_TAG_INITIALIZER                                                                                        \
-  { FOREVER, FOREVER_MICROSTEP }
-#define ZERO_TAG                                                                                                       \
-  (tag_t) { .time = 0LL, .microstep = 0u }
+#define FOREVER_TAG_INITIALIZER {FOREVER, FOREVER_MICROSTEP}
+#define ZERO_TAG (tag_t){.time = 0LL, .microstep = 0u}
 
 // Returns true if timeout has elapsed.
 #define CHECK_TIMEOUT(start, duration) (lf_time_physical() > ((start) + (duration)))


### PR DESCRIPTION
This PR installs clang-format v19.1.5 in CI and uses it to check formatting.

NOTE: The target branch is the #501 branch. 