### PR TITLE
Support command-line overrides of top-level parameters with primitive types or time type.

### DIFF
--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -972,6 +972,8 @@ void usage(int argc, const char* argv[]) {
       lf_cli_param_t* p = &_lf_cli_params[j];
       if (p->type == CLI_TIME) {
         printf("  --%s <value> <units>\n", p->name);
+      } else if (p->type == CLI_BOOL) {
+        printf("  --%s <true|false>\n", p->name);
       } else {
         printf("  --%s <value>\n", p->name);
       }
@@ -1067,6 +1069,19 @@ int process_user_args(int argc, const char* argv[], int* newargc, const char** n
               fprintf(stderr, "Error: invalid float value '%s' for --%s.\n", val_str, p->name);
               return 2;
             }
+            break;
+          case CLI_BOOL:
+            if (strcmp(val_str, "true") == 0 || strcmp(val_str, "1") == 0) {
+              *((bool*)p->value) = true;
+            } else if (strcmp(val_str, "false") == 0 || strcmp(val_str, "0") == 0) {
+              *((bool*)p->value) = false;
+            } else {
+              fprintf(stderr, "Error: invalid bool value '%s' for --%s (expected true or false).\n", val_str, p->name);
+              return 2;
+            }
+            break;
+          case CLI_STRING:
+            *((const char**)p->value) = val_str;
             break;
           default:
             break;

--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -11,6 +11,7 @@
  */
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <time.h>
 
@@ -952,30 +953,50 @@ void schedule_output_reactions(environment_t* env, reaction_t* reaction, int wor
   }
 }
 
