### PR TITLE
Update checkout action to v4

### DIFF
--- a/.github/workflows/api-docs.yml
+++ b/.github/workflows/api-docs.yml
@@ -12,7 +12,7 @@ jobs:
       run: |
         brew install doxygen
     - name: Checkout repo
-      uses: actions/checkout@1.0.0
+      uses: actions/checkout@v4
     - name: Build docs
       run: make docs
         && cd docs/_build/html


### PR DESCRIPTION
This PR updates the checkout action from the very old 1.0.0 to v4.