### PR TITLE
Fix memory bug when obtaining a port number

### DIFF
--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -1978,10 +1978,13 @@ void lf_connect_to_rti(const char* hostname, int port) {
 
 void lf_create_server(int specified_port) {
   assert(specified_port <= UINT16_MAX && specified_port >= 0);
-  if (create_server(specified_port, &_fed.server_socket, (uint16_t*)&_fed.server_port, TCP, false)) {
+  uint16_t final_port;
+  if (create_server(specified_port, &_fed.server_socket, &final_port, TCP, false)) {
     lf_print_error_system_failure("RTI failed to create TCP server: %s.", strerror(errno));
   };
-  LF_PRINT_LOG("Server for communicating with other federates started using port %d.", _fed.server_port);
+
+  LF_PRINT_LOG("Server for communicating with other federates started using port %u.", final_port);
+  _fed.server_port = final_port;
 
   // Send the server port number to the RTI
   // on an MSG_TYPE_ADDRESS_ADVERTISEMENT message (@see net_common.h).


### PR DESCRIPTION
The problem here was that the port number is an int32, it was initialized to -1. Then its address was casted to an `uint16_t *` and then written to from the `create_server` function.  However, when a port number was obtained and written, it would only overwrite two of the four bytes. So you were left with the sign bit (set when initialized to -1)