### PR TITLE
Use `find_package` to link against external trace plugin.

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -53,49 +53,7 @@ add_library(reactor-c)
 target_sources(reactor-c PRIVATE ${REACTORC_SOURCES})
 lf_enable_compiler_warnings(reactor-c)
 
-if(DEFINED LF_TRACE)
-    include(${LF_ROOT}/trace/api/CMakeLists.txt)
-    target_link_libraries(reactor-c PUBLIC lf::trace-api)
-    # If LF_TRACE_PLUGIN is set, treat it as a CMake package name and try to locate it via find_package().
-    # If that fails (or the target isn't available), do not link anything here and assume the user supplies a
-    # cmake-include file to link against the trace plugin and its dependencies.
-    # To set LF_TRACE_PLUGIN, the user specifies a "package" field under "trace-plugin".
-    # Example: See Option 1 at https://github.com/lf-lang/lf-trace-xronos/blob/main/example/src/CPS.lf 
-    if(DEFINED LF_TRACE_PLUGIN AND NOT LF_TRACE_PLUGIN STREQUAL "")
-        # Optional: allow users to point CMake at a custom installation prefix or config dir(s).
-        # To set LF_TRACE_PLUGIN_PATHS, the user specifies a "path" field under "trace-plugin".
-        # Example: See Option 2 at https://github.com/lf-lang/lf-trace-xronos/blob/main/example/src/CPS.lf 
-        if(DEFINED LF_TRACE_PLUGIN_PATHS AND NOT LF_TRACE_PLUGIN_PATHS STREQUAL "")
-            message(STATUS "Trying to find package ${LF_TRACE_PLUGIN} in: ${LF_TRACE_PLUGIN_PATHS}")
-            find_package(${LF_TRACE_PLUGIN} QUIET CONFIG
-                NO_DEFAULT_PATH
-                PATHS ${LF_TRACE_PLUGIN_PATHS}
-                PATH_SUFFIXES lib/cmake/${LF_TRACE_PLUGIN} share/${LF_TRACE_PLUGIN}/cmake
-            )
-        else()
-            message(STATUS "Trying to find package ${LF_TRACE_PLUGIN} in the default system path")
-            find_package(${LF_TRACE_PLUGIN} QUIET CONFIG)
-        endif()
-
-        if(DEFINED LF_TRACE_PLUGIN_LIBRARY AND NOT LF_TRACE_PLUGIN_LIBRARY STREQUAL "" AND TARGET "${LF_TRACE_PLUGIN_LIBRARY}")
-            # To set LF_TRACE_PLUGIN_LIBRARY, the user specifies a "library" field under "trace-plugin".
-            # Example: See Option 1 & 2 at https://github.com/lf-lang/lf-trace-xronos/blob/main/example/src/CPS.lf 
-            message(STATUS "Package ${LF_TRACE_PLUGIN} found. Linking trace plugin target: ${LF_TRACE_PLUGIN_LIBRARY}")
-            target_link_libraries(reactor-c PRIVATE "${LF_TRACE_PLUGIN_LIBRARY}")
-        else()
-            # Example: See Option 3 at https://github.com/lf-lang/lf-trace-xronos/blob/main/example/src/CPS.lf 
-            message(STATUS "Trace plugin package/target not found (or LF_TRACE_PLUGIN_LIBRARY not set). Expecting user cmake-include to link the plugin.")
-        endif()
-    else()
-        # If not, use the default implementation.
-        message(STATUS "Linking with default trace implementation")
-        include(${LF_ROOT}/trace/impl/CMakeLists.txt)
-        target_link_libraries(reactor-c PRIVATE lf::trace-impl)
-    endif()
-else()
-    include(${LF_ROOT}/trace/api/types/CMakeLists.txt)
-    target_link_libraries(reactor-c PUBLIC lf::trace-api-types)
-endif()
+include(${LF_ROOT}/core/lf_trace.cmake)
 
 include(${LF_ROOT}/version/api/CMakeLists.txt)
 target_link_libraries(reactor-c PUBLIC lf::version-api)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -56,16 +56,11 @@ lf_enable_compiler_warnings(reactor-c)
 if(DEFINED LF_TRACE)
     include(${LF_ROOT}/trace/api/CMakeLists.txt)
     target_link_libraries(reactor-c PUBLIC lf::trace-api)
