### PR TITLE
Add lf_refresh_key() API for SST session key rotation in federated execution

### DIFF
--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -1028,6 +1028,9 @@ void* federate_info_thread_TCP(void* fed) {
     case MSG_TYPE_FAILED:
       handle_federate_failed(my_fed);
       return NULL;
+    case MSG_TYPE_SST_KEY_REFRESH_REQUEST:
+      handle_key_refresh_request(my_fed, buffer);
+      break;
     default:
       lf_print_error("RTI received from federate %d an unrecognized TCP message type: %u.", my_fed->enclave.id,
                      buffer[0]);
@@ -1607,6 +1610,25 @@ void free_scheduling_nodes(scheduling_node_t** scheduling_nodes, uint16_t number
     free(node);
   }
   free(scheduling_nodes);
+}
+
+void handle_key_refresh_request(federate_info_t* fed, unsigned char* buffer){
+  unsigned char key_id[SESSION_KEY_ID_SIZE];
+  read_from_net_fail_on_error(fed->net, SESSION_KEY_ID_SIZE, key_id, NULL);
+
+  fetch_pending_session_key(fed->net, key_id);
+  LF_PRINT_DEBUG("New session key fetched and stored in the pending key field");
+  
+  LF_MUTEX_LOCK(&rti_mutex);
+  send_key_refresh_request(fed->net, MSG_TYPE_SST_KEY_ACK);
+  LF_MUTEX_UNLOCK(&rti_mutex);
+
+  swap_to_pending_key(fed->net);
+
+  LF_PRINT_DEBUG("Key ID swap complete");
+
+
+  
 }
 
 #endif // STANDALONE_RTI

