### PR TITLE
Avoid variable size array on stack for Windows

### DIFF
--- a/core/federated/RTI/rti_common.c
+++ b/core/federated/RTI/rti_common.c
@@ -380,7 +380,7 @@ void update_min_delays() {
 
       scheduling_node_t* node = rti_common->scheduling_nodes[j];
       // Array of results on the stack:
-      tag_t path_delays = (tag_t*)calloc(n, sizeof(tag_t));
+      tag_t* path_delays = (tag_t*)calloc(n, sizeof(tag_t));
       // This will be the number of non-FOREVER entries put into path_delays.
       size_t count = 0;
 

--- a/core/federated/RTI/rti_common.c
+++ b/core/federated/RTI/rti_common.c
@@ -380,7 +380,7 @@ void update_min_delays() {
 
       scheduling_node_t* node = rti_common->scheduling_nodes[j];
       // Array of results on the stack:
-      tag_t path_delays[n];
+      tag_t path_delays = (tag_t*)calloc(n, sizeof(tag_t));
       // This will be the number of non-FOREVER entries put into path_delays.
       size_t count = 0;
 
@@ -403,6 +403,7 @@ void update_min_delays() {
         }
         */
       }
+      free(path_delays);
     }
   }
 }

--- a/lingua-franca-ref.txt
+++ b/lingua-franca-ref.txt
@@ -1,1 +1,1 @@
-faster-tests
+master

--- a/lingua-franca-ref.txt
+++ b/lingua-franca-ref.txt
@@ -1,1 +1,1 @@
-master
+faster-tests


### PR DESCRIPTION
This works around a Windows limitation that variable-size arrays cannot be put on a stack.  Not sure why this just started showing up.