-    # If the user specified an external trace plugin. Find it and link with it
+    # If trace plugin is set to TRUE, skip linking the default trace implementation here.
+    # The user must supply a cmake-include file to link against the custom trace plugin
+    # and its dependencies (e.g., target_link_libraries(reactor-c PRIVATE <plugin-lib>)).
     if (LF_TRACE_PLUGIN)
-        message(STATUS "Linking trace plugin library ${LF_TRACE_PLUGIN}")
-        find_library(TRACE_LIB NAMES ${LF_TRACE_PLUGIN} HINTS "${LF_ROOT}")
-        if (NOT TRACE_LIB)
-            message(FATAL_ERROR "The trace plugin library ${LF_TRACE_PLUGIN} not found")
-        endif()
-        # We also link with libdl because it is needed for some platforms.
-        # TODO: Figure out why this is the case and how to avoid it.
-        target_link_libraries(reactor-c PRIVATE ${TRACE_LIB} dl)
+        message(STATUS "Trace plugin is set to TRUE. Expecting a cmake file for linking against the plugin via the `cmake-include` target property.")
     else()
     # If not, use the default implementation
         message(STATUS "Linking with default trace implementation")

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -56,13 +56,38 @@ lf_enable_compiler_warnings(reactor-c)
 if(DEFINED LF_TRACE)
     include(${LF_ROOT}/trace/api/CMakeLists.txt)
     target_link_libraries(reactor-c PUBLIC lf::trace-api)
-    # If trace plugin is set to TRUE, skip linking the default trace implementation here.
-    # The user must supply a cmake-include file to link against the custom trace plugin
-    # and its dependencies (e.g., target_link_libraries(reactor-c PRIVATE <plugin-lib>)).
-    if (LF_TRACE_PLUGIN)
-        message(STATUS "Trace plugin is set to TRUE. Expecting a cmake file for linking against the plugin via the `cmake-include` target property.")
+    # If LF_TRACE_PLUGIN is set, treat it as a CMake package name and try to locate it via find_package().
+    # If that fails (or the target isn't available), do not link anything here and assume the user supplies a
+    # cmake-include file to link against the trace plugin and its dependencies.
+    # To set LF_TRACE_PLUGIN, the user specifies a "package" field under "trace-plugin".
+    # Example: See Option 1 at https://github.com/lf-lang/lf-trace-xronos/blob/main/example/src/CPS.lf 
+    if(DEFINED LF_TRACE_PLUGIN AND NOT LF_TRACE_PLUGIN STREQUAL "")
+        # Optional: allow users to point CMake at a custom installation prefix or config dir(s).
+        # To set LF_TRACE_PLUGIN_PATHS, the user specifies a "path" field under "trace-plugin".
+        # Example: See Option 2 at https://github.com/lf-lang/lf-trace-xronos/blob/main/example/src/CPS.lf 
+        if(DEFINED LF_TRACE_PLUGIN_PATHS AND NOT LF_TRACE_PLUGIN_PATHS STREQUAL "")
+            message(STATUS "Trying to find package ${LF_TRACE_PLUGIN} in: ${LF_TRACE_PLUGIN_PATHS}")
+            find_package(${LF_TRACE_PLUGIN} QUIET CONFIG
+                NO_DEFAULT_PATH
+                PATHS ${LF_TRACE_PLUGIN_PATHS}
+                PATH_SUFFIXES lib/cmake/${LF_TRACE_PLUGIN} share/${LF_TRACE_PLUGIN}/cmake
+            )
+        else()
+            message(STATUS "Trying to find package ${LF_TRACE_PLUGIN} in the default system path")
+            find_package(${LF_TRACE_PLUGIN} QUIET CONFIG)
+        endif()
+
+        if(DEFINED LF_TRACE_PLUGIN_LIBRARY AND NOT LF_TRACE_PLUGIN_LIBRARY STREQUAL "" AND TARGET "${LF_TRACE_PLUGIN_LIBRARY}")
+            # To set LF_TRACE_PLUGIN_LIBRARY, the user specifies a "library" field under "trace-plugin".
+            # Example: See Option 1 & 2 at https://github.com/lf-lang/lf-trace-xronos/blob/main/example/src/CPS.lf 
+            message(STATUS "Package ${LF_TRACE_PLUGIN} found. Linking trace plugin target: ${LF_TRACE_PLUGIN_LIBRARY}")
+            target_link_libraries(reactor-c PRIVATE "${LF_TRACE_PLUGIN_LIBRARY}")
+        else()
+            # Example: See Option 3 at https://github.com/lf-lang/lf-trace-xronos/blob/main/example/src/CPS.lf 
+            message(STATUS "Trace plugin package/target not found (or LF_TRACE_PLUGIN_LIBRARY not set). Expecting user cmake-include to link the plugin.")
+        endif()
     else()
