### PR TITLE
New `update` policy

### DIFF
--- a/core/clock.c
+++ b/core/clock.c
@@ -11,7 +11,7 @@
  * implementation of the clock functions. This allows controlling the
  * physical time the runtime sees. It is useful for integration with simulators
  * or for repeatable test environments.
- * 
+ *
  * Steps to provide an external clock plugin:
  * 1. Use the cmake-include target property to add a custom CMake file to the build.
  * 2. Add `target_compile_definition(reactor-uc PUBLIC LF_EXTERNAL_CLOCK_PLUGIN)` to the custom CMake file.

--- a/include/core/lf_types.h
+++ b/include/core/lf_types.h
@@ -72,13 +72,13 @@ typedef struct _lf_tag_advancement_barrier {
  * The default policy is `defer`: adjust the tag to that the minimum
  * interarrival time is satisfied.
  * The `drop` policy simply drops events that are scheduled too early.
- * The `replace` policy drops the preceding event and replaces it with
- * the newly scheduled event.
- * The `update` policy will attempt to update the payload of
+ * The `replace` policy will attempt to replace the payload of
  * the preceding event. Unless the preceding event has already been
  * handled, its gets assigned the value of the new event. If the
  * preceding event has already been popped off the event queue, the
  * `defer` policy is fallen back to.
+ * The `update` policy drops the preceding event and updates it with
+ * the newly scheduled event.
  */
 typedef enum { defer, drop, replace, update } lf_spacing_policy_t;
 

--- a/include/core/lf_types.h
+++ b/include/core/lf_types.h
@@ -72,13 +72,15 @@ typedef struct _lf_tag_advancement_barrier {
  * The default policy is `defer`: adjust the tag to that the minimum
  * interarrival time is satisfied.
  * The `drop` policy simply drops events that are scheduled too early.
- * The `replace` policy will attempt to replace the value of the event
- * that it preceded it. Unless the preceding event has already been
+ * The `replace` policy drops the preceding event and replaces it with
+ * the newly scheduled event.
+ * The `update` policy will attempt to update the payload of
+ * the preceding event. Unless the preceding event has already been
  * handled, its gets assigned the value of the new event. If the
  * preceding event has already been popped off the event queue, the
  * `defer` policy is fallen back to.
  */
-typedef enum { defer, drop, replace } lf_spacing_policy_t;
+typedef enum { defer, drop, replace, update } lf_spacing_policy_t;
 
 /**
  * Status of a given port at a given logical time.

--- a/include/core/lf_types.h
+++ b/include/core/lf_types.h
@@ -74,10 +74,10 @@ typedef struct _lf_tag_advancement_barrier {
  * The `drop` policy simply drops events that are scheduled too early.
  * The `replace` policy will attempt to replace the payload of
  * the preceding event. Unless the preceding event has already been
- * handled, its gets assigned the value of the new event. If the
+ * handled, it gets assigned the value of the new event. If the
  * preceding event has already been popped off the event queue, the
  * `defer` policy is fallen back to.
- * The `update` policy drops the preceding event and updates it with
+ * The `update` policy drops the preceding event, if it is still in the event queue, and updates it with
  * the newly scheduled event.
  */
 typedef enum { defer, drop, replace, update } lf_spacing_policy_t;

--- a/lib/schedule.c
+++ b/lib/schedule.c
@@ -227,7 +227,7 @@ trigger_handle_t lf_schedule_trigger(environment_t* env, trigger_t* trigger, int
     // scheduled event. It determines the
     // earliest time at which the new event can be scheduled.
     // Check to see whether the event is too early.
-    instant_t earliest_time = trigger->last_tag.time + min_spacing;
+    instant_t earliest_time = lf_time_add(trigger->last_tag.time, min_spacing);
     LF_PRINT_DEBUG("There is a previously scheduled event; earliest possible time "
                    "with min spacing: " PRINTF_TIME,
                    earliest_time);

--- a/lib/schedule.c
+++ b/lib/schedule.c
@@ -255,7 +255,7 @@ trigger_handle_t lf_schedule_trigger(environment_t* env, trigger_t* trigger, int
 
         if (found != NULL) {
           // Remove the previous event.
-          pqueue_tag_remove(env->event_q, found);
+          pqueue_tag_remove(env->event_q, (pqueue_tag_element_t*)found);
         }
         // Recycle the dummy event used to find the previous event.
         lf_recycle_event(env, dummy);

--- a/lib/schedule.c
+++ b/lib/schedule.c
@@ -244,7 +244,7 @@ trigger_handle_t lf_schedule_trigger(environment_t* env, trigger_t* trigger, int
         lf_recycle_event(env, e);
         return (0);
       case replace:
-        LF_PRINT_DEBUG("Policy is replace. Replacing the previous event.");
+        LF_PRINT_DEBUG("Policy is replace. Replacing the previous event with new tag and payload.");
         // If the event with the previous tag is still on the event
         // queue, then replace the token.  To find this event, we have
         // to construct a dummy event_t struct.
@@ -254,19 +254,11 @@ trigger_handle_t lf_schedule_trigger(environment_t* env, trigger_t* trigger, int
         found = (event_t*)pqueue_tag_find_equal_same_tag(env->event_q, (pqueue_tag_element_t*)dummy);
 
         if (found != NULL) {
-          // Recycle the existing token and the new event
-          // and update the token of the existing event.
-          lf_replace_token(found, token);
-          lf_recycle_event(env, e);
-          lf_recycle_event(env, dummy);
-          // Leave the last_tag the same.
-          return (0);
+          // Remove the previous event.
+          pqueue_tag_remove(env->event_q, found);
         }
+        // Recycle the dummy event used to find the previous event.
         lf_recycle_event(env, dummy);
-
-        // If the preceding event _has_ been handled, then adjust
-        // the tag to defer the event.
-        intended_tag = (tag_t){.time = earliest_time, .microstep = 0};
         break;
       default:
         // Default policy is defer

--- a/lib/schedule.c
+++ b/lib/schedule.c
@@ -244,24 +244,7 @@ trigger_handle_t lf_schedule_trigger(environment_t* env, trigger_t* trigger, int
         lf_recycle_event(env, e);
         return (0);
       case replace:
-        LF_PRINT_DEBUG("Policy is replace. Drop the previous event and insert a new event.");
-        // If the event with the previous tag is still on the event
-        // queue, then drop the previous event. To find this event, we have
-        // to construct a dummy event_t struct.
-        dummy = lf_get_new_event(env);
-        dummy->trigger = trigger;
-        dummy->base.tag = trigger->last_tag;
-        found = (event_t*)pqueue_tag_find_equal_same_tag(env->event_q, (pqueue_tag_element_t*)dummy);
-
-        if (found != NULL) {
-          // Remove the previous event.
-          pqueue_tag_remove(env->event_q, (pqueue_tag_element_t*)found);
-        }
-        // Recycle the dummy event used to find the previous event.
-        lf_recycle_event(env, dummy);
-        break;
-      case update:
-        LF_PRINT_DEBUG("Policy is update. Update the previous event with new payload.");
+        LF_PRINT_DEBUG("Policy is replace. Replace the previous event's payload with new payload.");
         // If the event with the previous tag is still on the event
         // queue, then replace the token. To find this event, we have
         // to construct a dummy event_t struct.
@@ -284,6 +267,23 @@ trigger_handle_t lf_schedule_trigger(environment_t* env, trigger_t* trigger, int
         // If the preceding event _has_ been handled, then adjust
         // the tag to defer the event.
         intended_tag = (tag_t){.time = earliest_time, .microstep = 0};
+        break;
+      case update:
+        LF_PRINT_DEBUG("Policy is update. Drop the previous event and insert a new event.");
+        // If the event with the previous tag is still on the event
+        // queue, then drop the previous event. To find this event, we have
+        // to construct a dummy event_t struct.
+        dummy = lf_get_new_event(env);
+        dummy->trigger = trigger;
+        dummy->base.tag = trigger->last_tag;
+        found = (event_t*)pqueue_tag_find_equal_same_tag(env->event_q, (pqueue_tag_element_t*)dummy);
+
+        if (found != NULL) {
+          // Remove the previous event.
+          pqueue_tag_remove(env->event_q, (pqueue_tag_element_t*)found);
+        }
+        // Recycle the dummy event used to find the previous event.
+        lf_recycle_event(env, dummy);
         break;
       default:
         // Default policy is defer


### PR DESCRIPTION
This PR introduces a new `update` policy: dropping the already scheduled event, and replacing it with a newly scheduled event.

The new `update` policy enables a useful pattern with minimum spacing — renewing the delay interval of an already scheduled event, which can be used to implement the election timeout mechanism essential to implementing the [Raft](https://raft.github.io) protocol.