### PR TITLE
Timestamped logging macro

### DIFF
--- a/logging/api/logging_macros.h
+++ b/logging/api/logging_macros.h
@@ -12,10 +12,11 @@
 #define LOGGING_MACROS_H
 #include "logging.h"
 #include <stdbool.h>
+#include "tag.h"
 
 /** Default log level. */
 #ifndef LOG_LEVEL
-#define LOG_LEVEL LOG_LEVEL_INFO
+#define LOG_LEVEL LOG_LEVEL_DEBUG
 #endif
 
 // To prevent warnings "conditional expression is constant", we define static booleans
@@ -73,6 +74,20 @@ static const bool _lf_log_level_is_debug = LOG_LEVEL >= LOG_LEVEL_DEBUG;
   do {                                                                                                                 \
     if (_lf_log_level_is_debug) {                                                                                      \
       lf_print_debug(format, ##__VA_ARGS__);                                                                           \
+    }                                                                                                                  \
+  } while (0)
+
+/**
+ * @brief A macro used to print timestamped(physical time) debug information.
+ * @ingroup API
+ *
+ * @note This macro is functionally same as @ref LF_PRINT_DEBUG but with added timestamp for physical time.
+ * This is to check physical time of debug logs. It uses @ref lf_time_physical to get the physical time.
+ */
+#define LF_TIMESTAMP_PRINT_DEBUG(format, ...)                                                                          \
+  do {                                                                                                                 \
+    if (_lf_log_level_is_debug) {                                                                                      \
+      lf_print_debug("[%ld] " format, lf_time_physical_elapsed(), ##__VA_ARGS__);                                             \
     }                                                                                                                  \
   } while (0)
 

--- a/test/general/logging_test.c
+++ b/test/general/logging_test.c
@@ -1,0 +1,20 @@
+#include "logging_macros.h"
+#include <unistd.h>
+
+#define TOTAL_LOOP_CASES 10
+
+/**
+* @brief test for testing LF_TIMESTAMP_PRINT_DEBUG macro
+* must be in LOG_LEVEL LOG_LEVEL_DEBUG
+*/
+int main()
+{
+    LF_PRINT_DEBUG("Start time: %ld", lf_time_start());
+    for(int i; i<TOTAL_LOOP_CASES; i++)
+    {
+        LF_TIMESTAMP_PRINT_DEBUG("[Test case: %d]testing timed debug prints", i);
+        sleep(1);
+    }
+    
+    return 0;
+}


### PR DESCRIPTION
This PR is a fix for #395.

I have implemented a macro which prepends the physical lapsed time to debug messages
`LF_TIMESTAMP_PRINT_DEBUG` in `logging_macros.h`
I have also included a test code to test the functionality of the macro to check its expected output.

expected output:
DEBUG: Start time: -9223372036854775808
DEBUG: [-7464962496372149757] [Test case: 0]testing timed debug prints
DEBUG: [-7464962491372064629] [Test case: 1]testing timed debug prints
DEBUG: [-7464962486371771465] [Test case: 2]testing timed debug prints
DEBUG: [-7464962481371438023] [Test case: 3]testing timed debug prints
DEBUG: [-7464962476371116940] [Test case: 4]testing timed debug prints
DEBUG: [-7464962471370813344] [Test case: 5]testing timed debug prints
DEBUG: [-7464962466370645568] [Test case: 6]testing timed debug prints
DEBUG: [-7464962461370410362] [Test case: 7]testing timed debug prints
DEBUG: [-7464962456370065744] [Test case: 8]testing timed debug prints
DEBUG: [-7464962451369754731] [Test case: 9]testing timed debug prints 