### PR TITLE
Handle min_spacing of zero correctly

### DIFF
--- a/include/api/schedule.h
+++ b/include/api/schedule.h
@@ -70,12 +70,12 @@ trigger_handle_t lf_schedule_int(void* action, interval_t extra_delay, int value
  * to the current time, then the tag will be one microstep beyond the current tag.
  * If the action is physical, the time will be the current physical time plus the extra delay,
  * and the microstep will be zero.
- * 
+ *
  * In both cases, if the resulting tag of the event conincides with a previously scheduled event
  * for the same action, then, by default, a microstep will be added to the tag until there is no
  * colliding event. This behavior can be changed by specifying a minimum spacing and a policy,
  * as explained below.
- * 
+ *
  * An action will trigger at a logical time that depends on the `extra_delay` argument given to
  * this schedule function, the `<min_delay>`, `<min_spacing>`, and `<policy>` arguments in the
  * action declaration, and whether the action is physical or logical.
@@ -103,7 +103,7 @@ trigger_handle_t lf_schedule_int(void* action, interval_t extra_delay, int value
  * the previously scheduled event, then the time will be modified to enforce
  * the minimum spacing. The `<policy>` argument (if supported by the target)
  * determines how the minimum spacing constraint is enforced.
- * 
+ *
  * Note that "previously scheduled" here means specifically the tag resulting from
  * the most recent call to the schedule function for the same action.
  *
@@ -122,7 +122,7 @@ trigger_handle_t lf_schedule_int(void* action, interval_t extra_delay, int value
  * Note that while the `"defer"` policy is conservative in the sense that it does not discard events,
  * it could potentially cause an unbounded growth of the event queue.
  *
- * For example, suppose the minimum spacing of a logical action is 10 ms and the policy is `"defer"`. 
+ * For example, suppose the minimum spacing of a logical action is 10 ms and the policy is `"defer"`.
  * Suppose that in a reaction to `startup`, the logical action is scheduled with a delay of
  * 100 ms, then again with a delay of 99 ms, and a third time with a delay of 101 ms.
  * The logical action will trigger at elapsed times 100 ms, 110 ms, and 120 ms.

--- a/include/api/schedule.h
+++ b/include/api/schedule.h
@@ -91,21 +91,26 @@ trigger_handle_t lf_schedule_int(void* action, interval_t extra_delay, int value
  *
  * If no `<min_spacing>` has been declared, then the tag of the event is simply the preliminary time
  * unless there is already an event scheduled for the same action with the same tag.
- * In that case, a microstep is added to the tag.
- * If there is again a previously scheduled event with the same tag, then a microstep is added to the tag again.
+ * In that case, a microstep is added to the tag. If there is again a previously scheduled
+ * event with the same tag, then a microstep is added to the tag again.
  * This process is repeated until there is no previously scheduled event with the same tag.
- * This is equvalent to specifying a `<min_spacing>` of 0 with a `"defer"` policy.
  *
  * If a `<min_spacing>` has been declared, then it gives a minimum logical time
- * interval between the tags of two subsequently scheduled events. If the
+ * interval between the tags of two subsequently scheduled events. The first effect this
+ * has is that events will have monotically increasing tags. The difference between the
+ * times of two successive tags is at least `<min_spacing>`. If the
  * preliminary time is closer than `<min_spacing>` to the time of the previously
  * scheduled event (if there is one), or if the preliminary time is earlier than
  * the previously scheduled event, then the time will be modified to enforce
- * the minimum spacing. The `<policy>` argument (if supported by the target)
- * determines how the minimum spacing constraint is enforced.
+ * the minimum spacing. The `<policy>` argument  determines how the minimum spacing
+ * constraint is enforced.
  *
  * Note that "previously scheduled" here means specifically the tag resulting from
  * the most recent call to the schedule function for the same action.
+ *
+ * A `<min_spacing>` of 0 is not quite the same as no `<min_spacing>` declared.
+ * With a `<min_spacing>` of 0, events will still have monotically increasing tags,
+ * but the difference between the times of two successive tags can be 0.
  *
  * The `<policy>` is one of the following:
  *

--- a/lib/schedule.c
+++ b/lib/schedule.c
@@ -206,7 +206,7 @@ trigger_handle_t lf_schedule_trigger(environment_t* env, trigger_t* trigger, int
 #endif
 
   // Check for conflicts (a queued event with the same trigger and tag).
-  if (min_spacing <= 0) {
+  if (min_spacing < 0) {
     // No minimum spacing defined.
     e->base.tag = intended_tag;
     event_t* found = (event_t*)pqueue_tag_find_equal_same_tag(env->event_q, (pqueue_tag_element_t*)e);
@@ -242,7 +242,7 @@ trigger_handle_t lf_schedule_trigger(environment_t* env, trigger_t* trigger, int
                    "with min spacing: " PRINTF_TIME,
                    earliest_time);
     // If the event is early, see which policy applies.
-    if (earliest_time > intended_tag.time) {
+    if (earliest_time > intended_tag.time || (earliest_time == intended_tag.time && min_spacing == 0)) {
       LF_PRINT_DEBUG("Event is early.");
       event_t *dummy, *found;
       switch (trigger->policy) {


### PR DESCRIPTION
This PR fixes the handling of a `min_spacing` of zero, which is not exactly the same as no `min_spacing` policy for actions. Specifically, a `min_spacing` of zero imposes a constraint that tags of scheduled events are monotonically increasing.