-    # If not, use the default implementation
+        # If not, use the default implementation.
         message(STATUS "Linking with default trace implementation")
         include(${LF_ROOT}/trace/impl/CMakeLists.txt)
         target_link_libraries(reactor-c PRIVATE lf::trace-impl)

--- a/core/lf_trace.cmake
+++ b/core/lf_trace.cmake
@@ -28,8 +28,8 @@ if(DEFINED LF_TRACE)
             message(STATUS "Package ${LF_TRACE_PLUGIN} found. Linking trace plugin target: ${LF_TRACE_PLUGIN_LIBRARY}")
             target_link_libraries(reactor-c PRIVATE "${LF_TRACE_PLUGIN_LIBRARY}")
         else()
-            # Case C: None of LF_TRACE_PLUGIN, LF_TRACE_PLUGIN_LIBRARY, and LF_TRACE_PLUGIN_PATHS are set,
-            # when the user does not use "trace-plugin" at all. A custom cmake integration is expected from the user.
+            # Case C: Neither LF_TRACE_PLUGIN_LIBRARY nor LF_TRACE_PLUGIN_PATHS is set. LF_TRACE_PLUGIN is set via cmake-args.
+            # This case happens when the user does not use "trace-plugin" but proceeds with a custom integration via cmake-include and cmake-args.
             # Example: See https://github.com/lf-lang/lf-trace-xronos/blob/53e77a6b072f6b25d4fdfd53a4a3700fc199f938/tests/src/TracePluginCustomCmake.lf
             message(STATUS "Trace plugin package or library not found. Expecting user cmake-include to link the plugin.")
         endif()

--- a/core/lf_trace.cmake
+++ b/core/lf_trace.cmake
@@ -28,8 +28,10 @@ if(DEFINED LF_TRACE)
             message(STATUS "Package ${LF_TRACE_PLUGIN} found. Linking trace plugin target: ${LF_TRACE_PLUGIN_LIBRARY}")
             target_link_libraries(reactor-c PRIVATE "${LF_TRACE_PLUGIN_LIBRARY}")
         else()
-            # Case C: Neither LF_TRACE_PLUGIN_LIBRARY nor LF_TRACE_PLUGIN_PATHS is set. LF_TRACE_PLUGIN is set via cmake-args.
-            # This case happens when the user does not use "trace-plugin" but proceeds with a custom integration via cmake-include and cmake-args.
+            # Case C: LF_TRACE_PLUGIN is set but the specified trace plugin library target is not available
+            # (LF_TRACE_PLUGIN_LIBRARY is undefined, empty, or does not name an existing target, e.g., package not found).
+            # This case covers when the user either does not use "trace-plugin" or the package/library cannot be resolved,
+            # and instead proceeds with a custom integration via cmake-include and cmake-args.
             # Example: See https://github.com/lf-lang/lf-trace-xronos/blob/53e77a6b072f6b25d4fdfd53a4a3700fc199f938/tests/src/TracePluginCustomCmake.lf
             message(STATUS "Trace plugin package or library not found. Expecting user cmake-include to link the plugin.")
         endif()

