### PR TITLE
Enable QEMU emulation in CI to fix multi-arch RTI Docker builds

### DIFF
--- a/.github/workflows/build-rti.yml
+++ b/.github/workflows/build-rti.yml
@@ -23,6 +23,10 @@ jobs:
     steps:
       - name: Check out reactor-c repository
         uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm, arm64, riscv64
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Build Docker image


### PR DESCRIPTION
This PR adds a QEMU setup step to the `docker-build` job so that multi-architecture Docker builds (particularly `linux/arm/v7`) can run correctly in GitHub Actions.

Previously, the CI runner attempted to execute ARM binaries during the apk add phase of the RTI Dockerfile. Since QEMU/binfmt was not registered, ARM executables (notably BusyBox triggers) failed with:

```
execve: No such file or directory
ERROR: busybox-1.37.0-r29.trigger: exited with error 127
```
This caused the RTI image build to fail for `linux/arm/v7` as mentioned in #550.

I enabled the github runner to register the required `binfmt` handlers so `Buildx` can emulate the `linux/arm/v7`.