### PR TITLE
Renamed API function and allow zero argument

### DIFF
--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -53,8 +53,8 @@ extern int _lf_count_payload_allocations;
  * @brief Global STA (safe to advance) offset uniformly applied to advancement of each
  * time step in federated execution.
  *
- * This can be retrieved in user code by calling lf_get_stp_offset() and adjusted by
- * calling lf_set_stp_offset(interval_t offset).
+ * This can be retrieved in user code by calling lf_get_sta() and adjusted by
+ * calling lf_set_sta(interval_t offset).
  */
 interval_t lf_fed_STA_offset = 0LL;
 
@@ -185,11 +185,11 @@ const char* lf_reactor_full_name(self_base_t* self) {
 
 interval_t lf_get_stp_offset() { return lf_fed_STA_offset; }
 
-void lf_set_stp_offset(interval_t offset) {
-  if (offset > 0LL) {
-    lf_fed_STA_offset = offset;
-  }
-}
+interval_t lf_get_sta() { return lf_fed_STA_offset; }
+
+void lf_set_stp_offset(interval_t offset) { lf_set_sta(offset); }
+
+void lf_set_sta(interval_t offset) { lf_fed_STA_offset = offset; }
 
 #endif // FEDERATED_DECENTRALIZED
 

--- a/include/core/reactor.h
+++ b/include/core/reactor.h
@@ -56,14 +56,27 @@ void lf_set_stop_tag(environment_t* env, tag_t tag);
 
 /**
  * @brief Return the global STP offset on advancement of logical time for federated execution.
+ * @deprecated Use lf_get_sta() instead.
  */
 interval_t lf_get_stp_offset(void);
 
 /**
+ * @brief Return the global STA (safe to advance) offset for federated execution.
+ */
+interval_t lf_get_sta(void);
+
+/**
  * @brief Set the global STP offset on advancement of logical time for federated execution.
- * @param offset A positive time value to be applied as the STP offset.
+ * @param offset A non-negative time value to be applied as the STP offset.
+ * @deprecated Use lf_set_sta() instead.
  */
 void lf_set_stp_offset(interval_t offset);
+
+/**
+ * @brief Set the global STA (safe to advance) offset for federated execution.
+ * @param offset A non-negative time value to be applied as the STA offset.
+ */
+void lf_set_sta(interval_t offset);
 
 #endif // FEDERATED_DECENTRALIZED
 


### PR DESCRIPTION
This PR renames `lf_set_stp_offset` to `lf_set_sta` (deprecating the previous version) and allows a zero argument.
It also renames `lf_get_stp_offset` to `lf_get_sta`.