### PR TITLE
Handle STP violation over deadline when both occur

### DIFF
--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -292,7 +292,8 @@ static void update_last_known_status_on_input_port(environment_t* env, tag_t tag
     lf_print_warning("Attempt to update the last known status tag " PRINTF_TAG
                      " of network input port %d to an earlier tag " PRINTF_TAG " was ignored.",
                      input_port_action->last_known_status_tag.time - lf_time_start(),
-                     input_port_action->last_known_status_tag.microstep, port_id, tag.time - lf_time_start(), tag.microstep);
+                     input_port_action->last_known_status_tag.microstep, port_id, tag.time - lf_time_start(),
+                     tag.microstep);
   }
 }
 

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -289,9 +289,10 @@ static void update_last_known_status_on_input_port(environment_t* env, tag_t tag
     lf_cond_broadcast(&env->event_q_changed);
   } else {
     // Message arrivals should be monotonic, so this should not occur.
-    lf_print_warning("Attempt to update the last known status tag "
-                     "of network input port %d to an earlier tag was ignored.",
-                     port_id);
+    lf_print_warning("Attempt to update the last known status tag " PRINTF_TAG
+                     " of network input port %d to an earlier tag " PRINTF_TAG " was ignored.",
+                     input_port_action->last_known_status_tag.time - lf_time_start(),
+                     input_port_action->last_known_status_tag.microstep, port_id, tag.time - lf_time_start(), tag.microstep);
   }
 }
 

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -732,7 +732,7 @@ bool _lf_worker_handle_deadline_violation_for_reaction(environment_t* env, int w
  *
  * @return true if an STP violation occurred and was handled. false otherwise.
  */
-bool _lf_worker_handle_STP_violation_for_reaction(environment_t* env, int worker_number, reaction_t* reaction) {
+static bool _lf_worker_handle_STP_violation_for_reaction(environment_t* env, int worker_number, reaction_t* reaction) {
   bool violation_occurred = false;
   // If the reaction violates the STP offset,
   // an input trigger to this reaction has been triggered at a later
@@ -800,8 +800,8 @@ bool _lf_worker_handle_STP_violation_for_reaction(environment_t* env, int worker
 bool _lf_worker_handle_violations(environment_t* env, int worker_number, reaction_t* reaction) {
   bool violation = false;
 
-  violation = _lf_worker_handle_deadline_violation_for_reaction(env, worker_number, reaction) ||
-              _lf_worker_handle_STP_violation_for_reaction(env, worker_number, reaction);
+  violation = _lf_worker_handle_STP_violation_for_reaction(env, worker_number, reaction) ||
+              _lf_worker_handle_deadline_violation_for_reaction(env, worker_number, reaction);
   return violation;
 }
 


### PR DESCRIPTION
This PR makes the following changes to decentralized coordination:
1. When a network input has both an STP violation and a deadline violation, we used to invoke the deadline violation handler only. This PR changes it to invoke the STP violation handler only. The reason for this is that the current tag is incorrect, which is not normally the case in a deadline violation handler. The previous strategy would mask the STP violation, making it impossible to distinguish between lateness caused by local overhead and lateness caused by network issues.
2. Removes spurious warnings "Attempt to update the last known status tag" generated when the background thread updates the last known status tag without taking into account after delays on incoming links.

This has a companion PR: https://github.com/lf-lang/lingua-franca/pull/2487