### PR TITLE
Compile RTI for each federation

### DIFF
--- a/core/federated/RTI/CMakeLists.txt
+++ b/core/federated/RTI/CMakeLists.txt
@@ -88,8 +88,10 @@ target_compile_options(${RTI_LIB} PUBLIC -Werror)
 find_package(Threads REQUIRED)
 target_link_libraries(${RTI_LIB} PUBLIC Threads::Threads)
 
-# Option for enabling federate authentication by RTI.
-option(AUTH "Federate authentication by RTI enabled." OFF)
+if (NOT DEFINED AUTH)
+    set(AUTH OFF)
+ENDIF()
+
 IF(AUTH MATCHES ON)
   target_compile_definitions(${RTI_LIB} PUBLIC __RTI_AUTH__)
   # Find OpenSSL and link to it

--- a/core/federated/RTI/CMakeLists.txt
+++ b/core/federated/RTI/CMakeLists.txt
@@ -88,6 +88,7 @@ target_compile_options(${RTI_LIB} PUBLIC -Werror)
 find_package(Threads REQUIRED)
 target_link_libraries(${RTI_LIB} PUBLIC Threads::Threads)
 
+# If AUTH is defined, then the RTI will be able to authenticate federates. By default, this is off.
 if (NOT DEFINED AUTH)
     set(AUTH OFF)
 ENDIF()


### PR DESCRIPTION
This PR removes the use of CMake options in the RTI CMakeLists.txt. We should be consistent, and the other arguments are handled as normal CMake variables. CMake options are more complicated and we dont need them for this simple use-case.

See: https://github.com/lf-lang/lingua-franca/pull/2492