+// Defaults for the code-generated parameter table.
+// The code generator overrides these if there are user-defined parameters.
+lf_cli_param_t* _lf_cli_params = NULL;
+int _lf_cli_params_count = 0;
+
 /**
- * Print a usage message.
+ * Print a usage message listing user-defined parameters (if any) and runtime options.
  */
 void usage(int argc, const char* argv[]) {
 #if defined(NO_CLI)
   printf("\nNo command-line arguments are supported.\n");
 #else
-  printf("\nCommand-line arguments: \n\n");
-  printf("  -f, --fast [true | false]\n");
-  printf("   Whether to wait for physical time to match logical time.\n\n");
+  printf("\nUsage: %s [options]\n\n", argv[0]);
+  if (_lf_cli_params_count > 0) {
+    printf("Reactor Parameters:\n");
+    for (int j = 0; j < _lf_cli_params_count; j++) {
+      lf_cli_param_t* p = &_lf_cli_params[j];
+      if (p->is_time) {
+        printf("  --%s <value> <units>\n", p->name);
+      } else {
+        printf("  --%s <value>\n", p->name);
+      }
+      printf("      %s\n\n", p->description);
+    }
+  }
+  printf("Runtime Options:\n");
+  printf("  -f, --fast <true|false>\n");
+  printf("      Whether to wait for physical time to match logical time.\n\n");
   printf("  -o, --timeout <duration> <units>\n");
-  printf("   Stop after the specified amount of logical time, where units are one of\n");
-  printf("   nsec, usec, msec, sec, minute, hour, day, week, or the plurals of those.\n\n");
-  printf("  -k, --keepalive\n");
-  printf("   Whether continue execution even when there are no events to process.\n\n");
+  printf("      Stop after the specified amount of logical time, where units are one of\n");
+  printf("      nsec, usec, msec, sec, minute, hour, day, week, or the plurals of those.\n\n");
+  printf("  -k, --keepalive <true|false>\n");
+  printf("      Whether to continue execution even when there are no events to process.\n\n");
   printf("  -w, --workers <n>\n");
-  printf("   Executed in <n> threads if possible (optional feature).\n\n");
-  printf("  -i, --id <n>\n");
-  printf("   The ID of the federation that this reactor will join.\n\n");
+  printf("      Execute in <n> threads if possible (optional feature).\n\n");
+  printf("  -h, --help\n");
+  printf("      Display this help message.\n\n");
 #ifdef FEDERATED
+  printf("  -i, --id <n>\n");
+  printf("      The ID of the federation that this reactor will join.\n\n");
   printf("  -r, --rti <n>\n");
-  printf("   The address of the RTI, which can be in the form of user@host:port or ip:port.\n\n");
+  printf("      The address of the RTI, which can be in the form of user@host:port or ip:port.\n\n");
   printf("  -l\n");
-  printf("   Send stdout to individual log files for each federate.\n\n");
+  printf("      Send stdout to individual log files for each federate.\n\n");
 #endif
 #endif
   printf("Command given:\n");
@@ -983,6 +1004,63 @@ void usage(int argc, const char* argv[]) {
     printf("%s ", argv[i]);
   }
   printf("\n\n");
+}
+
+/**
+ * Process user-defined main reactor parameters from the command line.
+ * Returns 0 on success, non-zero on error.
+ */
+int process_user_args(int argc, const char* argv[], int* newargc, const char** newargv) {
+  *newargc = 0;
+  newargv[(*newargc)++] = argv[0];
+  for (int i = 1; i < argc; i++) {
+    if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
+      usage(argc, argv);
+      return 1;
+    }
+    bool matched = false;
+    for (int j = 0; j < _lf_cli_params_count; j++) {
+      lf_cli_param_t* p = &_lf_cli_params[j];
+      // Build the option string "--name"
+      char option[256];
+      snprintf(option, sizeof(option), "--%s", p->name);
+      if (strcmp(argv[i], option) == 0) {
+        matched = true;
+        if (p->is_width) {
+          fprintf(stderr, "Error: Command-line changes to multiport and bank widths"
+                          " are not supported.\n"
+                          "Change the width in the source code and recompile instead.\n");
+          return 2;
+        }
+        if (p->is_time) {
+          if (i + 2 >= argc) {
+            fprintf(stderr, "Error: --%s needs a time value and units (e.g., --%s 500 msec).\n", p->name, p->name);
+            return 2;
+          }
+          const char* time_str = argv[++i];
+          const char* unit_str = argv[++i];
+          if (lf_time_parse(time_str, unit_str, (interval_t*)p->value) != 0) {
+            fprintf(stderr, "Error: invalid time value '%s %s' for --%s.\n", time_str, unit_str, p->name);
+            return 2;
+          }
+          *p->given = true;
+        } else {
+          // Assume the argument is an integer.
+          if (i + 1 >= argc) {
+            fprintf(stderr, "Error: --%s needs a value.\n", p->name);
+            return 2;
+          }
+          *((int*)p->value) = atoi(argv[++i]);
+          *p->given = true;
+        }
+        break;
+      }
+    }
+    if (!matched) {
+      newargv[(*newargc)++] = argv[i];
+    }
+  }
+  return 0;
 }
 
 // Some options given in the target directive are provided here as
@@ -1043,6 +1121,9 @@ int process_args(int argc, const char* argv[]) {
       } else {
         lf_print_error("Invalid value for --keepalive: %s", keep_spec);
       }
