### PR TITLE
Add `shutdown_socket()` function for follow up of #505

### DIFF
--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -871,14 +871,7 @@ static void handle_federate_failed(federate_info_t* my_fed) {
   // Indicate that there will no further events from this federate.
   my_fed->enclave.next_event = FOREVER_TAG;
 
-  // According to this: https://stackoverflow.com/questions/4160347/close-vs-shutdown-socket,
-  // the close should happen when receiving a 0 length message from the other end.
-  // Here, we just signal the other side that no further writes to the socket are
-  // forthcoming, which should result in the other end getting a zero-length reception.
-  shutdown(my_fed->socket, SHUT_RDWR);
-
-  // We can now safely close the socket.
-  close(my_fed->socket); //  from unistd.h
+  shutdown_socket(&my_fed->socket, false);
 
   // Check downstream federates to see whether they should now be granted a TAG.
   // To handle cycles, need to create a boolean array to keep
@@ -917,21 +910,7 @@ static void handle_federate_resign(federate_info_t* my_fed) {
   // Indicate that there will no further events from this federate.
   my_fed->enclave.next_event = FOREVER_TAG;
 
-  // According to this: https://stackoverflow.com/questions/4160347/close-vs-shutdown-socket,
-  // the close should happen when receiving a 0 length message from the other end.
-  // Here, we just signal the other side that no further writes to the socket are
-  // forthcoming, which should result in the other end getting a zero-length reception.
-  shutdown(my_fed->socket, SHUT_WR);
-
-  // Wait for the federate to send an EOF or a socket error to occur.
-  // Discard any incoming bytes. Normally, this read should return 0 because
-  // the federate is resigning and should itself invoke shutdown.
-  unsigned char buffer[10];
-  while (read(my_fed->socket, buffer, 10) > 0)
-    ;
-
-  // We can now safely close the socket.
-  close(my_fed->socket); //  from unistd.h
+  shutdown_socket(&my_fed->socket, true);
 
   // Check downstream federates to see whether they should now be granted a TAG.
   // To handle cycles, need to create a boolean array to keep
@@ -1030,9 +1009,7 @@ void send_reject(int* socket_id, unsigned char error_code) {
     lf_print_warning("RTI failed to write MSG_TYPE_REJECT message on the socket.");
   }
   // Close the socket.
-  shutdown(*socket_id, SHUT_RDWR);
-  close(*socket_id);
-  *socket_id = -1;
+  shutdown_socket(socket_id, false);
   LF_MUTEX_UNLOCK(&rti_mutex);
 }
 
@@ -1420,9 +1397,7 @@ void lf_connect_to_federates(int socket_descriptor) {
       if (!authenticate_federate(&socket_id)) {
         lf_print_warning("RTI failed to authenticate the incoming federate.");
         // Close the socket.
-        shutdown(socket_id, SHUT_RDWR);
-        close(socket_id);
-        socket_id = -1;
+        shutdown_socket(&socket_id, false);
         // Ignore the federate that failed authentication.
         i--;
         continue;
@@ -1490,8 +1465,7 @@ void* respond_to_erroneous_connections(void* nothing) {
       lf_print_warning("RTI failed to write FEDERATION_ID_DOES_NOT_MATCH to erroneous incoming connection.");
     }
     // Close the socket.
-    shutdown(socket_id, SHUT_RDWR);
-    close(socket_id);
+    shutdown_socket(&socket_id, false);
   }
   return NULL;
 }
@@ -1554,21 +1528,10 @@ void wait_for_federates(int socket_descriptor) {
   // Shutdown and close the socket that is listening for incoming connections
   // so that the accept() call in respond_to_erroneous_connections returns.
   // That thread should then check rti->all_federates_exited and it should exit.
-  if (shutdown(socket_descriptor, SHUT_RDWR)) {
-    LF_PRINT_LOG("On shut down TCP socket, received reply: %s", strerror(errno));
-  }
-  // NOTE: In all common TCP/IP stacks, there is a time period,
-  // typically between 30 and 120 seconds, called the TIME_WAIT period,
-  // before the port is released after this close. This is because
-  // the OS is preventing another program from accidentally receiving
-  // duplicated packets intended for this program.
-  close(socket_descriptor);
+  shutdown_socket(&socket_descriptor, false);
 
   if (rti_remote->socket_descriptor_UDP > 0) {
-    if (shutdown(rti_remote->socket_descriptor_UDP, SHUT_RDWR)) {
-      LF_PRINT_LOG("On shut down UDP socket, received reply: %s", strerror(errno));
-    }
-    close(rti_remote->socket_descriptor_UDP);
+    shutdown_socket(&rti_remote->socket_descriptor_UDP, false);
   }
 }
 

--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -1563,7 +1563,7 @@ void initialize_RTI(rti_remote_t* rti) {
 
   // Initialize thread synchronization primitives
   LF_MUTEX_INIT(&rti_mutex);
-  LF_MUTEX_INIT(&shutdown_mutex);
+  init_shutdown_mutex();
   LF_COND_INIT(&received_start_times, &rti_mutex);
   LF_COND_INIT(&sent_start_time, &rti_mutex);
 

--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -1510,7 +1510,7 @@ void initialize_federate(federate_info_t* fed, uint16_t id) {
 int32_t start_rti_server(uint16_t port) {
   _lf_initialize_clock();
   // Create the TCP socket server
-  if (create_TCP_server(port, &rti_remote->socket_descriptor_TCP, &rti_remote->final_port_TCP)) {
+  if (create_TCP_server(port, &rti_remote->socket_descriptor_TCP, &rti_remote->final_port_TCP, true)) {
     lf_print_error_system_failure("RTI failed to create TCP server: %s.", strerror(errno));
   };
   lf_print("RTI: Listening for federates.");
@@ -1518,7 +1518,7 @@ int32_t start_rti_server(uint16_t port) {
   // Try to get the rti_remote->final_port_TCP + 1 port
   if (rti_remote->clock_sync_global_status >= clock_sync_on) {
     if (create_UDP_server(rti_remote->final_port_TCP + 1, &rti_remote->socket_descriptor_UDP,
-                          &rti_remote->final_port_UDP)) {
+                          &rti_remote->final_port_UDP, true)) {
       lf_print_error_system_failure("RTI failed to create UDP server: %s.", strerror(errno));
     }
   }
@@ -1588,12 +1588,7 @@ void initialize_RTI(rti_remote_t* rti) {
   rti_remote->num_feds_proposed_start = 0;
   rti_remote->all_federates_exited = false;
   rti_remote->federation_id = "Unidentified Federation";
-  // Default values for user_specified_port are 0 for a federate and 1 for the RTI. Neither of these are valid port
-  // numbers, but rather specify that an available port needs to be found. With value 0, the operating system will
-  // provide an available port number. With value 1, the function will first try DEFAULT_PORT, which is 15045, and,
-  // if this fails, wait for time given by PORT_BIND_RETRY_INTERVAL and try again. It fails if this process fails after
-  // MAX_NUM_PORT_ADDRESSES tries. For more details, check this PR. https://github.com/lf-lang/reactor-c/pull/505.
-  rti_remote->user_specified_port = 1;
+  rti_remote->user_specified_port = 0;
   rti_remote->final_port_TCP = 0;
   rti_remote->socket_descriptor_TCP = -1;
   rti_remote->final_port_UDP = UINT16_MAX;

--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -942,7 +942,7 @@ void* federate_info_thread_TCP(void* fed) {
       // Nothing more to do. Close the socket and exit.
       // Prevent multiple threads from closing the same socket at the same time.
       LF_MUTEX_LOCK(&rti_mutex);
-      shutdown_socket(my_fed->socket, false); //  from unistd.h
+      shutdown_socket(&my_fed->socket, false); //  from unistd.h
       LF_MUTEX_UNLOCK(&rti_mutex);
       // FIXME: We need better error handling here, but do not stop execution here.
       break;
@@ -1007,7 +1007,7 @@ void send_reject(int* socket_id, unsigned char error_code) {
     lf_print_warning("RTI failed to write MSG_TYPE_REJECT message on the socket.");
   }
   // Close the socket without reading until EOF.
-  shutdown_socket(socket_id, false);
+  shutdown_socket(&socket_id, false);
   LF_MUTEX_UNLOCK(&rti_mutex);
 }
 

--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -1413,7 +1413,7 @@ static bool authenticate_federate(int* socket) {
 
 void lf_connect_to_federates(int socket_descriptor) {
   for (int i = 0; i < rti_remote->base.number_of_scheduling_nodes; i++) {
-    int socket_id = accept_rti_socket(rti_remote->socket_descriptor_TCP);
+    int socket_id = accept_socket(rti_remote->socket_descriptor_TCP, -1);
 // Wait for the first message from the federate when RTI -a option is on.
 #ifdef __RTI_AUTH__
     if (rti_remote->authentication_enabled) {
@@ -1473,7 +1473,7 @@ void* respond_to_erroneous_connections(void* nothing) {
     // Wait for an incoming connection request.
     // The following will block until either a federate attempts to connect
     // or close(rti->socket_descriptor_TCP) is called.
-    int socket_id = accept_rti_socket(rti_remote->socket_descriptor_TCP);
+    int socket_id = accept_socket(rti_remote->socket_descriptor_TCP, -1);
     if (socket_id < 0) {
       return NULL;
     }

--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -970,9 +970,9 @@ void* federate_info_thread_TCP(void* fed) {
       my_fed->enclave.state = NOT_CONNECTED;
       // Nothing more to do. Close the socket and exit.
       // Prevent multiple threads from closing the same socket at the same time.
-      LF_MUTEX_LOCK(&rti_mutex);
+      // LF_MUTEX_LOCK(&rti_mutex);
       shutdown_socket(&my_fed->socket, false); //  from unistd.h
-      LF_MUTEX_UNLOCK(&rti_mutex);
+      // LF_MUTEX_UNLOCK(&rti_mutex);
       // FIXME: We need better error handling here, but do not stop execution here.
       break;
     }
@@ -1030,14 +1030,14 @@ void send_reject(int* socket_id, unsigned char error_code) {
   unsigned char response[2];
   response[0] = MSG_TYPE_REJECT;
   response[1] = error_code;
-  LF_MUTEX_LOCK(&rti_mutex);
+  // LF_MUTEX_LOCK(&rti_mutex);
   // NOTE: Ignore errors on this response.
   if (write_to_socket(*socket_id, 2, response)) {
     lf_print_warning("RTI failed to write MSG_TYPE_REJECT message on the socket.");
   }
   // Close the socket without reading until EOF.
   shutdown_socket(socket_id, false);
-  LF_MUTEX_UNLOCK(&rti_mutex);
+  // LF_MUTEX_UNLOCK(&rti_mutex);
 }
 
 /**

--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -1007,7 +1007,7 @@ void send_reject(int* socket_id, unsigned char error_code) {
     lf_print_warning("RTI failed to write MSG_TYPE_REJECT message on the socket.");
   }
   // Close the socket without reading until EOF.
-  shutdown_socket(&socket_id, false);
+  shutdown_socket(socket_id, false);
   LF_MUTEX_UNLOCK(&rti_mutex);
 }
 

--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -1510,12 +1510,17 @@ void initialize_federate(federate_info_t* fed, uint16_t id) {
 int32_t start_rti_server(uint16_t port) {
   _lf_initialize_clock();
   // Create the TCP socket server
-  create_TCP_server(port, &rti_remote->socket_descriptor_TCP, &rti_remote->final_port_TCP);
+  if (create_TCP_server(port, &rti_remote->socket_descriptor_TCP, &rti_remote->final_port_TCP)) {
+    lf_print_error_system_failure("RTI failed to create TCP server: %s.", strerror(errno));
+  };
   lf_print("RTI: Listening for federates.");
   // Create the UDP socket server
   // Try to get the rti_remote->final_port_TCP + 1 port
   if (rti_remote->clock_sync_global_status >= clock_sync_on) {
-    create_UDP_server(rti_remote->final_port_TCP + 1, &rti_remote->socket_descriptor_UDP, &rti_remote->final_port_UDP);
+    if (create_UDP_server(rti_remote->final_port_TCP + 1, &rti_remote->socket_descriptor_UDP,
+                          &rti_remote->final_port_UDP)) {
+      lf_print_error_system_failure("RTI failed to create UDP server: %s.", strerror(errno));
+    }
   }
   return rti_remote->socket_descriptor_TCP;
 }

--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -970,9 +970,7 @@ void* federate_info_thread_TCP(void* fed) {
       my_fed->enclave.state = NOT_CONNECTED;
       // Nothing more to do. Close the socket and exit.
       // Prevent multiple threads from closing the same socket at the same time.
-      // LF_MUTEX_LOCK(&rti_mutex);
       shutdown_socket(&my_fed->socket, false); //  from unistd.h
-      // LF_MUTEX_UNLOCK(&rti_mutex);
       // FIXME: We need better error handling here, but do not stop execution here.
       break;
     }
@@ -1030,14 +1028,14 @@ void send_reject(int* socket_id, unsigned char error_code) {
   unsigned char response[2];
   response[0] = MSG_TYPE_REJECT;
   response[1] = error_code;
-  // LF_MUTEX_LOCK(&rti_mutex);
+  LF_MUTEX_LOCK(&rti_mutex);
   // NOTE: Ignore errors on this response.
   if (write_to_socket(*socket_id, 2, response)) {
     lf_print_warning("RTI failed to write MSG_TYPE_REJECT message on the socket.");
   }
   // Close the socket without reading until EOF.
   shutdown_socket(socket_id, false);
-  // LF_MUTEX_UNLOCK(&rti_mutex);
+  LF_MUTEX_UNLOCK(&rti_mutex);
 }
 
 /**

--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -1008,7 +1008,7 @@ void send_reject(int* socket_id, unsigned char error_code) {
   if (write_to_socket(*socket_id, 2, response)) {
     lf_print_warning("RTI failed to write MSG_TYPE_REJECT message on the socket.");
   }
-  // Close the socket.
+  // Close the socket without reading until EOF.
   shutdown_socket(socket_id, false);
   LF_MUTEX_UNLOCK(&rti_mutex);
 }
@@ -1394,7 +1394,7 @@ void lf_connect_to_federates(int socket_descriptor) {
     if (rti_remote->authentication_enabled) {
       if (!authenticate_federate(&socket_id)) {
         lf_print_warning("RTI failed to authenticate the incoming federate.");
-        // Close the socket.
+        // Close the socket without reading until EOF.
         shutdown_socket(&socket_id, false);
         // Ignore the federate that failed authentication.
         i--;
@@ -1462,7 +1462,7 @@ void* respond_to_erroneous_connections(void* nothing) {
     if (write_to_socket(socket_id, 2, response)) {
       lf_print_warning("RTI failed to write FEDERATION_ID_DOES_NOT_MATCH to erroneous incoming connection.");
     }
-    // Close the socket.
+    // Close the socket without reading until EOF.
     shutdown_socket(&socket_id, false);
   }
   return NULL;

--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -1563,6 +1563,7 @@ void initialize_RTI(rti_remote_t* rti) {
 
   // Initialize thread synchronization primitives
   LF_MUTEX_INIT(&rti_mutex);
+  LF_MUTEX_INIT(&shutdown_mutex);
   LF_COND_INIT(&received_start_times, &rti_mutex);
   LF_COND_INIT(&sent_start_time, &rti_mutex);
 

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -417,11 +417,11 @@ static trigger_handle_t schedule_message_received_from_network_locked(environmen
  *  federate.
  */
 static void close_inbound_socket(int fed_id) {
-  LF_MUTEX_LOCK(&lf_inbound_socket_mutex);
+  // LF_MUTEX_LOCK(&lf_inbound_socket_mutex);
   if (_fed.sockets_for_inbound_p2p_connections[fed_id] >= 0) {
     shutdown_socket(&_fed.sockets_for_inbound_p2p_connections[fed_id], false);
   }
-  LF_MUTEX_UNLOCK(&lf_inbound_socket_mutex);
+  // LF_MUTEX_UNLOCK(&lf_inbound_socket_mutex);
 }
 
 /**
@@ -831,13 +831,13 @@ static void close_outbound_socket(int fed_id) {
   // This will result in EOF being sent to the remote federate, except for
   // abnormal termination, in which case it will just close the socket.
   if (_lf_normal_termination) {
-    LF_MUTEX_LOCK(&lf_outbound_socket_mutex);
+    // LF_MUTEX_LOCK(&lf_outbound_socket_mutex);
     if (_fed.sockets_for_outbound_p2p_connections[fed_id] >= 0) {
       // Close the socket by sending a FIN packet indicating that no further writes
       // are expected.  Then read until we get an EOF indication.
       shutdown_socket(&_fed.sockets_for_outbound_p2p_connections[fed_id], true);
     }
-    LF_MUTEX_UNLOCK(&lf_outbound_socket_mutex);
+    // LF_MUTEX_UNLOCK(&lf_outbound_socket_mutex);
   } else {
     shutdown_socket(&_fed.sockets_for_outbound_p2p_connections[fed_id], false);
   }
@@ -2093,12 +2093,12 @@ void* lf_handle_p2p_connections_from_federates(void* env_arg) {
     int result = lf_thread_create(&_fed.inbound_socket_listeners[received_federates], listen_to_federates, fed_id_arg);
     if (result != 0) {
       // Failed to create a listening thread.
-      LF_MUTEX_LOCK(&lf_inbound_socket_mutex);
+      // LF_MUTEX_LOCK(&lf_inbound_socket_mutex);
       if (_fed.sockets_for_inbound_p2p_connections[remote_fed_id] != -1) {
         shutdown_socket(&socket_id, false);
         _fed.sockets_for_inbound_p2p_connections[remote_fed_id] = -1;
       }
-      LF_MUTEX_UNLOCK(&lf_inbound_socket_mutex);
+      // LF_MUTEX_UNLOCK(&lf_inbound_socket_mutex);
       lf_print_error_and_exit("Failed to create a thread to listen for incoming physical connection. Error code: %d.",
                               result);
     }

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -1943,8 +1943,9 @@ void lf_connect_to_rti(const char* hostname, int port) {
 
 void lf_create_server(int specified_port) {
   assert(specified_port <= UINT16_MAX && specified_port >= 0);
-  create_TCP_server(specified_port, &_fed.server_socket, (uint16_t*)&_fed.server_port);
-
+  if (create_TCP_server(specified_port, &_fed.server_socket, (uint16_t*)&_fed.server_port)) {
+    lf_print_error_system_failure("RTI failed to create TCP server: %s.", strerror(errno));
+  };
   LF_PRINT_LOG("Server for communicating with other federates started using port %d.", _fed.server_port);
 
   // Send the server port number to the RTI

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -1995,7 +1995,7 @@ void* lf_handle_p2p_connections_from_federates(void* env_arg) {
   _fed.inbound_socket_listeners = (lf_thread_t*)calloc(_fed.number_of_inbound_p2p_connections, sizeof(lf_thread_t));
   while (received_federates < _fed.number_of_inbound_p2p_connections && !_lf_termination_executed) {
     // Wait for an incoming connection request.
-    int socket_id = accept_federate_socket(_fed.server_socket, _fed.socket_TCP_RTI);
+    int socket_id = accept_socket(_fed.server_socket, _fed.socket_TCP_RTI);
     if (socket_id < 0) {
       lf_print_warning("Federate failed to accept the socket.");
       return NULL;

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -51,8 +51,6 @@ extern bool _lf_termination_executed;
 // Global variables references in federate.h
 lf_mutex_t lf_outbound_socket_mutex;
 
-lf_mutex_t lf_inbound_socket_mutex;
-
 lf_cond_t lf_port_status_changed;
 
 /**
@@ -417,11 +415,9 @@ static trigger_handle_t schedule_message_received_from_network_locked(environmen
  *  federate.
  */
 static void close_inbound_socket(int fed_id) {
-  // LF_MUTEX_LOCK(&lf_inbound_socket_mutex);
   if (_fed.sockets_for_inbound_p2p_connections[fed_id] >= 0) {
     shutdown_socket(&_fed.sockets_for_inbound_p2p_connections[fed_id], false);
   }
-  // LF_MUTEX_UNLOCK(&lf_inbound_socket_mutex);
 }
 
 /**
@@ -831,13 +827,11 @@ static void close_outbound_socket(int fed_id) {
   // This will result in EOF being sent to the remote federate, except for
   // abnormal termination, in which case it will just close the socket.
   if (_lf_normal_termination) {
-    // LF_MUTEX_LOCK(&lf_outbound_socket_mutex);
     if (_fed.sockets_for_outbound_p2p_connections[fed_id] >= 0) {
       // Close the socket by sending a FIN packet indicating that no further writes
       // are expected.  Then read until we get an EOF indication.
       shutdown_socket(&_fed.sockets_for_outbound_p2p_connections[fed_id], true);
     }
-    // LF_MUTEX_UNLOCK(&lf_outbound_socket_mutex);
   } else {
     shutdown_socket(&_fed.sockets_for_outbound_p2p_connections[fed_id], false);
   }
@@ -2093,12 +2087,10 @@ void* lf_handle_p2p_connections_from_federates(void* env_arg) {
     int result = lf_thread_create(&_fed.inbound_socket_listeners[received_federates], listen_to_federates, fed_id_arg);
     if (result != 0) {
       // Failed to create a listening thread.
-      // LF_MUTEX_LOCK(&lf_inbound_socket_mutex);
       if (_fed.sockets_for_inbound_p2p_connections[remote_fed_id] != -1) {
         shutdown_socket(&socket_id, false);
         _fed.sockets_for_inbound_p2p_connections[remote_fed_id] = -1;
       }
-      // LF_MUTEX_UNLOCK(&lf_inbound_socket_mutex);
       lf_print_error_and_exit("Failed to create a thread to listen for incoming physical connection. Error code: %d.",
                               result);
     }

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -1493,7 +1493,7 @@ static void* listen_to_rti_TCP(void* args) {
         lf_print_error("Socket connection to the RTI was closed by the RTI without"
                        " properly sending an EOF first. Considering this a soft error.");
         // FIXME: If this happens, possibly a new RTI must be elected.
-        shutdown_socket(_fed.socket_TCP_RTI, false);
+        shutdown_socket(&_fed.socket_TCP_RTI, false);
         return NULL;
       } else {
         lf_print_error("Socket connection to the RTI has been broken with error %d: %s."
@@ -1501,13 +1501,13 @@ static void* listen_to_rti_TCP(void* args) {
                        " Considering this a soft error.",
                        errno, strerror(errno));
         // FIXME: If this happens, possibly a new RTI must be elected.
-        shutdown_socket(_fed.socket_TCP_RTI, false);
+        shutdown_socket(&_fed.socket_TCP_RTI, false);
         return NULL;
       }
     } else if (read_failed > 0) {
       // EOF received.
       lf_print("Connection to the RTI closed with an EOF.");
-      shutdown_socket(_fed.socket_TCP_RTI, false);
+      shutdown_socket(&_fed.socket_TCP_RTI, false);
       return NULL;
     }
     switch (buffer[0]) {

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -1818,7 +1818,7 @@ void lf_connect_to_federate(uint16_t remote_federate_id) {
                        remote_federate_id, ADDRESS_QUERY_RETRY_INTERVAL);
       continue;
     } else {
-      lf_print("Connected to federate %d, port %d.", remote_federate_id, port);
+      lf_print("Connected to federate %d, port %hu.", remote_federate_id, uport);
       // Trace the event when tracing is enabled
       tracepoint_federate_to_federate(receive_ACK, _lf_my_fed_id, remote_federate_id, NULL);
       break;

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -1993,7 +1993,7 @@ void* lf_handle_p2p_connections_from_federates(void* env_arg) {
         // Ignore errors on this response.
         write_to_socket(socket_id, 2, response);
       }
-      close(socket_id);
+      shutdown_socket(socket_id, false);
       continue;
     }
 
@@ -2013,7 +2013,7 @@ void* lf_handle_p2p_connections_from_federates(void* env_arg) {
         // Ignore errors on this response.
         write_to_socket(socket_id, 2, response);
       }
-      close(socket_id);
+      shutdown_socket(socket_id, false);
       continue;
     }
 
@@ -2051,7 +2051,7 @@ void* lf_handle_p2p_connections_from_federates(void* env_arg) {
       // Failed to create a listening thread.
       LF_MUTEX_LOCK(&socket_mutex);
       if (_fed.sockets_for_inbound_p2p_connections[remote_fed_id] != -1) {
-        close(socket_id);
+        shutdown_socket(socket_id, false);
         _fed.sockets_for_inbound_p2p_connections[remote_fed_id] = -1;
       }
       LF_MUTEX_UNLOCK(&socket_mutex);

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -50,7 +50,9 @@ extern bool _lf_termination_executed;
 
 // Global variables references in federate.h
 lf_mutex_t lf_outbound_socket_mutex;
+
 lf_mutex_t lf_inbound_socket_mutex;
+
 lf_cond_t lf_port_status_changed;
 
 /**

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -50,6 +50,7 @@ extern bool _lf_termination_executed;
 
 // Global variables references in federate.h
 lf_mutex_t lf_outbound_socket_mutex;
+lf_mutex_t lf_inbound_socket_mutex;
 lf_cond_t lf_port_status_changed;
 
 /**
@@ -414,11 +415,11 @@ static trigger_handle_t schedule_message_received_from_network_locked(environmen
  *  federate.
  */
 static void close_inbound_socket(int fed_id) {
-  LF_MUTEX_LOCK(&socket_mutex);
+  LF_MUTEX_LOCK(&lf_inbound_socket_mutex);
   if (_fed.sockets_for_inbound_p2p_connections[fed_id] >= 0) {
     shutdown_socket(&_fed.sockets_for_inbound_p2p_connections[fed_id], false);
   }
-  LF_MUTEX_UNLOCK(&socket_mutex);
+  LF_MUTEX_UNLOCK(&lf_inbound_socket_mutex);
 }
 
 /**
@@ -2090,12 +2091,12 @@ void* lf_handle_p2p_connections_from_federates(void* env_arg) {
     int result = lf_thread_create(&_fed.inbound_socket_listeners[received_federates], listen_to_federates, fed_id_arg);
     if (result != 0) {
       // Failed to create a listening thread.
-      LF_MUTEX_LOCK(&socket_mutex);
+      LF_MUTEX_LOCK(&lf_inbound_socket_mutex);
       if (_fed.sockets_for_inbound_p2p_connections[remote_fed_id] != -1) {
         shutdown_socket(&socket_id, false);
         _fed.sockets_for_inbound_p2p_connections[remote_fed_id] = -1;
       }
-      LF_MUTEX_UNLOCK(&socket_mutex);
+      LF_MUTEX_UNLOCK(&lf_inbound_socket_mutex);
       lf_print_error_and_exit("Failed to create a thread to listen for incoming physical connection. Error code: %d.",
                               result);
     }

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -1493,7 +1493,7 @@ static void* listen_to_rti_TCP(void* args) {
         lf_print_error("Socket connection to the RTI was closed by the RTI without"
                        " properly sending an EOF first. Considering this a soft error.");
         // FIXME: If this happens, possibly a new RTI must be elected.
-        _fed.socket_TCP_RTI = -1;
+        shutdown_socket(_fed.socket_TCP_RTI, false);
         return NULL;
       } else {
         lf_print_error("Socket connection to the RTI has been broken with error %d: %s."
@@ -1501,13 +1501,13 @@ static void* listen_to_rti_TCP(void* args) {
                        " Considering this a soft error.",
                        errno, strerror(errno));
         // FIXME: If this happens, possibly a new RTI must be elected.
-        _fed.socket_TCP_RTI = -1;
+        shutdown_socket(_fed.socket_TCP_RTI, false);
         return NULL;
       }
     } else if (read_failed > 0) {
       // EOF received.
       lf_print("Connection to the RTI closed with an EOF.");
-      _fed.socket_TCP_RTI = -1;
+      shutdown_socket(_fed.socket_TCP_RTI, false);
       return NULL;
     }
     switch (buffer[0]) {

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -1943,7 +1943,7 @@ void lf_connect_to_rti(const char* hostname, int port) {
 
 void lf_create_server(int specified_port) {
   assert(specified_port <= UINT16_MAX && specified_port >= 0);
-  if (create_TCP_server(specified_port, &_fed.server_socket, (uint16_t*)&_fed.server_port)) {
+  if (create_TCP_server(specified_port, &_fed.server_socket, (uint16_t*)&_fed.server_port, false)) {
     lf_print_error_system_failure("RTI failed to create TCP server: %s.", strerror(errno));
   };
   LF_PRINT_LOG("Server for communicating with other federates started using port %d.", _fed.server_port);

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -1993,7 +1993,7 @@ void* lf_handle_p2p_connections_from_federates(void* env_arg) {
         // Ignore errors on this response.
         write_to_socket(socket_id, 2, response);
       }
-      shutdown_socket(socket_id, false);
+      shutdown_socket(&socket_id, false);
       continue;
     }
 
@@ -2013,7 +2013,7 @@ void* lf_handle_p2p_connections_from_federates(void* env_arg) {
         // Ignore errors on this response.
         write_to_socket(socket_id, 2, response);
       }
-      shutdown_socket(socket_id, false);
+      shutdown_socket(&socket_id, false);
       continue;
     }
 
@@ -2051,7 +2051,7 @@ void* lf_handle_p2p_connections_from_federates(void* env_arg) {
       // Failed to create a listening thread.
       LF_MUTEX_LOCK(&socket_mutex);
       if (_fed.sockets_for_inbound_p2p_connections[remote_fed_id] != -1) {
-        shutdown_socket(socket_id, false);
+        shutdown_socket(&socket_id, false);
         _fed.sockets_for_inbound_p2p_connections[remote_fed_id] = -1;
       }
       LF_MUTEX_UNLOCK(&socket_mutex);

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -1920,7 +1920,6 @@ void lf_create_server(int specified_port) {
   if (create_server(specified_port, &_fed.server_socket, (uint16_t*)&_fed.server_port, TCP, false)) {
     lf_print_error_system_failure("RTI failed to create TCP server: %s.", strerror(errno));
   };
-  _fed.server_port = (int)port;
   LF_PRINT_LOG("Server for communicating with other federates started using port %d.", _fed.server_port);
 
   // Send the server port number to the RTI

--- a/core/federated/network/socket_common.c
+++ b/core/federated/network/socket_common.c
@@ -396,6 +396,8 @@ void write_to_socket_fail_on_error(int* socket, size_t num_bytes, unsigned char*
   }
 }
 
+void init_shutdown_mutex(void) { LF_MUTEX_INIT(&shutdown_mutex); }
+
 int shutdown_socket(int* socket, bool read_before_closing) {
   LF_MUTEX_LOCK(&shutdown_mutex);
   if (*socket == -1) {

--- a/core/federated/network/socket_common.c
+++ b/core/federated/network/socket_common.c
@@ -22,7 +22,6 @@
 
 // Mutex lock held while performing socket close operations.
 // A deadlock can occur if two threads simulataneously attempt to close the same socket.
-lf_mutex_t socket_mutex;
 lf_mutex_t shutdown_mutex;
 
 int create_real_time_tcp_socket_errexit() {

--- a/core/federated/network/socket_common.c
+++ b/core/federated/network/socket_common.c
@@ -266,8 +266,8 @@ int connect_to_socket(int sock, const char* hostname, int port) {
           used_port = DEFAULT_PORT;
         }
       }
-      lf_print_warning("Could not connect. Will try again every " PRINTF_TIME " nanoseconds.\n",
-                       CONNECT_RETRY_INTERVAL);
+      lf_print_warning("Could not connect. Will try again every " PRINTF_TIME " nanoseconds. Connecting to port %d.\n",
+                       CONNECT_RETRY_INTERVAL, used_port);
       continue;
     } else {
       break;

--- a/core/federated/network/socket_common.c
+++ b/core/federated/network/socket_common.c
@@ -155,7 +155,7 @@ static int create_server(uint16_t port, int* final_socket, uint16_t* final_port,
     return -1;
   }
   set_socket_timeout_option(socket_descriptor, &timeout_time);
-  int used_port = set_socket_bind_option(socket_descriptor, port, increment_port_on_retry);
+  uint16_t used_port = set_socket_bind_option(socket_descriptor, port, increment_port_on_retry);
   if (sock_type == 0) {
     // Enable listening for socket connections.
     // The second argument is the maximum number of queued socket requests,
@@ -408,7 +408,7 @@ void write_to_socket_fail_on_error(int* socket, size_t num_bytes, unsigned char*
 int shutdown_socket(int* socket, bool read_before_closing) {
   if (!read_before_closing) {
     if (shutdown(*socket, SHUT_RDWR)) {
-      lf_print_warning("On shut down TCP socket, received reply: %s", strerror(errno));
+      lf_print_log("On shutdown socket, received reply: %s", strerror(errno));
       return -1;
     }
   } else {
@@ -416,7 +416,7 @@ int shutdown_socket(int* socket, bool read_before_closing) {
     // This indicates the write direction is closed. For more details, refer to:
     // https://stackoverflow.com/questions/4160347/close-vs-shutdown-socket
     if (shutdown(*socket, SHUT_WR)) {
-      lf_print_warning("Failed to shut down socket: %s", strerror(errno));
+      lf_print_log("Failed to shutdown socket: %s", strerror(errno));
       return -1;
     }
 
@@ -435,7 +435,7 @@ int shutdown_socket(int* socket, bool read_before_closing) {
   // the OS is preventing another program from accidentally receiving
   // duplicated packets intended for this program.
   if (close(*socket)) {
-    lf_print_warning("Error while closing socket: %s\n", strerror(errno));
+    lf_print_log("Error while closing socket: %s\n", strerror(errno));
     return -1;
   }
   *socket = -1;

--- a/core/federated/network/socket_common.c
+++ b/core/federated/network/socket_common.c
@@ -90,7 +90,7 @@ static int set_socket_bind_option(int socket_descriptor, uint16_t specified_port
   // Zero out the server address structure.
   bzero((char*)&server_fd, sizeof(server_fd));
   uint16_t used_port = specified_port;
-  if (specified_port == 0 && increment_port_on_retry == true) { // RTI is set to 1 if no specified port.
+  if (specified_port == 0 && increment_port_on_retry == true) {
     used_port = DEFAULT_PORT;
   }
   server_fd.sin_family = AF_INET;         // IPv4
@@ -104,7 +104,7 @@ static int set_socket_bind_option(int socket_descriptor, uint16_t specified_port
 
   int count = 1;
   while (result != 0 && count++ < PORT_BIND_RETRY_LIMIT) {
-    if (specified_port == 0 && increment_port_on_retry == true) { // RTI is set to 1 if no specified port.
+    if (specified_port == 0 && increment_port_on_retry == true) {
       lf_print_warning("RTI failed to get port %d.", used_port);
       used_port++;
       if (used_port >= DEFAULT_PORT + MAX_NUM_PORT_ADDRESSES)
@@ -120,17 +120,17 @@ static int set_socket_bind_option(int socket_descriptor, uint16_t specified_port
   }
 
   // Set the global server port.
-  if (specified_port == 0) { // Federates are set to 0 if no specified port.
+  if (specified_port == 0 && increment_port_on_retry == false) {
     // Need to retrieve the port number assigned by the OS.
     struct sockaddr_in assigned;
     socklen_t addr_len = sizeof(assigned);
     if (getsockname(socket_descriptor, (struct sockaddr*)&assigned, &addr_len) < 0) {
-      lf_print_error_and_exit("Failed to retrieve assigned port number.");
+      lf_print_error_and_exit("Federate fdailed to retrieve assigned port number.");
     }
     used_port = ntohs(assigned.sin_port);
   }
   if (result != 0) {
-    lf_print_error_and_exit("Failed to bind the RTI socket. Port %d is not available. ", used_port);
+    lf_print_error_and_exit("Failed to bind the socket. Port %d is not available. ", used_port);
   }
   return used_port;
 }

--- a/core/federated/network/socket_common.c
+++ b/core/federated/network/socket_common.c
@@ -58,7 +58,7 @@ int create_real_time_tcp_socket_errexit() {
  * @param timeout_time A pointer to a `struct timeval` that specifies the timeout duration
  *                     for socket operations (receive and send).
  */
-void set_socket_timeout_option(int socket_descriptor, struct timeval* timeout_time) {
+static void set_socket_timeout_option(int socket_descriptor, struct timeval* timeout_time) {
   // Set the option for this socket to reuse the same address
   int true_variable = 1; // setsockopt() requires a reference to the value assigned to an option
   if (setsockopt(socket_descriptor, SOL_SOCKET, SO_REUSEADDR, &true_variable, sizeof(int32_t)) < 0) {
@@ -84,7 +84,7 @@ void set_socket_timeout_option(int socket_descriptor, struct timeval* timeout_ti
  *                       until an available port is found.
  * @return The final port number used.
  */
-int set_socket_bind_option(int socket_descriptor, uint16_t specified_port) {
+static int set_socket_bind_option(int socket_descriptor, uint16_t specified_port) {
   // Server file descriptor.
   struct sockaddr_in server_fd;
   // Zero out the server address structure.
@@ -182,7 +182,7 @@ int create_UDP_server(uint16_t port, int* final_socket, uint16_t* final_port) {
  * Return true if either the socket to the RTI is broken or the socket is
  * alive and the first unread byte on the socket's queue is MSG_TYPE_FAILED.
  */
-bool check_socket_closed(int socket) {
+static bool check_socket_closed(int socket) {
   unsigned char first_byte;
   ssize_t bytes = peek_from_socket(socket, &first_byte);
   if (bytes < 0 || (bytes == 1 && first_byte == MSG_TYPE_FAILED)) {
@@ -192,7 +192,7 @@ bool check_socket_closed(int socket) {
   }
 }
 
-int accept_socket(int socket, int rti_socket) {
+static int accept_socket(int socket, int rti_socket) {
   struct sockaddr client_fd;
   // Wait for an incoming connection request.
   uint32_t client_length = sizeof(client_fd);

--- a/core/federated/network/socket_common.c
+++ b/core/federated/network/socket_common.c
@@ -121,13 +121,14 @@ static int set_socket_bind_option(int socket_descriptor, uint16_t specified_port
     struct sockaddr_in assigned;
     socklen_t addr_len = sizeof(assigned);
     if (getsockname(socket_descriptor, (struct sockaddr*)&assigned, &addr_len) < 0) {
-      lf_print_error_and_exit("Federate fdailed to retrieve assigned port number.");
+      lf_print_error_and_exit("Federate failed to retrieve assigned port number.");
     }
     used_port = ntohs(assigned.sin_port);
   }
   if (result != 0) {
     lf_print_error_and_exit("Failed to bind the socket. Port %d is not available. ", used_port);
   }
+  lf_print_debug("Socket is binded to port %d.", used_port);
   return used_port;
 }
 

--- a/core/federated/network/socket_common.c
+++ b/core/federated/network/socket_common.c
@@ -20,8 +20,7 @@
 /** Number of nanoseconds to sleep before retrying a socket read. */
 #define SOCKET_READ_RETRY_INTERVAL 1000000
 
-// Mutex lock held while performing socket close operations.
-// A deadlock can occur if two threads simulataneously attempt to close the same socket.
+// Mutex lock held while performing socket shutdown and close operations.
 lf_mutex_t shutdown_mutex;
 
 int create_real_time_tcp_socket_errexit() {

--- a/core/federated/network/socket_common.c
+++ b/core/federated/network/socket_common.c
@@ -428,6 +428,7 @@ int shutdown_socket(int* socket, bool read_before_closing) {
       ;
   }
   LF_MUTEX_UNLOCK(&shutdown_mutex);
+  return 0;
 
 close_socket: // Label to jump to the closing part of the function
   // NOTE: In all common TCP/IP stacks, there is a time period,

--- a/core/federated/network/socket_common.c
+++ b/core/federated/network/socket_common.c
@@ -74,14 +74,11 @@ static void set_socket_timeout_option(int socket_descriptor, struct timeval* tim
 }
 
 /**
- * Set the socket bind options. If the specified port is 0, it means this is a federate socket server. If the specified
- * port is 1, it is creating a RTI server. RTI servers use the port increment when the default port is not available.
- * Returns the actually used port.
+ * Assign a port to the socket, and bind the socket.
  *
  * @param socket_descriptor The file descriptor of the socket to be bound to an address and port.
- * @param specified_port The port number to bind the socket to. If set to 0, the OS assigns a port.
- *                       If set to 1, the function starts binding at the `DEFAULT_PORT` and increments
- *                       until an available port is found.
+ * @param specified_port The port number to bind the socket to.
+ * @param increment_port_on_retry Boolean to retry port increment.
  * @return The final port number used.
  */
 static int set_socket_bind_option(int socket_descriptor, uint16_t specified_port, bool increment_port_on_retry) {
@@ -99,12 +96,11 @@ static int set_socket_bind_option(int socket_descriptor, uint16_t specified_port
 
   int result = bind(socket_descriptor, (struct sockaddr*)&server_fd, sizeof(server_fd));
 
-  // Try repeatedly to bind to a port. If no specific port is specified, then
-  // increment the port number each time.
-
+  // Try repeatedly to bind to a port.
   int count = 1;
   while (result != 0 && count++ < PORT_BIND_RETRY_LIMIT) {
     if (specified_port == 0 && increment_port_on_retry == true) {
+      //  If the specified port number is zero, and the increment_port_on_retry is true, increment the port number each time.
       lf_print_warning("RTI failed to get port %d.", used_port);
       used_port++;
       if (used_port >= DEFAULT_PORT + MAX_NUM_PORT_ADDRESSES)

--- a/core/federated/network/socket_common.c
+++ b/core/federated/network/socket_common.c
@@ -173,6 +173,7 @@ static int create_server(uint16_t port, int* final_socket, uint16_t* final_port,
 int create_TCP_server(uint16_t port, int* final_socket, uint16_t* final_port, bool increment_port_on_retry) {
   return create_server(port, final_socket, final_port, 0, increment_port_on_retry);
 }
+
 int create_UDP_server(uint16_t port, int* final_socket, uint16_t* final_port, bool increment_port_on_retry) {
   return create_server(port, final_socket, final_port, 1, increment_port_on_retry);
 }
@@ -191,7 +192,7 @@ static bool check_socket_closed(int socket) {
   }
 }
 
-static int accept_socket(int socket, int rti_socket) {
+int accept_socket(int socket, int rti_socket) {
   struct sockaddr client_fd;
   // Wait for an incoming connection request.
   uint32_t client_length = sizeof(client_fd);
@@ -222,9 +223,6 @@ static int accept_socket(int socket, int rti_socket) {
   }
   return socket_id;
 }
-
-int accept_rti_socket(int socket) { return accept_socket(socket, -1); }
-int accept_federate_socket(int socket, int rti_socket) { return accept_socket(socket, rti_socket); }
 
 int connect_to_socket(int sock, const char* hostname, int port) {
   struct addrinfo hints;

--- a/core/federated/network/socket_common.c
+++ b/core/federated/network/socket_common.c
@@ -203,7 +203,7 @@ int accept_socket(int socket, int rti_socket) {
       lf_print_error_system_failure("Firewall permissions prohibit connection.");
     } else {
       // For the federates, it should check if the rti_socket is still open, before retrying accept().
-      if (rti_socket == -1) {
+      if (rti_socket != -1) {
         if (check_socket_closed(rti_socket)) {
           break;
         }

--- a/core/federated/network/socket_common.c
+++ b/core/federated/network/socket_common.c
@@ -100,7 +100,8 @@ static int set_socket_bind_option(int socket_descriptor, uint16_t specified_port
   int count = 1;
   while (result != 0 && count++ < PORT_BIND_RETRY_LIMIT) {
     if (specified_port == 0 && increment_port_on_retry == true) {
-      //  If the specified port number is zero, and the increment_port_on_retry is true, increment the port number each time.
+      //  If the specified port number is zero, and the increment_port_on_retry is true, increment the port number each
+      //  time.
       lf_print_warning("RTI failed to get port %d.", used_port);
       used_port++;
       if (used_port >= DEFAULT_PORT + MAX_NUM_PORT_ADDRESSES)

--- a/include/core/federated/federate.h
+++ b/include/core/federated/federate.h
@@ -221,9 +221,14 @@ typedef enum parse_rti_code_t { SUCCESS, INVALID_PORT, INVALID_HOST, INVALID_USE
 // Global variables
 
 /**
- * Mutex lock held while performing socket write and close operations.
+ * Mutex lock held while performing outbound socket write and close operations.
  */
 extern lf_mutex_t lf_outbound_socket_mutex;
+
+/**
+ * Mutex lock held while performing inbound socket write and close operations.
+ */
+extern lf_mutex_t lf_inbound_socket_mutex;
 
 /**
  * Condition variable for blocking on unkonwn federate input ports.

--- a/include/core/federated/federate.h
+++ b/include/core/federated/federate.h
@@ -226,11 +226,6 @@ typedef enum parse_rti_code_t { SUCCESS, INVALID_PORT, INVALID_HOST, INVALID_USE
 extern lf_mutex_t lf_outbound_socket_mutex;
 
 /**
- * Mutex lock held while performing inbound socket write and close operations.
- */
-extern lf_mutex_t lf_inbound_socket_mutex;
-
-/**
  * Condition variable for blocking on unkonwn federate input ports.
  */
 extern lf_cond_t lf_port_status_changed;

--- a/include/core/federated/network/socket_common.h
+++ b/include/core/federated/network/socket_common.h
@@ -240,4 +240,13 @@ int write_to_socket_close_on_error(int* socket, size_t num_bytes, unsigned char*
 void write_to_socket_fail_on_error(int* socket, size_t num_bytes, unsigned char* buffer, lf_mutex_t* mutex,
                                    char* format, ...);
 
+/**
+ * @brief Gracefully shuts down and closes a socket, optionally reading until EOF.
+ * 
+ * @param socket Pointer to the socket descriptor to shutdown and close.
+ * @param read_before_closing If true, read until EOF before closing the socket.
+ * @return int Returns 0 on success, -1 on failure (errno will indicate the error).
+ */
+int shutdown_socket(int* socket, bool read_before_closing);
+
 #endif /* SOCKET_COMMON_H */

--- a/include/core/federated/network/socket_common.h
+++ b/include/core/federated/network/socket_common.h
@@ -78,20 +78,23 @@ extern lf_mutex_t socket_mutex;
 int create_real_time_tcp_socket_errexit();
 
 /**
- * Create a TCP or UDP server and enable listening for socket connections.
- * If the specified port if it is non-zero, it will attempt to acquire that port.
- * If it fails, it will repeatedly attempt up to PORT_BIND_RETRY_LIMIT times with
- * a delay of PORT_BIND_RETRY_INTERVAL in between. If the specified port is
- * zero, then it will attempt to acquire DEFAULT_PORT first. If this fails, then it
- * will repeatedly attempt up to PORT_BIND_RETRY_LIMIT times, incrementing the port
- * number between attempts, with no delay between attempts.  Once it has incremented
- * the port number MAX_NUM_PORT_ADDRESSES times, it will cycle around and begin again
+ * @brief Create a TCP or UDP server that listens for socket connections.
+ *
+ * If the specified port number is greater than one, this function will attempt to acquire that port.
+ * If the port number is zero, it delegates to the operating system to provide an available port number.
+ * If the port number is one, it will attempt to acquire DEFAULT_PORT.
+ *
+ * If acquiring the port fails, then this function will repeatedly attempt up to PORT_BIND_RETRY_LIMIT times
+ * with a delay of PORT_BIND_RETRY_INTERVAL in between each try.
+ * If the specified port number is one, then it will increment the port number from DEFAULT_PORT on each attempt
+ * until it has incremented MAX_NUM_PORT_ADDRESSES times, at which point it will cycle around and begin again
  * with DEFAULT_PORT.
  *
- * @param port The port number to use or 0 to start trying at DEFAULT_PORT.
+ * @param port The port number to use or 0 to let the OS pick or 1 to start trying at DEFAULT_PORT.
  * @param socket_type The type of the socket for the server (TCP or UDP).
- * @param final_socket The socket descriptor on which to accept connections.
- * @param final_port The final port of the TCP or UDP socket.
+ * @param final_socket Pointer to the returned socket descriptor on which accepting connections will occur.
+ * @param final_port Pointer to the final port the server will use.
+ * @return 0 for success, -1 for failure.
  */
 int create_TCP_server(uint16_t port, int* final_socket, uint16_t* final_port);
 int create_UDP_server(uint16_t port, int* final_socket, uint16_t* final_port);

--- a/include/core/federated/network/socket_common.h
+++ b/include/core/federated/network/socket_common.h
@@ -242,7 +242,9 @@ void write_to_socket_fail_on_error(int* socket, size_t num_bytes, unsigned char*
 
 /**
  * @brief Gracefully shuts down and closes a socket, optionally reading until EOF.
- * 
+ * Shutdown and close the socket. If read_before_closing is false, it just immediately calls shutdown() with SHUT_RDWR
+ * and close(). If read_before_closing is true, it calls shutdown with SHUT_WR, only disallowing further writing. Then,
+ * it calls read() until EOF is received, and discards all received bytes.
  * @param socket Pointer to the socket descriptor to shutdown and close.
  * @param read_before_closing If true, read until EOF before closing the socket.
  * @return int Returns 0 on success, -1 on failure (errno will indicate the error).

--- a/include/core/federated/network/socket_common.h
+++ b/include/core/federated/network/socket_common.h
@@ -69,11 +69,6 @@
 typedef enum socket_type_t { TCP, UDP } socket_type_t;
 
 /**
- * Mutex protecting socket close operations.
- */
-extern lf_mutex_t socket_mutex;
-
-/**
  * Mutex protecting socket shutdown operations.
  */
 extern lf_mutex_t shutdown_mutex;

--- a/include/core/federated/network/socket_common.h
+++ b/include/core/federated/network/socket_common.h
@@ -93,8 +93,8 @@ int create_real_time_tcp_socket_errexit();
  * @param final_socket The socket descriptor on which to accept connections.
  * @param final_port The final port of the TCP or UDP socket.
  */
-void create_TCP_server(uint16_t port, int* final_socket, uint16_t* final_port);
-void create_UDP_server(uint16_t port, int* final_socket, uint16_t* final_port);
+int create_TCP_server(uint16_t port, int* final_socket, uint16_t* final_port);
+int create_UDP_server(uint16_t port, int* final_socket, uint16_t* final_port);
 
 /**
  * These two functions waits for an incoming connection request on the specified server socket.

--- a/include/core/federated/network/socket_common.h
+++ b/include/core/federated/network/socket_common.h
@@ -78,7 +78,7 @@ extern lf_mutex_t socket_mutex;
 int create_real_time_tcp_socket_errexit();
 
 /**
- * @brief Create a TCP or UDP server that listens for socket connections.
+ * @brief Create a TCP server that listens for socket connections.
  *
  * If the specified port number is greater than one, this function will attempt to acquire that port.
  * If the port number is zero, it delegates to the operating system to provide an available port number.
@@ -91,12 +91,21 @@ int create_real_time_tcp_socket_errexit();
  * with DEFAULT_PORT.
  *
  * @param port The port number to use or 0 to let the OS pick or 1 to start trying at DEFAULT_PORT.
- * @param socket_type The type of the socket for the server (TCP or UDP).
  * @param final_socket Pointer to the returned socket descriptor on which accepting connections will occur.
  * @param final_port Pointer to the final port the server will use.
  * @return 0 for success, -1 for failure.
  */
 int create_TCP_server(uint16_t port, int* final_socket, uint16_t* final_port);
+/**
+ * @brief Create a UDP server that listens for socket connections.
+ *
+ * This function is just like create_TCP_server(), except that it creates a UDP server.
+ *
+ * @param port The port number to use or 0 to let the OS pick or 1 to start trying at DEFAULT_PORT.
+ * @param final_socket Pointer to the returned socket descriptor on which accepting connections will occur.
+ * @param final_port Pointer to the final port the server will use.
+ * @return 0 for success, -1 for failure.
+ */
 int create_UDP_server(uint16_t port, int* final_socket, uint16_t* final_port);
 
 /**

--- a/include/core/federated/network/socket_common.h
+++ b/include/core/federated/network/socket_common.h
@@ -74,6 +74,11 @@ typedef enum socket_type_t { TCP, UDP } socket_type_t;
 extern lf_mutex_t socket_mutex;
 
 /**
+ * Mutex protecting socket shutdown operations.
+ */
+extern lf_mutex_t shutdown_mutex;
+
+/**
  * @brief Create an IPv4 TCP socket with Nagle's algorithm disabled
  * (TCP_NODELAY) and Delayed ACKs disabled (TCP_QUICKACK). Exits application
  * on any error.

--- a/include/core/federated/network/socket_common.h
+++ b/include/core/federated/network/socket_common.h
@@ -69,11 +69,6 @@
 typedef enum socket_type_t { TCP, UDP } socket_type_t;
 
 /**
- * Mutex protecting socket shutdown operations.
- */
-extern lf_mutex_t shutdown_mutex;
-
-/**
  * @brief Create an IPv4 TCP socket with Nagle's algorithm disabled
  * (TCP_NODELAY) and Delayed ACKs disabled (TCP_QUICKACK). Exits application
  * on any error.
@@ -239,6 +234,11 @@ int write_to_socket_close_on_error(int* socket, size_t num_bytes, unsigned char*
  */
 void write_to_socket_fail_on_error(int* socket, size_t num_bytes, unsigned char* buffer, lf_mutex_t* mutex,
                                    char* format, ...);
+
+/**
+ * Initialize shutdown mutex.
+ */
+void init_shutdown_mutex(void);
 
 /**
  * Shutdown and close the socket. If read_before_closing is false, it just immediately calls shutdown() with SHUT_RDWR

--- a/include/core/federated/network/socket_common.h
+++ b/include/core/federated/network/socket_common.h
@@ -113,16 +113,16 @@ int create_UDP_server(uint16_t port, int* final_socket, uint16_t* final_port, bo
  * These two functions waits for an incoming connection request on the specified server socket.
  * It blocks until a connection is successfully accepted. If an error occurs that is not
  * temporary (e.g., `EAGAIN` or `EWOULDBLOCK`), it reports the error and exits. Temporary
- * errors cause the function to retry accepting the connection. The accept_federate_socket() function additionally
- * checks the RTI's server socket if it is still alive.
+ * errors cause the function to retry accepting the connection.
+ * If the rti_socket is not -1, it checks if the RTI's server socket is still open.
  *
  * @param socket The server socket file descriptor that is listening for incoming connections.
  * @param rti_socket The rti socket for the federate to check if it is still open.
- * @return int The file descriptor for the newly accepted socket on success, or -1 on failure
+ * @return The file descriptor for the newly accepted socket on success, or -1 on failure
  *             (with an appropriate error message printed).
  */
-int accept_rti_socket(int socket);
-int accept_federate_socket(int socket, int rti_socket);
+
+int accept_socket(int socket, int rti_socket);
 
 /**
  *

--- a/include/core/federated/network/socket_common.h
+++ b/include/core/federated/network/socket_common.h
@@ -80,22 +80,23 @@ int create_real_time_tcp_socket_errexit();
 /**
  * @brief Create a TCP server that listens for socket connections.
  *
- * If the specified port number is greater than one, this function will attempt to acquire that port.
- * If the port number is zero, it delegates to the operating system to provide an available port number.
- * If the port number is one, it will attempt to acquire DEFAULT_PORT.
- *
- * If acquiring the port fails, then this function will repeatedly attempt up to PORT_BIND_RETRY_LIMIT times
- * with a delay of PORT_BIND_RETRY_INTERVAL in between each try.
- * If the specified port number is one, then it will increment the port number from DEFAULT_PORT on each attempt
- * until it has incremented MAX_NUM_PORT_ADDRESSES times, at which point it will cycle around and begin again
+ * If the specified port number is greater than zero, this function will attempt to acquire that port.
+ * If the specified port number is zero, and the increment_port_on_retry is true, it will attempt to acquire
+ * DEFAULT_PORT. If it fails to acquire DEFAULT_PORT, then it will increment the port number from DEFAULT_PORT on each
+ * attempt until it has incremented MAX_NUM_PORT_ADDRESSES times, at which point it will cycle around and begin again
  * with DEFAULT_PORT.
+ * If the port number is zero, and the increment_port_on_retry is false, it delegates to the operating system to provide
+ * an available port number.
+ * If acquiring the port fails, then this function will repeatedly attempt up to PORT_BIND_RETRY_LIMIT times with a
+ * delay of PORT_BIND_RETRY_INTERVAL in between each try.
  *
  * @param port The port number to use or 0 to let the OS pick or 1 to start trying at DEFAULT_PORT.
  * @param final_socket Pointer to the returned socket descriptor on which accepting connections will occur.
  * @param final_port Pointer to the final port the server will use.
+ * @param increment_port_on_retry Boolean to retry port increment.
  * @return 0 for success, -1 for failure.
  */
-int create_TCP_server(uint16_t port, int* final_socket, uint16_t* final_port);
+int create_TCP_server(uint16_t port, int* final_socket, uint16_t* final_port, bool increment_port_on_retry);
 /**
  * @brief Create a UDP server that listens for socket connections.
  *
@@ -106,7 +107,7 @@ int create_TCP_server(uint16_t port, int* final_socket, uint16_t* final_port);
  * @param final_port Pointer to the final port the server will use.
  * @return 0 for success, -1 for failure.
  */
-int create_UDP_server(uint16_t port, int* final_socket, uint16_t* final_port);
+int create_UDP_server(uint16_t port, int* final_socket, uint16_t* final_port, bool increment_port_on_retry);
 
 /**
  * These two functions waits for an incoming connection request on the specified server socket.

--- a/lingua-franca-ref.txt
+++ b/lingua-franca-ref.txt
@@ -1,1 +1,1 @@
-master
+shutdown


### PR DESCRIPTION
This PR follow ups #505.
Please merge with lf-lang/lingua-franca#2474.

## New Integrated Function: `shutdown_socket()`
`int shutdown_socket(int* socket, bool read_before_closing);`

**Arguments**
- `socket`: A pointer to the socket descriptor that needs to be shut down and closed.
- `read_before_closing`: A boolean indicating whether the socket should read any remaining incoming data before closing:
  - true: Initiates a graceful shutdown by sending a `FIN` packet (`SHUT_WR`) and waits for `EOF` (0-length message) from the peer.
  - false: Immediately shuts down both reading and writing directions (`SHUT_RDWR`).

**Return Values**
- `0`: Indicates successful shutdown and closure of the socket.
- `-1`: Indicates a failure during shutdown or closure, with errno set to describe the specific error.

**Function Description**
This function gracefully shuts down and closes a socket.
- When read_before_closing is false:
  - The function calls `shutdown(SHUT_RDWR)` to immediately stop both sending and receiving data. Then calls `close()`.
- When read_before_closing is true:
  - The function calls `shutdown(SHUT_WR)` to signal the end of writing but allows reading to continue.
  - It waits for the peer to send an `EOF` (indicated by `read()` returning 0), and discards all received bytes.

This function holds a new mutex named `shutdown_mutex`, which ensures preventing deadlocks.

## Refactoring on `close_inbound_socket()` and `close_outbound_socket()` from `federate.c`
### `close_inbound_socket()`
The original code looked not updated. There were no use case when the argument `flag` was not 1. I removed the `flag` argument, and all unused code.
### `close_outbound_socket()`
The original flags were only set by this one line code.
`int flag = _lf_normal_termination ? 1 : -1;`
So it depends on `_lf_normal_termination`. However, this function can directly use `_lf_normal_termination`, so I removed the `flag`, and directly used `_lf_normal_termination`.

## Minor implementation details for macOS.
When the federate sends the `MSG_TYPE_RESIGN` signal, the RTI calls `shutdown(SHUT_WR)`. Then, in the federate side, the thread from `listen_to_rti_TCP()`'s `read_from_socket()`'s `read()` returns with a EOF. Then, it calls `shutdown_socket()`.

However, the `shutdown()` fails, with an `errno` `Socket is not connected` on only MacOS. even though the connection is half open. However, since the connection is half p[em, the federate should still send a `FIN_ACK` packet to the RTI, because the RTI is blocked on the `read()`.

Thus, the federate does not return on failure of `shutdown()`, and calls the `close()`, to ensure the `FIN_ACK` packet is sent.

To summarize, even when `shutdown()` fails, the code will try `close()`, to ensure the socket is closed.

## Minor addition of logic in `federate.c`'s `handle_tagged_message()`
In `federate.c`'s `handle_tagged_message()`, when the received message already missed the tag, it closes the inbound socket, however does not return -1 for failure of reading the message. This is logic is added.

## Some mutex locks removed.
`socket_mutex` was only used as federate's inbound socket mutex. Especially, it was only used when closing inbound sockets. The new `shutdown_socket()` function holds its own mutex, so removed the duplication of mutex locks.