--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -1029,7 +1029,9 @@ void* federate_info_thread_TCP(void* fed) {
       handle_federate_failed(my_fed);
       return NULL;
     case MSG_TYPE_SST_KEY_REFRESH_REQUEST:
+      #ifdef COMM_TYPE_SST
       handle_key_refresh_request(my_fed, buffer);
+      #endif
       break;
     default:
       lf_print_error("RTI received from federate %d an unrecognized TCP message type: %u.", my_fed->enclave.id,
@@ -1611,24 +1613,24 @@ void free_scheduling_nodes(scheduling_node_t** scheduling_nodes, uint16_t number
   }
   free(scheduling_nodes);
 }
-
+#ifdef COMM_TYPE_SST
 void handle_key_refresh_request(federate_info_t* fed, unsigned char* buffer){
-  unsigned char key_id[SESSION_KEY_ID_SIZE];
-  read_from_net_fail_on_error(fed->net, SESSION_KEY_ID_SIZE, key_id, NULL);
+  unsigned char key_id[8];
+  read_from_net_fail_on_error(fed->net, 8, key_id, NULL);
 
   fetch_pending_session_key(fed->net, key_id);
-  LF_PRINT_DEBUG("New session key fetched and stored in the pending key field");
+  lf_print("New session key fetched and stored in the pending key field");
   
   LF_MUTEX_LOCK(&rti_mutex);
   send_key_refresh_request(fed->net, MSG_TYPE_SST_KEY_ACK);
+  swap_to_pending_key(fed->net);
   LF_MUTEX_UNLOCK(&rti_mutex);
 
-  swap_to_pending_key(fed->net);
-
-  LF_PRINT_DEBUG("Key ID swap complete");
+  lf_print("Key ID swap complete");
 
 
   
 }
+#endif
 
 #endif // STANDALONE_RTI

--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -1618,14 +1618,7 @@ void free_scheduling_nodes(scheduling_node_t** scheduling_nodes, uint16_t number
   free(scheduling_nodes);
 }
 
-/**
- * Called by federate_info_thread_TCP when MSG_TYPE_SST_KEY_REFRESH_REQUEST arrives.
- * Reads the 8-byte key ID sent by the federate, retrieves the matching session key from
- * the RTI's SST context via fetch_pending_session_key, acknowledges with MSG_TYPE_SST_KEY_ACK,
- * then swaps the new key into the active slot under rti_mutex so no concurrent
- * send uses a stale key.
- */
-#ifdef COMM_TYPE_SST
+#ifdef COMM_TYPE_SST 
 void handle_key_refresh_request(federate_info_t* fed, unsigned char* buffer){
   unsigned char key_id[8];
   read_from_net_fail_on_error(fed->net, 8, key_id, NULL);

--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -1028,6 +1028,10 @@ void* federate_info_thread_TCP(void* fed) {
     case MSG_TYPE_FAILED:
       handle_federate_failed(my_fed);
       return NULL;
+    /**A federate is initiating an SST session key rotation. Calls handle_key_refresh_request
+     * fetches the new key from the RTI's SST context, ACKs the federate, then swaps
+     * the key into the active slot under rti_mutex. 
+    */
     case MSG_TYPE_SST_KEY_REFRESH_REQUEST:
       #ifdef COMM_TYPE_SST
       handle_key_refresh_request(my_fed, buffer);
@@ -1613,6 +1617,14 @@ void free_scheduling_nodes(scheduling_node_t** scheduling_nodes, uint16_t number
   }
   free(scheduling_nodes);
 }
+
+/**
+ * Called by federate_info_thread_TCP when MSG_TYPE_SST_KEY_REFRESH_REQUEST arrives.
+ * Reads the 8-byte key ID sent by the federate, retrieves the matching session key from
+ * the RTI's SST context via fetch_pending_session_key, acknowledges with MSG_TYPE_SST_KEY_ACK,
+ * then swaps the new key into the active slot under rti_mutex so no concurrent
+ * send uses a stale key.
+ */
 #ifdef COMM_TYPE_SST
 void handle_key_refresh_request(federate_info_t* fed, unsigned char* buffer){
   unsigned char key_id[8];

--- a/core/federated/RTI/rti_remote.h
+++ b/core/federated/RTI/rti_remote.h
@@ -440,9 +440,19 @@ int process_args(int argc, const char* argv[]);
  */
 void initialize_RTI(rti_remote_t* rti);
 /**
- * TODO(Kushal Paliwal)
- * Write comments
+ * @brief Handle a session key refresh request from a federate.
  *
+ * Reads the new key ID sent by the federate, fetches the corresponding
+ * session key from the SST context, acknowledges the request with
+ * MSG_TYPE_SST_KEY_ACK, and swaps the new key into the active slot.
+ * The key swap is performed under the RTI mutex to prevent concurrent
+ * access during the transition.
+ *
+ * This is called when the RTI receives a MSG_TYPE_SST_KEY_REFRESH_REQUEST
+ * message from a federate.
+ *
+ * @param fed The federate that initiated the key refresh.
+ * @param buffer The buffer containing the incoming message.
  */
 void handle_key_refresh_request(federate_info_t* fed, unsigned char* buffer);
 

--- a/core/federated/RTI/rti_remote.h
+++ b/core/federated/RTI/rti_remote.h
@@ -439,6 +439,12 @@ int process_args(int argc, const char* argv[]);
  * @param rti The RTI instance to initialize.
  */
 void initialize_RTI(rti_remote_t* rti);
+/**
+ * TODO(Kushal Paliwal)
+ * Write comments
+ *
+ */
+void handle_key_refresh_request(federate_info_t* fed, unsigned char* buffer);
 
 #endif // RTI_REMOTE_H
 #endif // STANDALONE_RTI

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -768,6 +768,9 @@ static void* listen_to_federates(void* _args) {
           net_closed = true;
         }
         break;
+      case MSG_TYPE_SST_KEY_REFRESH_REQUEST:
+        handle_key_refresh_request(net);
+        break;
       default:
         bad_message = true;
       }
@@ -2550,7 +2553,9 @@ int lf_send_tagged_message(environment_t* env, interval_t additional_delay, int 
   }
   LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
   #ifdef COMM_TYPE_SST
-  _lf_check_and_perform_rekey();
+  if(atomic_exchange(&_fed.rekey_requested, false)){
+    _lf_check_and_perform_rekey();
+  }
   #endif
   return result;
 }
@@ -2692,26 +2697,55 @@ instant_t lf_wait_until_time(tag_t tag) {
 
 void lf_refresh_key(void){
   lf_print("DEBUG: Rekey Requested");
-  _fed.rekey_requested = true;
+  atomic_store(&_fed.rekey_requested, true);
 }
 
 
 #ifdef COMM_TYPE_SST
 void _lf_check_and_perform_rekey(void){
-  if(_fed.rekey_requested){
-    lf_print("Acquiring new session key and sending it to RTI");
-    get_new_session_key(_fed.net_to_RTI);
 
-    // Hold the outbound mutex while sending the request and waiting for the RTI's ACK.
-    // lf_rekey_completed is signaled by handle_rti_session_key_ack once the new key is
-    // active, at which point this thread wakes, releases the mutex, and returns.
-    LF_MUTEX_LOCK(&lf_outbound_net_mutex);
-    send_key_refresh_request(_fed.net_to_RTI, MSG_TYPE_SST_KEY_REFRESH_REQUEST);
-    LF_COND_WAIT(&lf_rekey_completed);
-    LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
+  #ifdef FEDERATED_CENTRALIZED
+  lf_print("Acquiring new session key and sending it to RTI");
+  get_new_session_key(_fed.net_to_RTI);
 
-    _fed.rekey_requested = false;
+  // Hold the outbound mutex while sending the request and waiting for the RTI's ACK.
+  // lf_rekey_completed is signaled by handle_rti_session_key_ack once the new key is
+  // active, at which point this thread wakes, releases the mutex, and returns.
+  LF_MUTEX_LOCK(&lf_outbound_net_mutex);
+  send_key_refresh_request(_fed.net_to_RTI, MSG_TYPE_SST_KEY_REFRESH_REQUEST);
+  LF_COND_WAIT(&lf_rekey_completed);
+  LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
+  #endif
+
+  #ifdef FEDERATED_DECENTRALIZED
+  for (int i=0; i< _fed.number_of_outbound_p2p_connections; i++){
+
+    net_abstraction_t net = _fed.net_for_outbound_p2p_connections[i];
+    if(net != NULL){
+      get_new_session_key(net);
+      lf_print("DEBUG: New session key received\n");
+
+      LF_MUTEX_LOCK(&lf_outbound_net_mutex);
+      send_key_refresh_request(net, MSG_TYPE_SST_KEY_REFRESH_REQUEST);
+      lf_print("DEBUG: Refresh Request Sent");
+      LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
+
+      unsigned char buffer;
+      read_from_net_fail_on_error(net, 1, &buffer, NULL);
+      unsigned char key_id[SESSION_KEY_ID_SIZE];
+      lf_print("DEBUG: ACK ARRIVED");
+      read_from_net_fail_on_error(net, SESSION_KEY_ID_SIZE, key_id, NULL);
+      if(!verify_pending_key_id(net, key_id)){
+        lf_print_error("Key IDs dont match");
+      }
+
+      LF_MUTEX_LOCK(&lf_outbound_net_mutex);
+      swap_to_pending_key(net);
+      LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
+      
+    }
   }
+  #endif
 }
 
 void handle_rti_session_key_ack(net_abstraction_t net_abs, unsigned char* buffer){
@@ -2727,6 +2761,17 @@ void handle_rti_session_key_ack(net_abstraction_t net_abs, unsigned char* buffer
   LF_COND_BROADCAST(&lf_rekey_completed);
   LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
   lf_print("Key ID match in ACK");
+}
+
+void handle_key_refresh_request(net_abstraction_t net_abs){
+  unsigned char key_id[SESSION_KEY_ID_SIZE];
+  read_from_net_fail_on_error(net_abs, SESSION_KEY_ID_SIZE, key_id, NULL);
+  fetch_pending_session_key(net_abs, key_id);
+
+  LF_MUTEX_LOCK(&lf_outbound_net_mutex);
+  send_key_refresh_request(net_abs, MSG_TYPE_SST_KEY_ACK);
+  swap_to_pending_key(net_abs);
+  LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
 }
 #endif
 #endif // FEDERATED

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -1543,6 +1543,9 @@ static void* listen_to_rti_net(void* args) {
     case MSG_TYPE_CLOCK_SYNC_T4:
       lf_print_error("Federate %d received unexpected clock sync message from RTI.", _lf_my_fed_id);
       break;
+    case MSG_TYPE_SST_KEY_ACK:
+      handle_rti_session_key_ack(_fed.net_to_RTI, buffer);
+      break;
     default:
       lf_print_error_and_exit("Received from RTI an unrecognized message type: %hhx.", buffer[0]);
       // Trace the event when tracing is enabled
@@ -2675,4 +2678,38 @@ instant_t lf_wait_until_time(tag_t tag) {
 }
 #endif // FEDERATED_DECENTRALIZED
 
+/**
+ * Request a session-key refresh for federated communication.
+ *
+ * This is a reactor-level callable API that does NOT perform any network I/O.
+ * It only sets a flag indicating that a rekey/refresh should be performed later
+ * by the federated networking/runtime layer at a safe point (outside reaction execution).
+ */
+void lf_refresh_key(void){
+  lf_print("DEBUG: Rekey Requested");
+  _fed.rekey_requested = true;
+}
+
+void _lf_check_and_perform_rekey(void){
+  if(_fed.rekey_requested){
+    get_new_session_key(_fed.net_to_RTI);
+
+    LF_MUTEX_LOCK(&lf_outbound_net_mutex);
+    send_key_refresh_request(_fed.net_to_RTI, MSG_TYPE_SST_KEY_REFRESH_REQUEST);
+    LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
+    _fed.rekey_requested = false;
+  }
+}
+
+void handle_rti_session_key_ack(net_abstraction_t net_abs, unsigned char* buffer){
+  unsigned char key_id[SESSION_KEY_ID_SIZE];
+  read_from_net_fail_on_error(net_abs, SESSION_KEY_ID_SIZE, key_id, NULL);
+  if(!verify_pending_key_id(net_abs, key_id)){
+    LF_PRINT_DEBUG("Key IDs dont match");
+    return;
+  }
+
+  swap_to_pending_key(net_abs);
+  LF_PRINT_DEBUG("Key ID match in ACK");
+}
 #endif // FEDERATED

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -37,10 +37,9 @@
 #include <openssl/hmac.h> // For HMAC-based authentication of federates.
 #endif
 
-// Global variables for synchronizing read and write when session key is being refreshed
+// Global variable for synchronizing read and write when session key is being refreshed
 #ifdef COMM_TYPE_SST
 lf_cond_t lf_rekey_completed;
-static bool lf_rekey_in_progress = false;
 #endif
 // Global variables defined in tag.c:
 extern instant_t start_time;
@@ -138,12 +137,6 @@ static void send_tag(unsigned char type, tag_t tag) {
   // Trace the event when tracing is enabled
   tracepoint_federate_to_rti(event_type, _lf_my_fed_id, &tag);
   LF_MUTEX_LOCK(&lf_outbound_net_mutex);
-  #ifdef COMM_TYPE_SST
-  // Waits until the rekey in progress is complete before sending any more writes 
-  while(lf_rekey_in_progress){
-    LF_COND_WAIT(&lf_rekey_completed);
-  }
-  #endif
   write_to_net_fail_on_error(_fed.net_to_RTI, bytes_to_write, buffer, &lf_outbound_net_mutex,
                              "Failed to send tag " PRINTF_TAG " to the RTI.", tag.time - start_time, tag.microstep);
   LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
@@ -2713,37 +2706,46 @@ void lf_refresh_key(void){
   _fed.rekey_requested = true;
 }
 
+/**
+ * Performs a session key rotation if one has been requested via lf_refresh_key().
+ *
+ * When rekey_requested is set, this function:
+ *   1. Fetches a new session key from the SST auth server (get_new_session_key), storing it
+ *      as pending_key on the federate's RTI connection.
+ *   2. Sends a MSG_TYPE_SST_KEY_REFRESH_REQUEST to the RTI carrying the new key's ID, then
+ *      blocks on lf_rekey_completed until the RTI acknowledges.
+ *   3. Returns once handle_rti_session_key_ack has swapped the key and signaled completion.
+ *
+ * The outbound mutex is held across the send and wait to serialize this handshake with any
+ * other outbound writes.
+ */
 #ifdef COMM_TYPE_SST
 void _lf_check_and_perform_rekey(void){
   if(_fed.rekey_requested){
-    // environment_t* env;
-    // _lf_get_environments(&env);
-    // tag_t tag = env->current_tag;
-    // #ifdef LF_TRACE
-    // call_tracepoint(user_event, _sst_rekey_start_desc, tag, -1, -1, -1, NULL, NULL, 0);
-    // #endif
     lf_print("Acquiring new session key and sending it to RTI");
     get_new_session_key(_fed.net_to_RTI);
 
+    // Hold the outbound mutex while sending the request and waiting for the RTI's ACK.
+    // lf_rekey_completed is signaled by handle_rti_session_key_ack once the new key is
+    // active, at which point this thread wakes, releases the mutex, and returns.
     LF_MUTEX_LOCK(&lf_outbound_net_mutex);
     send_key_refresh_request(_fed.net_to_RTI, MSG_TYPE_SST_KEY_REFRESH_REQUEST);
-    lf_rekey_in_progress = true;
     LF_COND_WAIT(&lf_rekey_completed);
     LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
-    // #ifdef LF_TRACE
-    // call_tracepoint(user_event, _sst_rekey_end_desc, tag, -1, -1, -1, NULL, NULL, 0);
-    // #endif
+
     _fed.rekey_requested = false;
   }
 }
 #endif
 
 /**
- * When a message of type MSG_TYPE_SST_REFRESH_ACK arrives on the listner thread for RTI
- * this function is called to compare the received key id with the key id of the pending key
- * for the federate instance. On a match the current key is swapped with the pending key
- * and a broadcast signal is sent to alert the threads that rekey is complete and now threads 
- * can write to the socket. 
+ * Handles a MSG_TYPE_SST_KEY_ACK message received from the RTI on the listener thread.
+ * This is the final step of the key rotation handshake, running concurrently with
+ * _lf_check_and_perform_rekey() which is blocked waiting on lf_rekey_completed.
+ *
+ * Reads the 8-byte key ID from the RTI and verifies it matches the pending key that was
+ * requested. On a match, swaps the pending key into the active session key slot, then
+ * broadcasts lf_rekey_completed to wake _lf_check_and_perform_rekey(
  */
 void handle_rti_session_key_ack(net_abstraction_t net_abs, unsigned char* buffer){
   unsigned char key_id[SESSION_KEY_ID_SIZE];
@@ -2755,7 +2757,6 @@ void handle_rti_session_key_ack(net_abstraction_t net_abs, unsigned char* buffer
 
   swap_to_pending_key(net_abs);
   LF_MUTEX_LOCK(&lf_outbound_net_mutex);
-  lf_rekey_in_progress = false;
   LF_COND_BROADCAST(&lf_rekey_completed);
   LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
   lf_print("Key ID match in ACK");

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -37,6 +37,11 @@
 #include <openssl/hmac.h> // For HMAC-based authentication of federates.
 #endif
 
+// Global variables for synchronizing read and write when session key is being refreshed
+#ifdef COMM_TYPE_SST
+lf_cond_t lf_rekey_completed;
+static bool lf_rekey_in_progress = false;
+#endif
 // Global variables defined in tag.c:
 extern instant_t start_time;
 
@@ -133,6 +138,12 @@ static void send_tag(unsigned char type, tag_t tag) {
   // Trace the event when tracing is enabled
   tracepoint_federate_to_rti(event_type, _lf_my_fed_id, &tag);
   LF_MUTEX_LOCK(&lf_outbound_net_mutex);
+  #ifdef COMM_TYPE_SST
+  // Waits until the rekey in progress is complete before sending any more writes 
+  while(lf_rekey_in_progress){
+    LF_COND_WAIT(&lf_rekey_completed);
+  }
+  #endif
   write_to_net_fail_on_error(_fed.net_to_RTI, bytes_to_write, buffer, &lf_outbound_net_mutex,
                              "Failed to send tag " PRINTF_TAG " to the RTI.", tag.time - start_time, tag.microstep);
   LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
@@ -2545,6 +2556,9 @@ int lf_send_tagged_message(environment_t* env, interval_t additional_delay, int 
     }
   }
   LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
+  #ifdef COMM_TYPE_SST
+  _lf_check_and_perform_rekey();
+  #endif
   return result;
 }
 
@@ -2579,12 +2593,21 @@ void lf_synchronize_with_other_federates(void) {
   _lf_get_environments(&top_level_env);
   LF_COND_INIT(&lf_port_status_changed, &top_level_env->mutex);
 
+  #ifdef COMM_TYPE_SST
+  LF_COND_INIT(&lf_rekey_completed, &lf_outbound_net_mutex);
+  #endif
+
   LF_PRINT_DEBUG("Synchronizing with other federates.");
 
   // Reset the start time to the coordinated start time for all federates.
   // Note that this does not grant execution to this federate.
   start_time = get_start_time_from_rti(lf_time_physical());
   lf_tracing_set_start_time(start_time);
+
+  // #if defined(COMM_TYPE_SST) && defined(LF_TRACE)
+  // _lf_register_trace_event(_sst_rekey_start_desc, NULL, trace_user, _sst_rekey_start_desc);
+  // _lf_register_trace_event(_sst_rekey_end_desc,   NULL, trace_user, _sst_rekey_end_desc);
+  // #endif
 
   // Start a thread to listen for incoming messages from the RTI.
   // @note Up until this point, the federate has been listening for messages
@@ -2690,17 +2713,38 @@ void lf_refresh_key(void){
   _fed.rekey_requested = true;
 }
 
+#ifdef COMM_TYPE_SST
 void _lf_check_and_perform_rekey(void){
   if(_fed.rekey_requested){
+    // environment_t* env;
+    // _lf_get_environments(&env);
+    // tag_t tag = env->current_tag;
+    // #ifdef LF_TRACE
+    // call_tracepoint(user_event, _sst_rekey_start_desc, tag, -1, -1, -1, NULL, NULL, 0);
+    // #endif
+    lf_print("Acquiring new session key and sending it to RTI");
     get_new_session_key(_fed.net_to_RTI);
 
     LF_MUTEX_LOCK(&lf_outbound_net_mutex);
     send_key_refresh_request(_fed.net_to_RTI, MSG_TYPE_SST_KEY_REFRESH_REQUEST);
+    lf_rekey_in_progress = true;
+    LF_COND_WAIT(&lf_rekey_completed);
     LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
+    // #ifdef LF_TRACE
+    // call_tracepoint(user_event, _sst_rekey_end_desc, tag, -1, -1, -1, NULL, NULL, 0);
+    // #endif
     _fed.rekey_requested = false;
   }
 }
+#endif
 
+/**
+ * When a message of type MSG_TYPE_SST_REFRESH_ACK arrives on the listner thread for RTI
+ * this function is called to compare the received key id with the key id of the pending key
+ * for the federate instance. On a match the current key is swapped with the pending key
+ * and a broadcast signal is sent to alert the threads that rekey is complete and now threads 
+ * can write to the socket. 
+ */
 void handle_rti_session_key_ack(net_abstraction_t net_abs, unsigned char* buffer){
   unsigned char key_id[SESSION_KEY_ID_SIZE];
   read_from_net_fail_on_error(net_abs, SESSION_KEY_ID_SIZE, key_id, NULL);
@@ -2710,6 +2754,10 @@ void handle_rti_session_key_ack(net_abstraction_t net_abs, unsigned char* buffer
   }
 
   swap_to_pending_key(net_abs);
-  LF_PRINT_DEBUG("Key ID match in ACK");
+  LF_MUTEX_LOCK(&lf_outbound_net_mutex);
+  lf_rekey_in_progress = false;
+  LF_COND_BROADCAST(&lf_rekey_completed);
+  LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
+  lf_print("Key ID match in ACK");
 }
 #endif // FEDERATED

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -2597,11 +2597,6 @@ void lf_synchronize_with_other_federates(void) {
   start_time = get_start_time_from_rti(lf_time_physical());
   lf_tracing_set_start_time(start_time);
 
-  // #if defined(COMM_TYPE_SST) && defined(LF_TRACE)
-  // _lf_register_trace_event(_sst_rekey_start_desc, NULL, trace_user, _sst_rekey_start_desc);
-  // _lf_register_trace_event(_sst_rekey_end_desc,   NULL, trace_user, _sst_rekey_end_desc);
-  // #endif
-
   // Start a thread to listen for incoming messages from the RTI.
   // @note Up until this point, the federate has been listening for messages
   //  from the RTI in a sequential manner in the main thread. From now on, a
@@ -2694,31 +2689,13 @@ instant_t lf_wait_until_time(tag_t tag) {
 }
 #endif // FEDERATED_DECENTRALIZED
 
-/**
- * Request a session-key refresh for federated communication.
- *
- * This is a reactor-level callable API that does NOT perform any network I/O.
- * It only sets a flag indicating that a rekey/refresh should be performed later
- * by the federated networking/runtime layer at a safe point (outside reaction execution).
- */
+
 void lf_refresh_key(void){
   lf_print("DEBUG: Rekey Requested");
   _fed.rekey_requested = true;
 }
 
-/**
- * Performs a session key rotation if one has been requested via lf_refresh_key().
- *
- * When rekey_requested is set, this function:
- *   1. Fetches a new session key from the SST auth server (get_new_session_key), storing it
- *      as pending_key on the federate's RTI connection.
- *   2. Sends a MSG_TYPE_SST_KEY_REFRESH_REQUEST to the RTI carrying the new key's ID, then
- *      blocks on lf_rekey_completed until the RTI acknowledges.
- *   3. Returns once handle_rti_session_key_ack has swapped the key and signaled completion.
- *
- * The outbound mutex is held across the send and wait to serialize this handshake with any
- * other outbound writes.
- */
+
 #ifdef COMM_TYPE_SST
 void _lf_check_and_perform_rekey(void){
   if(_fed.rekey_requested){
@@ -2736,17 +2713,7 @@ void _lf_check_and_perform_rekey(void){
     _fed.rekey_requested = false;
   }
 }
-#endif
 
-/**
- * Handles a MSG_TYPE_SST_KEY_ACK message received from the RTI on the listener thread.
- * This is the final step of the key rotation handshake, running concurrently with
- * _lf_check_and_perform_rekey() which is blocked waiting on lf_rekey_completed.
- *
- * Reads the 8-byte key ID from the RTI and verifies it matches the pending key that was
- * requested. On a match, swaps the pending key into the active session key slot, then
- * broadcasts lf_rekey_completed to wake _lf_check_and_perform_rekey(
- */
 void handle_rti_session_key_ack(net_abstraction_t net_abs, unsigned char* buffer){
   unsigned char key_id[SESSION_KEY_ID_SIZE];
   read_from_net_fail_on_error(net_abs, SESSION_KEY_ID_SIZE, key_id, NULL);
@@ -2761,4 +2728,5 @@ void handle_rti_session_key_ack(net_abstraction_t net_abs, unsigned char* buffer
   LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
   lf_print("Key ID match in ACK");
 }
+#endif
 #endif // FEDERATED

--- a/core/threaded/scheduler_NP.c
+++ b/core/threaded/scheduler_NP.c
@@ -180,6 +180,9 @@ static void _lf_scheduler_try_advance_tag_and_distribute(lf_scheduler_t* schedul
         break;
       }
       LF_MUTEX_UNLOCK(&env->mutex);
+      #ifdef COMM_TYPE_SST
+        _lf_check_and_perform_rekey();
+      #endif
     }
 
     if (_lf_sched_distribute_ready_reactions(scheduler) > 0) {

--- a/core/threaded/scheduler_NP.c
+++ b/core/threaded/scheduler_NP.c
@@ -180,9 +180,6 @@ static void _lf_scheduler_try_advance_tag_and_distribute(lf_scheduler_t* schedul
         break;
       }
       LF_MUTEX_UNLOCK(&env->mutex);
-      #ifdef COMM_TYPE_SST
-        _lf_check_and_perform_rekey();
-      #endif
     }
 
     if (_lf_sched_distribute_ready_reactions(scheduler) > 0) {

--- a/include/core/federated/federate.h
+++ b/include/core/federated/federate.h
@@ -569,17 +569,41 @@ void lf_stall_advance_level_federation_locked(size_t level);
 void lf_synchronize_with_other_federates(void);
 
 /**
- * @brief Refresh session keys for all the federates it is connected to
+ * @brief Request a session key refresh for all SST connections.
+ *
+ * Sets the rekey_requested flag, signaling that a key rotation should
+ * be performed. The actual handshake is deferred and handled asynchronously
+ * by _lf_check_and_perform_rekey() at a safe point outside of reaction
+ * execution. Safe to call from within a reaction.
+ *
+ * Only has effect when COMM_TYPE_SST is configured with centralized coordination.
  */
 void lf_refresh_key(void);
 
 /**
- * TODO(Kushal) write comments
+ * @brief Check if a key refresh has been requested and perform the handshake if so.
+ *
+ * If rekey_requested is set, fetches a new session key from the SST auth
+ * server, sends a MSG_TYPE_SST_KEY_REFRESH_REQUEST to the RTI containing
+ * the new key ID, and blocks until the RTI acknowledges via
+ * handle_rti_session_key_ack(). Resets rekey_requested upon completion.
+ *
+ * This function is called internally at a safe point in the federate's
+ * execution loop and should not be called directly by user code.
  */
 void _lf_check_and_perform_rekey(void);
 
 /**
- * 
+ * @brief Handle a session key acknowledgment from the RTI.
+ *
+ * Called when the RTI responds with MSG_TYPE_SST_KEY_ACK during a key
+ * rotation handshake. Reads the key ID from the message, verifies it
+ * matches the pending key, swaps the pending key into active use, resets
+ * sequence counters, and signals lf_rekey_completed to unblock
+ * _lf_check_and_perform_rekey().
+ *
+ * @param net_abs The network abstraction for the RTI connection.
+ * @param buffer The buffer containing the incoming message.
  */
 void handle_rti_session_key_ack(net_abstraction_t net_abs, unsigned char* buffer);
 

--- a/include/core/federated/federate.h
+++ b/include/core/federated/federate.h
@@ -192,6 +192,11 @@ typedef struct federate_instance_t {
    */
   instant_t min_delay_from_physical_action_to_federate_output;
 
+  /**
+   * Indicator that this federate needs to refresh its session key/keys for its connections
+   */
+  bool rekey_requested;
+
 #ifdef FEDERATED_DECENTRALIZED
   /**
    * Thread responsible for setting ports to absent by an STAA offset if they
@@ -562,6 +567,21 @@ void lf_stall_advance_level_federation_locked(size_t level);
  * time. It starts a thread to listen for messages from the RTI.
  */
 void lf_synchronize_with_other_federates(void);
+
+/**
+ * @brief Refresh session keys for all the federates it is connected to
+ */
+void lf_refresh_key(void);
+
+/**
+ * TODO(Kushal) write comments
+ */
+void _lf_check_and_perform_rekey(void);
+
+/**
+ * 
+ */
+void handle_rti_session_key_ack(net_abstraction_t net_abs, unsigned char* buffer);
 
 /**
  * @brief Update the max level allowed to advance (MLAA).

--- a/include/core/federated/federate.h
+++ b/include/core/federated/federate.h
@@ -19,6 +19,7 @@
 #define FEDERATE_H
 
 #include <stdbool.h>
+#include <stdatomic.h>
 
 #include "tag.h"
 #include "lf_types.h"
@@ -195,7 +196,7 @@ typedef struct federate_instance_t {
   /**
    * Indicator that this federate needs to refresh its session key/keys for its connections
    */
-  bool rekey_requested;
+  _Atomic bool rekey_requested;
 
 #ifdef FEDERATED_DECENTRALIZED
   /**
@@ -607,6 +608,17 @@ void _lf_check_and_perform_rekey(void);
  */
 void handle_rti_session_key_ack(net_abstraction_t net_abs, unsigned char* buffer);
 
+/**
+ * @brief Handle a session key refresh request from a federate
+ * 
+ * Called when a federate sends a key refresh request with MSG_TYPE__SST_KEY_REFRESH_REQUEST
+ * to its outbound federates. Reads the key ID from the message, fetches the corresponding key
+ * from the auth and stores it in the pending key field. Responds back to the federate who initiated the request with
+ * MSG_TYPE_SST_KEY_ACK and then swaps it current key with the key stored in the pending key field
+ * 
+ * @param net_abs The network abstraction for the RTI connection.
+ */
+void handle_key_refresh_request(net_abstraction_t net_abs);
 /**
  * @brief Update the max level allowed to advance (MLAA).
  * @ingroup Federated

--- a/network/api/lf_sst_support.h
+++ b/network/api/lf_sst_support.h
@@ -11,7 +11,7 @@ typedef struct sst_priv_t {
   unsigned char buffer[MAX_SECURE_COMM_MSG_LENGTH];
   size_t buf_filled;
   size_t buf_off; 
-  session_key_t* pending_key;
+  session_key_t pending_key;
 } sst_priv_t;
 
 typedef struct sst_connection_params_t {

--- a/network/api/lf_sst_support.h
+++ b/network/api/lf_sst_support.h
@@ -11,6 +11,7 @@ typedef struct sst_priv_t {
   unsigned char buffer[MAX_SECURE_COMM_MSG_LENGTH];
   size_t buf_filled;
   size_t buf_off; 
+  session_key_t* pending_key;
 } sst_priv_t;
 
 typedef struct sst_connection_params_t {

--- a/network/api/net_abstraction.h
+++ b/network/api/net_abstraction.h
@@ -309,4 +309,14 @@ void set_server_port(net_abstraction_t net_abs, int32_t port);
  */
 void set_server_hostname(net_abstraction_t net_abs, const char* hostname);
 
+void get_new_session_key(net_abstraction_t net_abs);
+
+void send_key_refresh_request(net_abstraction_t net_abs, unsigned char msg_type);
+
+void fetch_pending_session_key(net_abstraction_t net_abs, unsigned char* key_id);
+
+bool verify_pending_key_id(net_abstraction_t net_abs, unsigned char* key_id);
+
+void swap_to_pending_key(net_abstraction_t net_abs);
+
 #endif /* NET_ABSTRACTION_H */

--- a/network/api/net_abstraction.h
+++ b/network/api/net_abstraction.h
@@ -309,14 +309,65 @@ void set_server_port(net_abstraction_t net_abs, int32_t port);
  */
 void set_server_hostname(net_abstraction_t net_abs, const char* hostname);
 
+/**
+ * @brief Fetches a fresh session key from the SST auth server and stores it as pending_key.
+ * @ingroup Network
+ *
+ * Called by _lf_check_and_perform_rekey() on the federate before sending a key refresh
+ * request. The key is stored by value so it survives the free of the returned key list.
+ *
+ * @param net_abs The network abstraction whose pending_key will be updated.
+ */
 void get_new_session_key(net_abstraction_t net_abs);
 
+/**
+ * @brief Sends a key refresh message containing the pending key ID to the peer.
+ * @ingroup Network
+ *
+ * Used in both directions: federate sends MSG_TYPE_SST_KEY_REFRESH_REQUEST to initiate
+ * rotation; RTI sends MSG_TYPE_SST_KEY_ACK to confirm. The format is identical: 1 byte
+ * msg_type + 8 bytes key ID.
+ *
+ * @param net_abs  The network abstraction to send from.
+ * @param msg_type MSG_TYPE_SST_KEY_REFRESH_REQUEST or MSG_TYPE_SST_KEY_ACK.
+ */
 void send_key_refresh_request(net_abstraction_t net_abs, unsigned char msg_type);
 
+/**
+ * @brief Looks up a session key by ID in the SST context and stores it as pending_key.
+ * @ingroup Network
+ *
+ * Called on the RTI in handle_key_refresh_request() after receiving a refresh request.
+ * The RTI uses the key ID sent by the federate to locate the same key locally, so both
+ * sides can swap to it after the ACK.
+ *
+ * @param net_abs The network abstraction whose pending_key will be set.
+ * @param key_id  The 8-byte key ID received from the peer.
+ */
 void fetch_pending_session_key(net_abstraction_t net_abs, unsigned char* key_id);
 
+/**
+ * @brief Returns true if key_id matches the pending key's ID.
+ * @ingroup Network
+ *
+ * Called by handle_rti_session_key_ack() on the federate to verify the RTI's ACK refers
+ * to the key that was requested. A mismatch means the ACK is ignored and no swap occurs.
+ *
+ * @param net_abs The network abstraction holding pending_key.
+ * @param key_id  The 8-byte key ID from the peer's message.
+ */
 bool verify_pending_key_id(net_abstraction_t net_abs, unsigned char* key_id);
 
+/**
+ * @brief Activates pending_key as the current session key and resets sequence counters.
+ * @ingroup Network
+ *
+ * Called after both sides confirm the key ID: on the federate in handle_rti_session_key_ack()
+ * and on the RTI in handle_key_refresh_request(). Resetting sequence counters to zero ensures
+ * the new key starts from a clean state.
+ *
+ * @param net_abs The network abstraction to update.
+ */
 void swap_to_pending_key(net_abstraction_t net_abs);
 
 #endif /* NET_ABSTRACTION_H */

--- a/network/api/net_common.h
+++ b/network/api/net_common.h
@@ -628,6 +628,23 @@
  */
 #define MSG_TYPE_P2P_TAGGED_MESSAGE 18
 
+/**
+ * @brief Byte identifying a key refresh request.
+ * @ingroup Network
+ * 
+ * Used to request that the perr should switch to a new session key.
+ */
+#define MSG_TYPE_SST_KEY_REFRESH_REQUEST 110
+
+/**
+ * @brief Byte identifying a key refresh acknowledgement.
+ * @ingroup Network
+ * 
+ * Sent in response to MSG_TYPE_SST_KEY_REFRESH_REQUEST to confirm the peer is ready
+ * to use the new session key.
+ */
+#define MSG_TYPE_SST_KEY_ACK 111
+
 ////////////////////////////////////////////////
 /**
  * @brief Physical clock synchronization messages according to PTP.

--- a/network/api/net_common.h
+++ b/network/api/net_common.h
@@ -632,7 +632,7 @@
  * @brief Byte identifying a key refresh request.
  * @ingroup Network
  * 
- * Used to request that the perr should switch to a new session key.
+ * Used to request that the peer should switch to a new session key.
  */
 #define MSG_TYPE_SST_KEY_REFRESH_REQUEST 110
 

--- a/network/impl/src/lf_sst_support.c
+++ b/network/impl/src/lf_sst_support.c
@@ -80,7 +80,8 @@ net_abstraction_t accept_net(net_abstraction_t server_chan) {
     if (get_peer_address(client_priv->socket_priv) != 0) {
       lf_print_error("Failed to save peer address.");
     }
-
+    
+    client_priv->sst_ctx = serv_priv->sst_ctx;
     // TODO: Do we need to copy sst_ctx form server_chan to fed_chan?
     session_key_list_t* s_key_list = init_empty_session_key_list();
     SST_session_ctx_t* session_ctx =
@@ -316,4 +317,53 @@ void set_server_port(net_abstraction_t net_abs, int32_t port) {
 void set_server_hostname(net_abstraction_t net_abs, const char* hostname) {
   sst_priv_t* priv = (sst_priv_t*)net_abs;
   memcpy(priv->socket_priv->server_hostname, hostname, INET_ADDRSTRLEN);
+}
+
+void get_new_session_key(net_abstraction_t net_abs){
+  LF_ASSERT_NON_NULL(net_abs);
+  LF_PRINT_LOG("New session key acquired");
+  sst_priv_t* priv = (sst_priv_t *)net_abs;
+  session_key_list_t* new_list = get_session_key(priv->sst_ctx, NULL);
+  priv->pending_key = &new_list->s_key[0];
+  // LF_PRINT_DEBUG("New session key acquired");
+}
+
+void send_key_refresh_request(net_abstraction_t net_abs, unsigned char msg_type){
+  LF_ASSERT_NON_NULL(net_abs);
+  sst_priv_t* priv = (sst_priv_t *)net_abs;
+  
+  unsigned char buffer[1+SESSION_KEY_ID_SIZE];
+  buffer[0] = msg_type;
+  memcpy(&buffer[1], priv->pending_key->key_id, SESSION_KEY_ID_SIZE);
+
+  int result = write_to_net_close_on_error(net_abs, 9, buffer);
+  LF_PRINT_DEBUG("Result: %d", result);
+}
+
+void fetch_pending_session_key(net_abstraction_t net_abs, unsigned char* key_id){
+  LF_ASSERT_NON_NULL(net_abs);
+  sst_priv_t* priv = (sst_priv_t *)net_abs;
+  session_key_list_t* existing = init_empty_session_key_list();
+  session_key_t* new_key = get_session_key_by_ID(key_id, priv->sst_ctx, existing);
+  if(new_key != NULL){
+    priv->pending_key = new_key;
+  }
+  //Todo: check if the key is still there
+  free_session_key_list_t(existing);
+
+}
+
+bool verify_pending_key_id(net_abstraction_t net_abs, unsigned char* key_id){
+  LF_ASSERT_NON_NULL(net_abs);
+  sst_priv_t* priv = (sst_priv_t *)net_abs;
+  return memcmp(priv->pending_key->key_id, key_id, SESSION_KEY_ID_SIZE);
+}
+
+void swap_to_pending_key(net_abstraction_t net_abs){
+  LF_ASSERT_NON_NULL(net_abs);
+  sst_priv_t* priv = (sst_priv_t *)net_abs;
+  priv->session_ctx->s_key = *priv->pending_key;
+  priv->session_ctx->received_seq_num = 0;
+  priv->session_ctx->sent_seq_num = 0;
+  priv->pending_key = NULL;
 }

--- a/network/impl/src/lf_sst_support.c
+++ b/network/impl/src/lf_sst_support.c
@@ -319,7 +319,11 @@ void set_server_hostname(net_abstraction_t net_abs, const char* hostname) {
   memcpy(priv->socket_priv->server_hostname, hostname, INET_ADDRSTRLEN);
 }
 
-
+/**
+ * Called by _lf_check_and_perform_rekey() on the federate side before initiating a key
+ * rotation. Contacts the SST auth server to obtain a fresh session key and stores it in
+ * pending_key by value, so it remains valid after new_list is freed.
+ */
 void get_new_session_key(net_abstraction_t net_abs){
   LF_ASSERT_NON_NULL(net_abs);
   sst_priv_t* priv = (sst_priv_t *)net_abs;
@@ -330,8 +334,12 @@ void get_new_session_key(net_abstraction_t net_abs){
 }
 
 /**
- * 
+ * Sends a key refresh message to the peer: 1 byte msg_type followed by the 8-byte pending
+ * key ID. Used in both directions of the handshake:
+ *   Federate -> RTI: called with MSG_TYPE_SST_KEY_REFRESH_REQUEST to start a key rotation.
+ *   RTI -> Federate: called with MSG_TYPE_SST_KEY_ACK to confirm the new key is accepted.
  */
+
 void send_key_refresh_request(net_abstraction_t net_abs, unsigned char msg_type){
   LF_ASSERT_NON_NULL(net_abs);
   sst_priv_t* priv = (sst_priv_t *)net_abs;
@@ -344,6 +352,12 @@ void send_key_refresh_request(net_abstraction_t net_abs, unsigned char msg_type)
   LF_PRINT_DEBUG("Result: %d", result);
 }
 
+/**
+ * Called on the RTI side in handle_key_refresh_request() when a MSG_TYPE_SST_KEY_REFRESH_REQUEST
+ * arrives. The federate has already fetched the new key from the auth server and sent its ID;
+ * this function retrieves the matching key from the RTI's SST context and stores it as
+ * pending_key.
+ */
 void fetch_pending_session_key(net_abstraction_t net_abs, unsigned char* key_id){
   LF_ASSERT_NON_NULL(net_abs);
   sst_priv_t* priv = (sst_priv_t *)net_abs;
@@ -352,22 +366,31 @@ void fetch_pending_session_key(net_abstraction_t net_abs, unsigned char* key_id)
   if(new_key != NULL){
     priv->pending_key = *new_key;
   }
-  //Todo: check if the key is still there
+
   free_session_key_list_t(existing);
 
 }
 
+/**
+ * Called by handle_rti_session_key_ack() on the federate side to confirm the key ID in the
+ * RTI's ACK refers to the same key that was requested. Returns false if they don't match.
+ */
 bool verify_pending_key_id(net_abstraction_t net_abs, unsigned char* key_id){
   LF_ASSERT_NON_NULL(net_abs);
   sst_priv_t* priv = (sst_priv_t *)net_abs;
   return memcmp(priv->pending_key.key_id, key_id, SESSION_KEY_ID_SIZE) == 0;
 }
 
+/**
+ * Replaces the active session key with pending_key and resets both sequence counters to zero
+ * so encryption restarts cleanly with the new key. Called on the federate side in
+ * handle_rti_session_key_ack() and on the RTI side in handle_key_refresh_request(), after
+ * both sides have confirmed the key ID matches.
+ */
 void swap_to_pending_key(net_abstraction_t net_abs){
   LF_ASSERT_NON_NULL(net_abs);
   sst_priv_t* priv = (sst_priv_t *)net_abs;
   priv->session_ctx->s_key = priv->pending_key;
   priv->session_ctx->received_seq_num = 0;
   priv->session_ctx->sent_seq_num = 0;
-  // priv->pending_key = memset(&priv->pending_key, 0, sizeof(session_key_t));
 }

--- a/network/impl/src/lf_sst_support.c
+++ b/network/impl/src/lf_sst_support.c
@@ -319,22 +319,26 @@ void set_server_hostname(net_abstraction_t net_abs, const char* hostname) {
   memcpy(priv->socket_priv->server_hostname, hostname, INET_ADDRSTRLEN);
 }
 
+
 void get_new_session_key(net_abstraction_t net_abs){
   LF_ASSERT_NON_NULL(net_abs);
-  LF_PRINT_LOG("New session key acquired");
   sst_priv_t* priv = (sst_priv_t *)net_abs;
   session_key_list_t* new_list = get_session_key(priv->sst_ctx, NULL);
-  priv->pending_key = &new_list->s_key[0];
-  // LF_PRINT_DEBUG("New session key acquired");
+  priv->pending_key = new_list->s_key[0];
+  free_session_key_list_t(new_list);
+  lf_print("DEBUG: Session key acquired on the federate side");
 }
 
+/**
+ * 
+ */
 void send_key_refresh_request(net_abstraction_t net_abs, unsigned char msg_type){
   LF_ASSERT_NON_NULL(net_abs);
   sst_priv_t* priv = (sst_priv_t *)net_abs;
   
   unsigned char buffer[1+SESSION_KEY_ID_SIZE];
   buffer[0] = msg_type;
-  memcpy(&buffer[1], priv->pending_key->key_id, SESSION_KEY_ID_SIZE);
+  memcpy(&buffer[1], priv->pending_key.key_id, SESSION_KEY_ID_SIZE);
 
   int result = write_to_net_close_on_error(net_abs, 9, buffer);
   LF_PRINT_DEBUG("Result: %d", result);
@@ -346,7 +350,7 @@ void fetch_pending_session_key(net_abstraction_t net_abs, unsigned char* key_id)
   session_key_list_t* existing = init_empty_session_key_list();
   session_key_t* new_key = get_session_key_by_ID(key_id, priv->sst_ctx, existing);
   if(new_key != NULL){
-    priv->pending_key = new_key;
+    priv->pending_key = *new_key;
   }
   //Todo: check if the key is still there
   free_session_key_list_t(existing);
@@ -356,14 +360,14 @@ void fetch_pending_session_key(net_abstraction_t net_abs, unsigned char* key_id)
 bool verify_pending_key_id(net_abstraction_t net_abs, unsigned char* key_id){
   LF_ASSERT_NON_NULL(net_abs);
   sst_priv_t* priv = (sst_priv_t *)net_abs;
-  return memcmp(priv->pending_key->key_id, key_id, SESSION_KEY_ID_SIZE);
+  return memcmp(priv->pending_key.key_id, key_id, SESSION_KEY_ID_SIZE) == 0;
 }
 
 void swap_to_pending_key(net_abstraction_t net_abs){
   LF_ASSERT_NON_NULL(net_abs);
   sst_priv_t* priv = (sst_priv_t *)net_abs;
-  priv->session_ctx->s_key = *priv->pending_key;
+  priv->session_ctx->s_key = priv->pending_key;
   priv->session_ctx->received_seq_num = 0;
   priv->session_ctx->sent_seq_num = 0;
-  priv->pending_key = NULL;
+  // priv->pending_key = memset(&priv->pending_key, 0, sizeof(session_key_t));
 }


### PR DESCRIPTION
This PR introduces a new API function, `lf_refresh_key()`, to rotate SST (Secure Signed Transport) session keys at runtime for federates using either centralized or decentralized coordination.

The current SST model negotiates session keys at startup but provides no mechanism for rotating them during execution. For long-running federated programs, static session keys present a security risk. lf_refresh_key() allows reactions to request a coordinated key refresh during execution without blocking the calling reaction.

Use case: A distributed sensor network running for extended periods can trigger periodic key rotation via timer reactions to bound the impact of potential key compromise, or initiate an immediate refresh before transmitting sensitive data.

### How it works

`lf_refresh_key()` is non-blocking — calling it sets a rekey_requested flag and returns immediately. The actual handshake runs asynchronously at a safe point in the runtime by invoking _lf_check_and_perform_rekey() at the end of lf_send_tagged_message(). Key rotation is performed on-demand just before subsequent outbound traffic requires encryption. If no cross-federate messages are sent, deferring the refresh is intentional since no ciphertext is produced during that interval.

Depending on the coordination mode:
**Centralized coordination**: The federate requests a new key via the SST auth server and exchanges MSG_TYPE_SST_KEY_REFRESH_REQUEST (110) and MSG_TYPE_SST_KEY_ACK (111) messages with the RTI to synchronize key activation.
**Decentralized coordination**: Federates perform the refresh handshake directly within the peer-to-peer SST communication path, ensuring consistent key activation without relying on RTI-mediated coordination.

After verification of the new key ID, sequence counters are reset and communication resumes under the new session key.

Available when COMM_TYPE_SST is enabled.

### API

```
/**
 * @brief Request a session key refresh for all SST connections.
 * Sets a flag for asynchronous key rotation. Safe to call from reactions.
 * Only available when COMM_TYPE_SST is configured.
 */
void lf_refresh_key(void);

```
### Example
```

target C {
  coordination: centralized,
  comm-type: SST,
  sst-root-path: "/path/to/iotauth"
}

reactor Count {
  timer rekey_t(2 sec, 4 sec)

  // Rotates the SST session key every 4 seconds.
  reaction(rekey_t) {=
    lf_refresh_key();
  =}
}
```