+    } else if (strcmp(arg, "-h") == 0 || strcmp(arg, "--help") == 0) {
+      usage(argc, argv);
+      return 0;
     } else if (strcmp(arg, "-w") == 0 || strcmp(arg, "--workers") == 0) {
       if (argc < i + 1) {
         lf_print_error("--workers needs an integer argument.s");

--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -970,7 +970,7 @@ void usage(int argc, const char* argv[]) {
     printf("Reactor Parameters:\n");
     for (int j = 0; j < _lf_cli_params_count; j++) {
       lf_cli_param_t* p = &_lf_cli_params[j];
-      if (p->is_time) {
+      if (p->type == CLI_TIME) {
         printf("  --%s <value> <units>\n", p->name);
       } else {
         printf("  --%s <value>\n", p->name);
@@ -1008,7 +1008,7 @@ void usage(int argc, const char* argv[]) {
 
 /**
  * Process user-defined main reactor parameters from the command line.
- * Returns 0 on success, non-zero on error.
+ * Returns 0 on success, 1 for --help (exit 0), 2 for error (exit 1).
  */
 int process_user_args(int argc, const char* argv[], int* newargc, const char** newargv) {
   *newargc = 0;
@@ -1021,7 +1021,6 @@ int process_user_args(int argc, const char* argv[], int* newargc, const char** n
     bool matched = false;
     for (int j = 0; j < _lf_cli_params_count; j++) {
       lf_cli_param_t* p = &_lf_cli_params[j];
-      // Build the option string "--name"
       char option[256];
       snprintf(option, sizeof(option), "--%s", p->name);
       if (strcmp(argv[i], option) == 0) {
@@ -1032,7 +1031,7 @@ int process_user_args(int argc, const char* argv[], int* newargc, const char** n
                           "Change the width in the source code and recompile instead.\n");
           return 2;
         }
-        if (p->is_time) {
+        if (p->type == CLI_TIME) {
           if (i + 2 >= argc) {
             fprintf(stderr, "Error: --%s needs a time value and units (e.g., --%s 500 msec).\n", p->name, p->name);
             return 2;
@@ -1045,12 +1044,33 @@ int process_user_args(int argc, const char* argv[], int* newargc, const char** n
           }
           *p->given = true;
         } else {
-          // Assume the argument is an integer.
           if (i + 1 >= argc) {
             fprintf(stderr, "Error: --%s needs a value.\n", p->name);
             return 2;
           }
-          *((int*)p->value) = atoi(argv[++i]);
+          const char* val_str = argv[++i];
+          char* end;
+          switch (p->type) {
+          case CLI_INT:
+            *((int*)p->value) = atoi(val_str);
+            break;
+          case CLI_DOUBLE:
+            *((double*)p->value) = strtod(val_str, &end);
+            if (*end != '\0') {
+              fprintf(stderr, "Error: invalid double value '%s' for --%s.\n", val_str, p->name);
+              return 2;
+            }
+            break;
+          case CLI_FLOAT:
+            *((float*)p->value) = strtof(val_str, &end);
+            if (*end != '\0') {
+              fprintf(stderr, "Error: invalid float value '%s' for --%s.\n", val_str, p->name);
+              return 2;
+            }
+            break;
+          default:
+            break;
+          }
           *p->given = true;
         }
         break;

--- a/include/core/reactor_common.h
+++ b/include/core/reactor_common.h
@@ -54,7 +54,7 @@ typedef enum {
  */
 typedef struct {
   const char* name;        ///< Parameter name (e.g., "period").
-  lf_cli_type_t type;     ///< The type of the parameter value.
+  lf_cli_type_t type;      ///< The type of the parameter value.
   void* value;             ///< Pointer to the storage variable.
   bool* given;             ///< Pointer to a bool that is set to true when the arg is provided.
   const char* description; ///< Description for the help message (e.g., "time value (default: 1 sec)").

--- a/include/core/reactor_common.h
+++ b/include/core/reactor_common.h
@@ -39,7 +39,9 @@ typedef enum {
   CLI_TIME,   ///< interval_t, parsed as value + units (e.g., "500 msec").
   CLI_INT,    ///< int, parsed with atoi.
   CLI_DOUBLE, ///< double, parsed with strtod.
-  CLI_FLOAT   ///< float, parsed with strtof.
+  CLI_FLOAT,  ///< float, parsed with strtof.
+  CLI_BOOL,   ///< bool, parsed as "true"/"false" or "1"/"0".
+  CLI_STRING  ///< const char*, set directly from the argument string.
 } lf_cli_type_t;
 
 /**

--- a/include/core/reactor_common.h
+++ b/include/core/reactor_common.h
@@ -32,6 +32,17 @@
 //////////////////////  CLI Parameter Table  //////////////////////
 
 /**
+ * @brief Type tag for a user-defined CLI parameter.
+ * @ingroup Internal
+ */
+typedef enum {
+  CLI_TIME,   ///< interval_t, parsed as value + units (e.g., "500 msec").
+  CLI_INT,    ///< int, parsed with atoi.
+  CLI_DOUBLE, ///< double, parsed with strtod.
+  CLI_FLOAT   ///< float, parsed with strtof.
+} lf_cli_type_t;
+
+/**
  * @brief Descriptor for a user-defined main reactor parameter overridable from the command line.
  * @ingroup Internal
  *
@@ -41,8 +52,8 @@
  */
 typedef struct {
   const char* name;        ///< Parameter name (e.g., "period").
-  bool is_time;            ///< True if the parameter is a time value (interval_t), false for int.
-  void* value;             ///< Pointer to the storage variable (interval_t* or int*).
+  lf_cli_type_t type;     ///< The type of the parameter value.
+  void* value;             ///< Pointer to the storage variable.
   bool* given;             ///< Pointer to a bool that is set to true when the arg is provided.
   const char* description; ///< Description for the help message (e.g., "time value (default: 1 sec)").
   bool is_width;           ///< True if this parameter is used for multiport/bank widths (not overridable).

--- a/include/core/reactor_common.h
+++ b/include/core/reactor_common.h
@@ -29,6 +29,28 @@
 #include "modes.h"
 #include "port.h"
 
+//////////////////////  CLI Parameter Table  //////////////////////
+
+/**
+ * @brief Descriptor for a user-defined main reactor parameter overridable from the command line.
+ * @ingroup Internal
+ *
+ * The code generator populates an array of these structs so that the runtime
+ * can parse user parameters in a table-driven fashion, without generating
+ * large if-else chains.
+ */
+typedef struct {
+  const char* name;        ///< Parameter name (e.g., "period").
+  bool is_time;            ///< True if the parameter is a time value (interval_t), false for int.
+  void* value;             ///< Pointer to the storage variable (interval_t* or int*).
+  bool* given;             ///< Pointer to a bool that is set to true when the arg is provided.
+  const char* description; ///< Description for the help message (e.g., "time value (default: 1 sec)").
+  bool is_width;           ///< True if this parameter is used for multiport/bank widths (not overridable).
+} lf_cli_param_t;
+
+extern lf_cli_param_t* _lf_cli_params;
+extern int _lf_cli_params_count;
+
 //////////////////////  Constants & Macros  //////////////////////
 
 /**
@@ -362,6 +384,31 @@ void schedule_output_reactions(environment_t* env, reaction_t* reaction, int wor
  * @param argv The command-line arguments.
  */
 int process_args(int argc, const char* argv[]);
+
+/**
+ * @brief Process user-defined main reactor parameters from the command line.
+ * @ingroup Internal
+ *
+ * Parses user-defined parameters from argv using the table in _lf_cli_params.
+ * Recognized parameters are consumed; the remaining arguments are copied into
+ * newargv/newargc so they can be forwarded to lf_reactor_c_main().
+ *
+ * @param argc The number of command-line arguments.
+ * @param argv The command-line arguments.
+ * @param newargc Output: number of remaining (unrecognized) arguments.
+ * @param newargv Output: array of remaining arguments (must be pre-allocated to at least argc).
+ * @return 0 on success, non-zero on error (the program should exit).
+ */
+int process_user_args(int argc, const char* argv[], int* newargc, const char** newargv);
+
+/**
+ * @brief Print a usage message listing both user-defined parameters and runtime options.
+ * @ingroup Internal
+ *
+ * @param argc The number of command-line arguments.
+ * @param argv The command-line arguments.
+ */
+void usage(int argc, const char* argv[]);
 
 /**
  * @brief Initialize global variables and start tracing before calling the


### PR DESCRIPTION
This PR (a companion to https://github.com/lf-lang/lingua-franca/pull/2591) shifts some of the code for supporting command-line overrides of top-level parameters from the code generator to the runtime and helps avoid code duplication.