--- a/core/lf_trace.cmake
+++ b/core/lf_trace.cmake
@@ -1,0 +1,43 @@
+if(DEFINED LF_TRACE)
+    include(${LF_ROOT}/trace/api/CMakeLists.txt)
+    target_link_libraries(reactor-c PUBLIC lf::trace-api)
+    # If LF_TRACE_PLUGIN is set, treat it as a CMake package name and try to locate it via find_package().
+    # If that fails (or the target isn't available), do not link anything here and assume the user supplies a
+    # cmake-include file to link against the trace plugin and its dependencies.
+    # To set LF_TRACE_PLUGIN, the user specifies a "package" field under "trace-plugin".
+    # Example: See Option 1 at https://github.com/lf-lang/lf-trace-xronos/blob/8cd2ee82d624f6cc6a2788b0378e25df33be7347/example/src/CPS.lf
+    if(DEFINED LF_TRACE_PLUGIN AND NOT LF_TRACE_PLUGIN STREQUAL "")
+        # Optional: allow users to point CMake at a custom installation prefix or config dir(s).
+        # To set LF_TRACE_PLUGIN_PATHS, the user specifies a "path" field under "trace-plugin".
+        # Example: See Option 2 at https://github.com/lf-lang/lf-trace-xronos/blob/8cd2ee82d624f6cc6a2788b0378e25df33be7347/example/src/CPS.lf
+        if(DEFINED LF_TRACE_PLUGIN_PATHS AND NOT LF_TRACE_PLUGIN_PATHS STREQUAL "")
+            message(STATUS "Trying to find package ${LF_TRACE_PLUGIN} in: ${LF_TRACE_PLUGIN_PATHS}")
+            find_package(${LF_TRACE_PLUGIN} QUIET CONFIG
+                NO_DEFAULT_PATH
+                PATHS ${LF_TRACE_PLUGIN_PATHS}
+                PATH_SUFFIXES lib/cmake/${LF_TRACE_PLUGIN} share/${LF_TRACE_PLUGIN}/cmake
+            )
+        else()
+            message(STATUS "Trying to find package ${LF_TRACE_PLUGIN} in the default system path")
+            find_package(${LF_TRACE_PLUGIN} QUIET CONFIG)
+        endif()
+
+        if(DEFINED LF_TRACE_PLUGIN_LIBRARY AND NOT LF_TRACE_PLUGIN_LIBRARY STREQUAL "" AND TARGET "${LF_TRACE_PLUGIN_LIBRARY}")
+            # To set LF_TRACE_PLUGIN_LIBRARY, the user specifies a "library" field under "trace-plugin".
+            # Example: See Option 1 & 2 at https://github.com/lf-lang/lf-trace-xronos/blob/8cd2ee82d624f6cc6a2788b0378e25df33be7347/example/src/CPS.lf
+            message(STATUS "Package ${LF_TRACE_PLUGIN} found. Linking trace plugin target: ${LF_TRACE_PLUGIN_LIBRARY}")
+            target_link_libraries(reactor-c PRIVATE "${LF_TRACE_PLUGIN_LIBRARY}")
+        else()
+            # Example: See Option 3 at https://github.com/lf-lang/lf-trace-xronos/blob/8cd2ee82d624f6cc6a2788b0378e25df33be7347/example/src/CPS.lf
+            message(STATUS "Trace plugin package/target not found (or LF_TRACE_PLUGIN_LIBRARY not set). Expecting user cmake-include to link the plugin.")
+        endif()
+    else()
+        # If not, use the default implementation.
+        message(STATUS "Linking with default trace implementation")
+        include(${LF_ROOT}/trace/impl/CMakeLists.txt)
+        target_link_libraries(reactor-c PRIVATE lf::trace-impl)
+    endif()
+else()
+    include(${LF_ROOT}/trace/api/types/CMakeLists.txt)
+    target_link_libraries(reactor-c PUBLIC lf::trace-api-types)
+endif()

--- a/trace/impl/CMakeLists.txt
+++ b/trace/impl/CMakeLists.txt
@@ -1,5 +1,40 @@
-set(LF_ROOT ${CMAKE_CURRENT_LIST_DIR}/../..)
+## This CMakeLists is used in two ways:
+## 1) Included from the reactor-c build (e.g., from `core/CMakeLists.txt`)
+## 2) Built standalone by running CMake in `trace/impl/`
+##
+## When built standalone, we need to create the dependency targets that the
+## implementation links against (they are lightweight INTERFACE libraries).
+
+set(_LF_TRACE_IMPL_STANDALONE OFF)
+# Check if the trace plugin is compiled standalone.
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_LIST_DIR)
+    cmake_minimum_required(VERSION 3.13)
+    project(lf_trace_impl LANGUAGES C)
+    set(CMAKE_C_STANDARD 11)
+    set(CMAKE_C_STANDARD_REQUIRED ON)
+    set(_LF_TRACE_IMPL_STANDALONE ON)
+endif()
+
+get_filename_component(LF_ROOT "${CMAKE_CURRENT_LIST_DIR}/../.." ABSOLUTE)
 include(${LF_ROOT}/core/lf_utils.cmake)
