### PR TITLE
Introduce a federate protocol version message

### DIFF
--- a/core/federated/RTI/CMakeLists.txt
+++ b/core/federated/RTI/CMakeLists.txt
@@ -34,7 +34,7 @@ target_include_directories(${RTI_LIB} PUBLIC ${IncludeDir}/modal_models)
 target_include_directories(${RTI_LIB} PUBLIC ${IncludeDir}/utils)
 
 if (NOT DEFINED LOG_LEVEL)
-    set(LOG_LEVEL 2)
+    set(LOG_LEVEL 9)
 ENDIF(NOT DEFINED LOG_LEVEL)
 
 IF(CMAKE_BUILD_TYPE MATCHES DEBUG)

--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -1039,15 +1039,15 @@ void send_reject(int* socket_id, unsigned char error_code) {
 }
 
 /**
- * Listen for a MSG_TYPE_FED_IDS message, which includes as a payload
- * a federate ID and a federation ID. If the federation ID
+ * Listen for a MSG_TYPE_INITIAL_HANDSHAKE message, which includes as a payload
+ * the protocol version, a federate ID and a federation ID. If the federation ID
  * matches this federation, send an MSG_TYPE_ACK and otherwise send
  * a MSG_TYPE_REJECT message.
  * @param socket_id Pointer to the socket on which to listen.
  * @param client_fd The socket address.
  * @return The federate ID for success or -1 for failure.
  */
