### PR TITLE
Add lf_time_parse function to get a time from a numeric string and a units string.

### DIFF
--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -1099,9 +1099,15 @@ int process_args(int argc, const char* argv[]) {
     else if (strcmp(arg, "--ros-args") == 0) {
       // FIXME: Ignore ROS arguments for now
     } else {
+#ifdef FEDERATED
+      // In federated programs, arguments intended for other federates
+      // may be forwarded here. Skip them silently.
+      lf_print("Ignoring unrecognized command-line argument: %s. Assuming it is intended for another federate.", arg);
+#else
       lf_print_error("Unrecognized command-line argument: %s", arg);
       usage(argc, argv);
       return 0;
+#endif
     }
   }
   return 1;

--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -1021,39 +1021,11 @@ int process_args(int argc, const char* argv[]) {
       }
       const char* time_spec = argv[i++];
       const char* units = argv[i++];
-
-#if defined(PLATFORM_ARDUINO)
-      duration = atol(time_spec);
-#else
-      duration = atoll(time_spec);
-#endif
-
-      // A parse error returns 0LL, so check to see whether that is what is meant.
-      if (duration == 0LL && strncmp(time_spec, "0", 1) != 0) {
-        // Parse error.
-        lf_print_error("Invalid time value: %s", time_spec);
-        usage(argc, argv);
-        return 0;
-      }
-      if (strncmp(units, "sec", 3) == 0) {
-        duration = SEC(duration);
-      } else if (strncmp(units, "msec", 4) == 0) {
-        duration = MSEC(duration);
-      } else if (strncmp(units, "usec", 4) == 0) {
-        duration = USEC(duration);
-      } else if (strncmp(units, "nsec", 4) == 0) {
-        duration = NSEC(duration);
-      } else if (strncmp(units, "min", 3) == 0) {
-        duration = MINUTE(duration);
-      } else if (strncmp(units, "hour", 4) == 0) {
-        duration = HOUR(duration);
-      } else if (strncmp(units, "day", 3) == 0) {
-        duration = DAY(duration);
-      } else if (strncmp(units, "week", 4) == 0) {
-        duration = WEEK(duration);
-      } else {
-        // Invalid units.
-        lf_print_error("Invalid time units: %s", units);
+      int parse_result = lf_time_parse(time_spec, units, &duration);
+      if (parse_result != 0) {
+        lf_print_error(parse_result == -1
+            ? "Invalid time value: %s" : "Invalid time units: %s",
+            parse_result == -1 ? time_spec : units);
         usage(argc, argv);
         return 0;
       }

--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -996,7 +996,6 @@ const char** default_argv = NULL;
  * @return 1 if the arguments processed successfully, 0 otherwise.
  */
 int process_args(int argc, const char* argv[]) {
-#if !defined(NO_CLI)
   int i = 1;
   while (i < argc) {
     const char* arg = argv[i++];
@@ -1105,7 +1104,6 @@ int process_args(int argc, const char* argv[]) {
       return 0;
     }
   }
-#endif
   return 1;
 }
 

--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -954,9 +954,11 @@ void schedule_output_reactions(environment_t* env, reaction_t* reaction, int wor
 
 /**
  * Print a usage message.
- * TODO: This is not necessary for NO_CLI
  */
 void usage(int argc, const char* argv[]) {
+#if defined(NO_CLI)
+  printf("\nNo command-line arguments are supported.\n");
+#else
   printf("\nCommand-line arguments: \n\n");
   printf("  -f, --fast [true | false]\n");
   printf("   Whether to wait for physical time to match logical time.\n\n");
@@ -975,7 +977,7 @@ void usage(int argc, const char* argv[]) {
   printf("  -l\n");
   printf("   Send stdout to individual log files for each federate.\n\n");
 #endif
-
+#endif
   printf("Command given:\n");
   for (int i = 0; i < argc; i++) {
     printf("%s ", argv[i]);
@@ -992,9 +994,9 @@ const char** default_argv = NULL;
  * Process the command-line arguments. If the command line arguments are not
  * understood, then print a usage message and return 0. Otherwise, return 1.
  * @return 1 if the arguments processed successfully, 0 otherwise.
- * TODO: Not necessary for NO_CLI
  */
 int process_args(int argc, const char* argv[]) {
+#if !defined(NO_CLI)
   int i = 1;
   while (i < argc) {
     const char* arg = argv[i++];
@@ -1023,9 +1025,8 @@ int process_args(int argc, const char* argv[]) {
       const char* units = argv[i++];
       int parse_result = lf_time_parse(time_spec, units, &duration);
       if (parse_result != 0) {
-        lf_print_error(parse_result == -1
-            ? "Invalid time value: %s" : "Invalid time units: %s",
-            parse_result == -1 ? time_spec : units);
+        lf_print_error(parse_result == -1 ? "Invalid time value: %s" : "Invalid time units: %s",
+                       parse_result == -1 ? time_spec : units);
         usage(argc, argv);
         return 0;
       }
@@ -1104,6 +1105,7 @@ int process_args(int argc, const char* argv[]) {
       return 0;
     }
   }
+#endif
   return 1;
 }
 

--- a/core/tag.c
+++ b/core/tag.c
@@ -10,6 +10,7 @@
 #include <assert.h>
 #include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "tag.h"
@@ -312,4 +313,33 @@ size_t lf_comma_separated_time(char* buffer, instant_t time) {
     result += 4;
   }
   return result;
+}
+
+int lf_time_parse(const char* time_str, const char* units_str, interval_t* result) {
+  char* end;
+  long long value = strtoll(time_str, &end, 10);
+  if (*end != '\0') {
+    return -1;
+  }
+  if (strncmp(units_str, "nsec", 4) == 0 || strcmp(units_str, "ns") == 0) {
+    *result = NSEC(value);
+  } else if (strncmp(units_str, "usec", 4) == 0 || strcmp(units_str, "us") == 0) {
+    *result = USEC(value);
+  } else if (strncmp(units_str, "msec", 4) == 0 || strcmp(units_str, "ms") == 0) {
+    *result = MSEC(value);
+  } else if (strncmp(units_str, "second", 6) == 0 || strncmp(units_str, "sec", 3) == 0
+             || strcmp(units_str, "s") == 0) {
+    *result = SEC(value);
+  } else if (strncmp(units_str, "minute", 6) == 0 || strncmp(units_str, "min", 3) == 0) {
+    *result = MINUTE(value);
+  } else if (strncmp(units_str, "hour", 4) == 0) {
+    *result = HOUR(value);
+  } else if (strncmp(units_str, "day", 3) == 0) {
+    *result = DAY(value);
+  } else if (strncmp(units_str, "week", 4) == 0) {
+    *result = WEEK(value);
+  } else {
+    return -2;
+  }
+  return 0;
 }

--- a/core/tag.c
+++ b/core/tag.c
@@ -315,6 +315,7 @@ size_t lf_comma_separated_time(char* buffer, instant_t time) {
   return result;
 }
 
+#if !defined(NO_CLI)
 int lf_time_parse(const char* time_str, const char* units_str, interval_t* result) {
   char* end;
   long long value = strtoll(time_str, &end, 10);
@@ -342,3 +343,4 @@ int lf_time_parse(const char* time_str, const char* units_str, interval_t* resul
   }
   return 0;
 }
+#endif // !NO_CLI

--- a/core/tag.c
+++ b/core/tag.c
@@ -327,8 +327,7 @@ int lf_time_parse(const char* time_str, const char* units_str, interval_t* resul
     *result = USEC(value);
   } else if (strncmp(units_str, "msec", 4) == 0 || strcmp(units_str, "ms") == 0) {
     *result = MSEC(value);
-  } else if (strncmp(units_str, "second", 6) == 0 || strncmp(units_str, "sec", 3) == 0
-             || strcmp(units_str, "s") == 0) {
+  } else if (strncmp(units_str, "second", 6) == 0 || strncmp(units_str, "sec", 3) == 0 || strcmp(units_str, "s") == 0) {
     *result = SEC(value);
   } else if (strncmp(units_str, "minute", 6) == 0 || strncmp(units_str, "min", 3) == 0) {
     *result = MINUTE(value);

--- a/core/tag.c
+++ b/core/tag.c
@@ -315,7 +315,6 @@ size_t lf_comma_separated_time(char* buffer, instant_t time) {
   return result;
 }
 
-#if !defined(NO_CLI)
 int lf_time_parse(const char* time_str, const char* units_str, interval_t* result) {
   char* end;
   int value = (int)strtol(time_str, &end, 10);
@@ -343,4 +342,3 @@ int lf_time_parse(const char* time_str, const char* units_str, interval_t* resul
   }
   return 0;
 }
-#endif // !NO_CLI

--- a/core/tag.c
+++ b/core/tag.c
@@ -318,7 +318,7 @@ size_t lf_comma_separated_time(char* buffer, instant_t time) {
 #if !defined(NO_CLI)
 int lf_time_parse(const char* time_str, const char* units_str, interval_t* result) {
   char* end;
-  long long value = strtoll(time_str, &end, 10);
+  int value = (int)strtol(time_str, &end, 10);
   if (*end != '\0') {
     return -1;
   }

--- a/tag/api/tag.h
+++ b/tag/api/tag.h
@@ -373,8 +373,6 @@ size_t lf_comma_separated_time(char* buffer, instant_t time);
  * @param result Pointer to store the resulting time in nanoseconds.
  * @return 0 on success, -1 if the time value is invalid, -2 if the units are invalid.
  */
-#if !defined(NO_CLI)
 int lf_time_parse(const char* time_str, const char* units_str, interval_t* result);
-#endif // !NO_CLI
 
 #endif // TAG_H

--- a/tag/api/tag.h
+++ b/tag/api/tag.h
@@ -373,6 +373,8 @@ size_t lf_comma_separated_time(char* buffer, instant_t time);
  * @param result Pointer to store the resulting time in nanoseconds.
  * @return 0 on success, -1 if the time value is invalid, -2 if the units are invalid.
  */
+#if !defined(NO_CLI)
 int lf_time_parse(const char* time_str, const char* units_str, interval_t* result);
+#endif // !NO_CLI
 
 #endif // TAG_H

--- a/tag/api/tag.h
+++ b/tag/api/tag.h
@@ -359,4 +359,20 @@ size_t lf_readable_time(char* buffer, instant_t time);
  */
 size_t lf_comma_separated_time(char* buffer, instant_t time);
 
+/**
+ * @brief Parse a time value and units from strings, producing a time in nanoseconds.
+ * @ingroup API
+ *
+ * Recognized unit strings (case-sensitive, prefix match):
+ * "nsec" or "ns", "usec" or "us", "msec" or "ms",
+ * "sec" or "s" or "second", "min" or "minute",
+ * "hour", "day", "week".
+ *
+ * @param time_str A string representing a numeric time value (e.g., "500").
+ * @param units_str A string representing the time units (e.g., "msec").
+ * @param result Pointer to store the resulting time in nanoseconds.
+ * @return 0 on success, -1 if the time value is invalid, -2 if the units are invalid.
+ */
+int lf_time_parse(const char* time_str, const char* units_str, interval_t* result);
+
 #endif // TAG_H


### PR DESCRIPTION
This PR adds the function `lf_time_parse` to convert a pair of strings (int and units) into a time of type `interval_t` and uses it to remove code duplication. This also adds some other support for the pompanion PR: https://github.com/lf-lang/lingua-franca/pull/2591, which adds support for command-line arguments that override parameter values with int or time data types.