### PR TITLE
Perform busy waiting when the wait duration is less than `MIN_SLEEP_DURATION`

### DIFF
--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -199,6 +199,11 @@ bool wait_until(instant_t wait_until_time, lf_cond_t* condition) {
     LF_PRINT_DEBUG("-------- Waiting until physical time " PRINTF_TIME, wait_until_time - start_time);
     // Check whether we actually need to wait, or if we have already passed the timepoint.
     interval_t wait_duration = wait_until_time - lf_time_physical();
+    if (wait_duration < MIN_SLEEP_DURATION) {
+      LF_PRINT_DEBUG("Wait time " PRINTF_TIME " is less than MIN_SLEEP_DURATION " PRINTF_TIME ". Skipping wait.",
+                     wait_duration, MIN_SLEEP_DURATION);
+      return true;
+    }
 
     // We do the sleep on the cond var so we can be awakened by the
     // asynchronous scheduling of a physical action. lf_clock_cond_timedwait

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -199,14 +199,6 @@ bool wait_until(instant_t wait_until_time, lf_cond_t* condition) {
     LF_PRINT_DEBUG("-------- Waiting until physical time " PRINTF_TIME, wait_until_time - start_time);
     // Check whether we actually need to wait, or if we have already passed the timepoint.
     interval_t wait_duration = wait_until_time - lf_time_physical();
-    if (wait_duration < MIN_SLEEP_DURATION) {
-      LF_PRINT_DEBUG("Wait time " PRINTF_TIME " is less than lf_min_sleep_duration " PRINTF_TIME
-                     ". Performing busy wait.",
-                     wait_duration, MIN_SLEEP_DURATION);
-      while (lf_time_physical() < wait_until_time) {
-        // Busy wait
-      }
-    }
 
     // We do the sleep on the cond var so we can be awakened by the
     // asynchronous scheduling of a physical action. lf_clock_cond_timedwait

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -199,9 +199,8 @@ bool wait_until(instant_t wait_until_time, lf_cond_t* condition) {
     LF_PRINT_DEBUG("-------- Waiting until physical time " PRINTF_TIME, wait_until_time - start_time);
     // Check whether we actually need to wait, or if we have already passed the timepoint.
     interval_t wait_duration = wait_until_time - lf_time_physical();
-    if (wait_duration < MIN_SLEEP_DURATION) {
-      LF_PRINT_DEBUG("Wait time " PRINTF_TIME " is less than MIN_SLEEP_DURATION " PRINTF_TIME ". Skipping wait.",
-                     wait_duration, MIN_SLEEP_DURATION);
+    if (wait_duration < 0) {
+      LF_PRINT_DEBUG("We have already passed " PRINTF_TIME ". Skipping wait.", wait_until_time);
       return true;
     }
 

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -200,9 +200,12 @@ bool wait_until(instant_t wait_until_time, lf_cond_t* condition) {
     // Check whether we actually need to wait, or if we have already passed the timepoint.
     interval_t wait_duration = wait_until_time - lf_time_physical();
     if (wait_duration < MIN_SLEEP_DURATION) {
-      LF_PRINT_DEBUG("Wait time " PRINTF_TIME " is less than MIN_SLEEP_DURATION " PRINTF_TIME ". Skipping wait.",
+      LF_PRINT_DEBUG("Wait time " PRINTF_TIME " is less than lf_min_sleep_duration " PRINTF_TIME
+                     ". Performing busy wait.",
                      wait_duration, MIN_SLEEP_DURATION);
-      return true;
+      while (lf_time_physical() < wait_until_time) {
+        // Busy wait
+      }
     }
 
     // We do the sleep on the cond var so we can be awakened by the

--- a/include/core/threaded/reactor_threaded.h
+++ b/include/core/threaded/reactor_threaded.h
@@ -93,7 +93,9 @@ void lf_synchronize_with_other_federates(void);
  * if that event time matches or exceeds the specified time.
  *
  * The mutex lock associated with the condition argument is assumed to be held by
- * the calling thread.
+ * the calling thread. This mutex is released while waiting. If the current physical
+ * time has already passed the specified time, then this function
+ * immediately returns true and the mutex is not released.
  *
  * @param env Environment within which we are executing.
  * @param wait_until_time The time to wait until physical time matches it.

--- a/include/core/threaded/reactor_threaded.h
+++ b/include/core/threaded/reactor_threaded.h
@@ -93,9 +93,7 @@ void lf_synchronize_with_other_federates(void);
  * if that event time matches or exceeds the specified time.
  *
  * The mutex lock associated with the condition argument is assumed to be held by
- * the calling thread. This mutex is released while waiting. If the wait time is
- * too small (less than MIN_SLEEP_DURATION) to wait using lf_clock_cond_timedwait,
- * then this function performs busy wait and the mutex is not released.
+ * the calling thread.
  *
  * @param env Environment within which we are executing.
  * @param wait_until_time The time to wait until physical time matches it.

--- a/include/core/threaded/reactor_threaded.h
+++ b/include/core/threaded/reactor_threaded.h
@@ -94,8 +94,8 @@ void lf_synchronize_with_other_federates(void);
  *
  * The mutex lock associated with the condition argument is assumed to be held by
  * the calling thread. This mutex is released while waiting. If the wait time is
- * too small to actually wait (less than MIN_SLEEP_DURATION), then this function
- * immediately returns true and the mutex is not released.
+ * too small (less than MIN_SLEEP_DURATION) to wait using lf_clock_cond_timedwait,
+ * then this function performs busy wait and the mutex is not released.
  *
  * @param env Environment within which we are executing.
  * @param wait_until_time The time to wait until physical time matches it.


### PR DESCRIPTION
This fixes https://github.com/lf-lang/reactor-c/issues/513. 

Add busy waiting when the wait duration is less than `MIN_SLEEP_DURATION` to prevent the reactor from advancing to a logical time greater than the current physical time.