+
+# Ensure dependency targets exist when building standalone.
+# When this file is included from the reactor-c build, that build is responsible
+# for including these modules (and including them twice causes duplicate targets).
+if(_LF_TRACE_IMPL_STANDALONE)
+    if(NOT TARGET lf::trace-api)
+        include(${LF_ROOT}/trace/api/CMakeLists.txt)
+    endif()
+    if(NOT TARGET lf::platform-api)
+        include(${LF_ROOT}/platform/api/CMakeLists.txt)
+    endif()
+    if(NOT TARGET lf::logging-api)
+        include(${LF_ROOT}/logging/api/CMakeLists.txt)
+    endif()
+    if(NOT TARGET lf::version-api)
+        include(${LF_ROOT}/version/api/CMakeLists.txt)
+    endif()
+endif()
 
 add_library(lf-trace-impl STATIC)
 add_library(lf::trace-impl ALIAS lf-trace-impl)

--- a/trace/impl/build.sh
+++ b/trace/impl/build.sh
@@ -2,12 +2,11 @@
 
 set -euo pipefail
 
-# This directory does not contain a standalone CMake project. `trace/impl/CMakeLists.txt`
-# is meant to be included from the reactor-c top-level build where the trace API include
-# paths (for "trace.h") are defined.
+# `trace/impl` is a standalone CMake project (and can also be included from the
+# reactor-c top-level build). This script builds the standalone project and
+# produces `lib/lf-trace-impl.a`.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REACTOR_C_ROOT="${SCRIPT_DIR}/../.."
 BUILD_DIR="${SCRIPT_DIR}/build"
 
-cmake -S "${REACTOR_C_ROOT}" -B "${BUILD_DIR}" -DLOG_LEVEL=4 -DLF_TRACE=1
+cmake -S "${SCRIPT_DIR}" -B "${BUILD_DIR}" -DLOG_LEVEL=4
 cmake --build "${BUILD_DIR}" --target lf-trace-impl

--- a/trace/impl/build.sh
+++ b/trace/impl/build.sh
@@ -1,4 +1,13 @@
 #!/bin/bash
 
-cmake -S . -B build -DLOG_LEVEL=4
-cmake --build build
+set -euo pipefail
+
+# This directory does not contain a standalone CMake project. `trace/impl/CMakeLists.txt`
+# is meant to be included from the reactor-c top-level build where the trace API include
+# paths (for "trace.h") are defined.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REACTOR_C_ROOT="${SCRIPT_DIR}/../.."
+BUILD_DIR="${SCRIPT_DIR}/build"
+
+cmake -S "${REACTOR_C_ROOT}" -B "${BUILD_DIR}" -DLOG_LEVEL=4 -DLF_TRACE=1
+cmake --build "${BUILD_DIR}" --target lf-trace-impl


### PR DESCRIPTION
The overall goal of this PR is to support a [new trace plugin](https://github.com/lf-lang/lf-trace-xronos) that streams data to the Xronos dashboard.

The existing mechanism to link against a trace plugin library is through `find_library`, which requires the plugin library to be located at the root of the generated C project (i.e., `LF_ROOT`). This requires using the `files` target property to copy the trace plugin library to `LF_ROOT`.

While this approach works for a small, self-contained library, this approach would not work if a library has its own dependencies, as the library needs to link against them, which `find_library` does not do.

A more robust approach is to pull in the plugin library dependencies using cmake's `find_package()` or using a custom cmake file via the `cmake-include` target property (more dev-friendly).

This PR:
1. uses `find_package` instead of `find_library` and adds a message for the user to provide a cmake file if `find_package` does not succeed;
2. makes the default plugin compilable using `build.sh`.