-static int32_t receive_and_check_fed_id_message(int* socket_id) {
+static int32_t receive_and_check_initial_handshake_message(int* socket_id) {
   // Buffer for message ID, federate ID, and federation ID length.
   size_t length = 1 + sizeof(uint16_t) + 1; // Message ID, federate ID, length of fedration ID.
   unsigned char buffer[length];
@@ -1057,15 +1057,20 @@ static int32_t receive_and_check_fed_id_message(int* socket_id) {
     lf_print_error("RTI failed to read from accepted socket.");
     return -1;
   }
-
+  uint8_t protocol_version = 255;                                // Initialize to an invalid value
   uint16_t fed_id = rti_remote->base.number_of_scheduling_nodes; // Initialize to an invalid value.
 
   // First byte received is the message type.
-  if (buffer[0] != MSG_TYPE_FED_IDS) {
+  if (buffer[0] != MSG_TYPE_INITIAL_HANDSHAKE) {
     if (rti_remote->base.tracing_enabled) {
       tracepoint_rti_to_federate(send_REJECT, fed_id, NULL);
     }
-    if (buffer[0] == MSG_TYPE_P2P_SENDING_FED_ID || buffer[0] == MSG_TYPE_P2P_TAGGED_MESSAGE) {
+    if (buffer[0] == MSG_TYPE_FED_IDS_DEPRECATED) {
+      lf_print_error(
+          "RTI received an initial message that indicates that the federate is compiled with an outdated\n"
+          "version of the reactor-c runtime. Make sure that the version of LFC and the RTI are compatible. ");
+      send_reject(socket_id, UNEXPECTED_MESSAGE);
+    } else if (buffer[0] == MSG_TYPE_P2P_SENDING_FED_ID || buffer[0] == MSG_TYPE_P2P_TAGGED_MESSAGE) {
       // The federate is trying to connect to a peer, not to the RTI.
       // It has connected to the RTI instead.
       // FIXME: This should not happen, but apparently has been observed.
@@ -1080,16 +1085,38 @@ static int32_t receive_and_check_fed_id_message(int* socket_id) {
     } else {
       send_reject(socket_id, UNEXPECTED_MESSAGE);
     }
-    lf_print_error("RTI expected a MSG_TYPE_FED_IDS message. Got %u (see net_common.h).", buffer[0]);
+    lf_print_error("RTI expected a MSG_TYPE_INITIAL_HANDSHAKE message. Got %u (see net_common.h).", buffer[0]);
     return -1;
   } else {
-    // Received federate ID.
-    fed_id = extract_uint16(buffer + 1);
-    LF_PRINT_DEBUG("RTI received federate ID: %d.", fed_id);
+    // Received MSG_TYPE_INITIAL_HANDSHAKE.
+
+    // Read and verify the protocol version.
+    protocol_version = buffer[1];
+
+    // If we have not selected a protocol version yet, then make sure it is supported.
+    if (rti_remote->protocol_version == FEDERATE_PROTOCOL_INVALID) {
+      if (protocol_version != FEDERATE_PROTOCOL_V2) {
+        lf_print_error("RTI received handshake with unsupported federate protocol v%d", protocol_version);
+        send_reject(socket_id, FEDERATE_PROTOCOL_VERSION_NOT_SUPPORTED);
+        return -1;
+      } else {
+        rti_remote->protocol_version = protocol_version;
+      }
+    } else {
+      // We have already received a message with a protocol version. Make sure this federate requests the same.
+      if (protocol_version != rti_remote->protocol_version) {
+        lf_print_error("RTI received handshake with unsupported federate protocol v%d", protocol_version);
+        send_reject(socket_id, FEDERATE_PROTOCOL_VERSION_NOT_SUPPORTED);
+        return -1;
+      }
+    }
 
     // Read the federation ID.  First read the length, which is one byte.
-    size_t federation_id_length = (size_t)buffer[sizeof(uint16_t) + 1];
-    char federation_id_received[federation_id_length + 1]; // One extra for null terminator.
+    fed_id = extract_uint16(buffer + 2);
+    LF_PRINT_DEBUG("RTI received federate ID: %d.", fed_id);
+
+    size_t federation_id_length = (size_t)buffer[sizeof(uint16_t) + 2];
+    char federation_id_received[federation_id_length + 2]; // One extra for null terminator.
     // Next read the actual federation ID.
     if (read_from_socket_close_on_error(socket_id, federation_id_length, (unsigned char*)federation_id_received)) {
       lf_print_error("RTI failed to read federation id from federate %d.", fed_id);
@@ -1136,7 +1163,7 @@ static int32_t receive_and_check_fed_id_message(int* socket_id) {
     }
   }
   federate_info_t* fed = GET_FED_INFO(fed_id);
-  // The MSG_TYPE_FED_IDS message has the right federation ID.
+  // The MSG_TYPE_INITIAL_HANDSHAKE message has a supported protocol version and the right federation ID.
 
   // Get the peer address from the connected socket_id. Then assign it as the federate's socket server.
   struct sockaddr_in peer_addr;
@@ -1427,7 +1454,7 @@ void lf_connect_to_federates(int socket_descriptor) {
 #endif
 
     // The first message from the federate should contain its ID and the federation ID.
-    int32_t fed_id = receive_and_check_fed_id_message(&socket_id);
+    int32_t fed_id = receive_and_check_initial_handshake_message(&socket_id);
     if (fed_id >= 0 && socket_id >= 0 && receive_connection_information(&socket_id, (uint16_t)fed_id) &&
         receive_udp_message_and_set_up_clock_sync(&socket_id, (uint16_t)fed_id)) {
 
@@ -1573,6 +1600,7 @@ void initialize_RTI(rti_remote_t* rti) {
   rti_remote->num_feds_proposed_start = 0;
   rti_remote->all_federates_exited = false;
   rti_remote->federation_id = "Unidentified Federation";
+  rti_remote->protocol_version = FEDERATE_PROTOCOL_INVALID;
   rti_remote->user_specified_port = 0;
   rti_remote->final_port_TCP = 0;
   rti_remote->socket_descriptor_TCP = -1;

--- a/core/federated/RTI/rti_remote.h
+++ b/core/federated/RTI/rti_remote.h
@@ -105,9 +105,6 @@ typedef struct rti_remote_t {
    */
   volatile bool all_federates_exited;
 
-  /** The protocol version used by the current federation.*/
-  uint8_t protocol_version;
-
   /**
    * The ID of the federation that this RTI will supervise.
    * This should be overridden with a command-line -i option to ensure

--- a/core/federated/RTI/rti_remote.h
+++ b/core/federated/RTI/rti_remote.h
@@ -105,6 +105,9 @@ typedef struct rti_remote_t {
    */
   volatile bool all_federates_exited;
 
+  /** The protocol version used by the current federation.*/
+  uint8_t protocol_version;
+
   /**
    * The ID of the federation that this RTI will supervise.
    * This should be overridden with a command-line -i option to ensure

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -1883,10 +1883,10 @@ void lf_connect_to_rti(const char* hostname, int port) {
 #endif
 
     // Send the message type first.
-    unsigned char buffer[4];
+    unsigned char buffer[5];
     buffer[0] = MSG_TYPE_INITIAL_HANDSHAKE;
     // Next send the version byte of the protocol
-    encode_uint8(FEDERATE_PROTOCOL_V2, &buffer[1]);
+    buffer[1] = FEDERATE_PROTOCOL_V2;
     // Next send the federate ID.
     if (_lf_my_fed_id == UINT16_MAX) {
       lf_print_error_and_exit("Too many federates! More than %d.", UINT16_MAX - 1);

--- a/include/core/federated/network/net_common.h
+++ b/include/core/federated/network/net_common.h
@@ -42,7 +42,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * use DEFAULT_PORT.
  *
  * When it has successfully opened a TCP connection, the first message it sends
- * to the RTI is a MSG_TYPE_FED_IDS_DEPRECATED message, which contains the ID of this federate
+ * to the RTI is a MSG_TYPE_FED_IDS message, which contains the ID of this federate
  * within the federation, contained in the global variable _lf_my_fed_id
  * in the federate code
  * (which is initialized by the code generator) and the unique ID of
@@ -232,7 +232,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define MSG_TYPE_ACK 255
 
 /**
- * Byte identifying an acknowledgment of the previously received MSG_TYPE_FED_IDS_DEPRECATED message
+ * Byte identifying an acknowledgment of the previously received MSG_TYPE_FED_IDS message
  * sent by the RTI to the federate
  * with a payload indicating the UDP port to use for clock synchronization.
  * The next four bytes will be the port number for the UDP server, or
@@ -241,34 +241,24 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #define MSG_TYPE_UDP_PORT 254
 
-/** Byte identifying a initial handshake message from a federate to an RTI containing
- *  the federation ID and the federate ID. The message contains, in this order:
- *  * One byte equal to MSG_TYPE_INITIAL_HANDSHAKE.
- *  * One byte giving the federate protocol version.
- *  * Two bytes (ushort) giving the federate ID.
- *  * One byte (uchar) giving the length N of the federation ID.
- *  * N bytes containing the federation ID. Each federate needs to have a unique ID
- *    between 0 and NUMBER_OF_FEDERATES-1. Each federate, when starting up, should send
- *    this message to the RTI. This is its first message to the RTI. The RTI will
- *    respond with either MSG_TYPE_REJECT, MSG_TYPE_ACK, or MSG_TYPE_UDP_PORT. If the
- *    federate is a C target LF program, the generated federate code does this by
- *    calling lf_synchronize_with_other_federates(), passing to it its federate ID.
- */
-#define MSG_TYPE_INITIAL_HANDSHAKE 253
-
+#define MSG_TYPE_PROTOCOL_VERSION 253
 /** Byte identifying a message from a federate to an RTI containing
  *  the federation ID and the federate ID. The message contains, in
  *  this order:
- *  * One byte equal to MSG_TYPE_FED_IDS_DEPRECATED.
+ *  * One byte equal to MSG_TYPE_FED_IDS.
  *  * Two bytes (ushort) giving the federate ID.
  *  * One byte (uchar) giving the length N of the federation ID.
  *  * N bytes containing the federation ID.
  *  Each federate needs to have a unique ID between 0 and
  *  NUMBER_OF_FEDERATES-1.
- *  NOTE: This message is deprecated and will be sent by federates using
- *  a runtime with a version older than 1.0
+ *  Each federate, when starting up, should send this message
+ *  to the RTI. This is its first message to the RTI.
+ *  The RTI will respond with either MSG_TYPE_REJECT, MSG_TYPE_ACK, or MSG_TYPE_UDP_PORT.
+ *  If the federate is a C target LF program, the generated federate
+ *  code does this by calling lf_synchronize_with_other_federates(),
+ *  passing to it its federate ID.
  */
-#define MSG_TYPE_FED_IDS_DEPRECATED 1
+#define MSG_TYPE_FED_IDS 1
 
 /////////// Messages used for authenticated federation. ///////////////
 /**


### PR DESCRIPTION
This PR introduces a new initial message sent from each federate to the RTI with the requested federate protocol version. This will make it possible to introduce future changes to the federate protocol without worrying about compatibility. The RTI can decide whether it accepts a certain protocol version or not. 

This PR does not try to introduce backwards compatibility. If a federate tries to connect with an RTI that was compiled before this PR, it will fail with an informative error message. If a federate compiled before this PR connects to the RTI it will likewise fail with an informative error message (at the RTI side). **However, there is absolutely nothing we can do from the RTI side to make the old federates terminate after sending the initial message. **

It would be wise to create a new release of `lfc` after this PR to avoid the problems we have been seeing with incompatibility between RTI compiled from `main` and stable `lfc`.

1. Federates connecting to an RTI compiled before this PR:
```
Fed 1 (fed2): Connected to localhost:15045.
Fed 0 (fed1): Connected to localhost:15045.
Fed 1 (fed2): FATAL ERROR: RTI rejected our MSG_TYPE_PROTOCOL VERSION with cause UNEXPECTED_MESSAGE. This suggests that the RTI is outdated and does not support versioning of the protocol. Please update the RTI.
ERROR: RTI expected a MSG_TYPE_FED_IDS message. Got 253 (see net_common.h).
ERROR: RTI expected a MSG_TYPE_FED_IDS message. Got 253 (see net_common.h).
Fed 0 (fed1): FATAL ERROR: RTI rejected our MSG_TYPE_PROTOCOL VERSION with cause UNEXPECTED_MESSAGE. This suggests that the RTI is outdated and does not support versioning of the protocol. Please update the RTI.
WARNING: Failed to accept the socket. Resource temporarily unavailable.
ERROR: RTI failed to read from accepted socket.
```

Here the federates will notice that they are dealing with an old RTI. The program does not crash, because calling `lf_print_error_and_exit` only terminates the current thread.

2. Federates before this PR (current master) connects to the RTI

The RTI will print:

```
ERROR: RTI received the MSG_TYPE_FED_IDS msg before MSG_TYPE_PROTOCOL_VERSION. This suggests that the federate is running an outdated version of the reactor-c runtime. Please make sure that the version of LFC and the version of the RTI are compatible.
```

The federates will just blast the terminal with:

```

```

3. Federates from v0.9.0 connects to the RTI.

The RTI will print as below. But instead of blasting the terminal with broken pipe messages, it will silently just do:

```
./federate__fed2
---- System clock resolution: 1 nsec
---- Start execution on Wed Apr 09 14:10:40 2025 ---- plus 662449456 nanoseconds
Fed 1 (fed2): Trying RTI again on port 15046.
Fed 1 (fed2): Trying RTI again on port 15047.
Fed 1 (fed2): Trying RTI again on port 15048.
Fed 1 (fed2): Trying RTI again on port 15049.
```





3. Federates connect to the RTI asking for an unsupported protocol version

```

```
```