### PR TITLE
Color logging outputs to stdout to better distinguish them from user outputs.

### DIFF
--- a/core/federated/RTI/main.c
+++ b/core/federated/RTI/main.c
@@ -85,9 +85,9 @@ void termination() {
     }
     if (rti.base.tracing_enabled) {
       lf_tracing_global_shutdown();
-      lf_print("RTI trace file saved.");
+      lf_print_info("RTI trace file saved.");
     }
-    lf_print("RTI is exiting abnormally.");
+    lf_print_warning("RTI is exiting abnormally.");
   }
 }
 
@@ -133,13 +133,13 @@ int process_clock_sync_args(int argc, const char* argv[]) {
   for (int i = 0; i < argc; i++) {
     if (strcmp(argv[i], "off") == 0) {
       rti.clock_sync_global_status = clock_sync_off;
-      lf_print("RTI: Clock sync: off");
+      lf_print_info("RTI: Clock sync: off");
     } else if (strcmp(argv[i], "init") == 0 || strcmp(argv[i], "initial") == 0) {
       rti.clock_sync_global_status = clock_sync_init;
-      lf_print("RTI: Clock sync: init");
+      lf_print_info("RTI: Clock sync: init");
     } else if (strcmp(argv[i], "on") == 0) {
       rti.clock_sync_global_status = clock_sync_on;
-      lf_print("RTI: Clock sync: on");
+      lf_print_info("RTI: Clock sync: on");
     } else if (strcmp(argv[i], "period") == 0) {
       if (rti.clock_sync_global_status != clock_sync_on) {
         lf_print_error("clock sync period can only be set if --clock-sync is set to on.");
@@ -158,7 +158,7 @@ int process_clock_sync_args(int argc, const char* argv[]) {
         continue; // Try to parse the rest of the arguments as clock sync args.
       }
       rti.clock_sync_period_ns = (int64_t)period_ns;
-      lf_print("RTI: Clock sync period: %lld", (long long int)rti.clock_sync_period_ns);
+      lf_print_info("RTI: Clock sync period: %lld", (long long int)rti.clock_sync_period_ns);
     } else if (strcmp(argv[i], "exchanges-per-interval") == 0) {
       if (rti.clock_sync_global_status != clock_sync_on && rti.clock_sync_global_status != clock_sync_init) {
         lf_print_error("clock sync exchanges-per-interval can only be set if\n"
@@ -177,7 +177,7 @@ int process_clock_sync_args(int argc, const char* argv[]) {
         continue; // Try to parse the rest of the arguments as clock sync args.
       }
       rti.clock_sync_exchanges_per_interval = (int32_t)exchanges; // FIXME: Loses numbers on 64-bit machines
-      lf_print("RTI: Clock sync exchanges per interval: %d", rti.clock_sync_exchanges_per_interval);
+      lf_print_info("RTI: Clock sync exchanges per interval: %d", rti.clock_sync_exchanges_per_interval);
     } else if (strcmp(argv[i], " ") == 0) {
       // Tolerate spaces
       continue;
@@ -202,7 +202,7 @@ int process_args(int argc, const char* argv[]) {
         return 0;
       }
       i++;
-      lf_print("RTI: Federation ID: %s", argv[i]);
+      lf_print_log("RTI: Federation ID: %s", argv[i]);
       rti.federation_id = argv[i];
     } else if (strcmp(argv[i], "-n") == 0 || strcmp(argv[i], "--number_of_federates") == 0) {
       if (argc < i + 2) {
@@ -218,7 +218,7 @@ int process_args(int argc, const char* argv[]) {
         return 0;
       }
       rti.base.number_of_scheduling_nodes = (int32_t)num_federates; // FIXME: Loses numbers on 64-bit machines
-      lf_print("RTI: Number of federates: %d", rti.base.number_of_scheduling_nodes);
+      lf_print_info("RTI: Number of federates: %d", rti.base.number_of_scheduling_nodes);
     } else if (strcmp(argv[i], "-p") == 0 || strcmp(argv[i], "--port") == 0) {
       if (argc < i + 2) {
         lf_print_error("--port needs a short unsigned integer argument ( > 0 and < %d).", UINT16_MAX);
@@ -297,11 +297,11 @@ int main(int argc, const char* argv[]) {
     // connections attempted after initialization phase has completed. Add 1
     // for the main thread.
     lf_tracing_global_init("rti", NULL, -1, _lf_number_of_workers * 2 + 3);
-    lf_print("Tracing the RTI execution in %s file.", rti_trace_file_name);
+    lf_print_info("Tracing the RTI execution in %s file.", rti_trace_file_name);
   }
 
-  lf_print("Starting RTI for %d federates in federation ID %s.", rti.base.number_of_scheduling_nodes,
-           rti.federation_id);
+  lf_print_log("Starting RTI for %d federates in federation ID %s.", rti.base.number_of_scheduling_nodes,
+               rti.federation_id);
   assert(rti.base.number_of_scheduling_nodes < UINT16_MAX);
 
   // Allocate memory for the federates
@@ -320,11 +320,11 @@ int main(int argc, const char* argv[]) {
     if (rti.base.tracing_enabled) {
       // No need for a mutex lock because all threads have exited.
       lf_tracing_global_shutdown();
-      lf_print("RTI trace file saved.");
+      lf_print_info("RTI trace file saved.");
     }
   }
 
-  lf_print("RTI is exiting."); // Do this before freeing scheduling nodes.
+  lf_print_info("RTI is exiting."); // Do this before freeing scheduling nodes.
   free_scheduling_nodes(rti.base.scheduling_nodes, rti.base.number_of_scheduling_nodes);
 
   // Even if the RTI is exiting normally, it should report an error code if one of the

--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -1535,10 +1535,10 @@ void wait_for_federates(int socket_descriptor) {
   void* thread_exit_status;
   for (int i = 0; i < rti_remote->base.number_of_scheduling_nodes; i++) {
     federate_info_t* fed = GET_FED_INFO(i);
-    lf_print_info("RTI: Waiting for thread handling federate %d.", fed->enclave.id);
+    LF_PRINT_LOG("RTI: Waiting for thread handling federate %d.", fed->enclave.id);
     lf_thread_join(fed->thread_id, &thread_exit_status);
     pqueue_tag_free(fed->in_transit_message_tags);
-    lf_print_info("RTI: Federate %d thread exited.", fed->enclave.id);
+    LF_PRINT_LOG("RTI: Federate %d thread exited.", fed->enclave.id);
   }
 
   rti_remote->all_federates_exited = true;

--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -930,7 +930,7 @@ static void handle_federate_resign(federate_info_t* my_fed) {
     tracepoint_rti_from_federate(receive_RESIGN, my_fed->enclave.id, NULL);
   }
 
-  lf_print("RTI: Federate %d has resigned.", my_fed->enclave.id);
+  lf_print_info("RTI: Federate %d has resigned.", my_fed->enclave.id);
 
   my_fed->enclave.state = NOT_CONNECTED;
 
@@ -1505,7 +1505,7 @@ int32_t start_rti_server(uint16_t port) {
   if (create_server(port, &rti_remote->socket_descriptor_TCP, &rti_remote->final_port_TCP, TCP, true)) {
     lf_print_error_system_failure("RTI failed to create TCP server: %s.", strerror(errno));
   };
-  lf_print("RTI: Listening for federates.");
+  lf_print_info("RTI: Listening for federates.");
   // Create the UDP socket server
   // Try to get the rti_remote->final_port_TCP + 1 port
   if (rti_remote->clock_sync_global_status >= clock_sync_on) {
@@ -1522,7 +1522,7 @@ void wait_for_federates(int socket_descriptor) {
   lf_connect_to_federates(socket_descriptor);
 
   // All federates have connected.
-  lf_print("RTI: All expected federates have connected. Starting execution.");
+  lf_print_info("RTI: All expected federates have connected. Starting execution.");
 
   // The socket server will not continue to accept connections after all the federates
   // have joined.
@@ -1535,10 +1535,10 @@ void wait_for_federates(int socket_descriptor) {
   void* thread_exit_status;
   for (int i = 0; i < rti_remote->base.number_of_scheduling_nodes; i++) {
     federate_info_t* fed = GET_FED_INFO(i);
-    lf_print("RTI: Waiting for thread handling federate %d.", fed->enclave.id);
+    lf_print_info("RTI: Waiting for thread handling federate %d.", fed->enclave.id);
     lf_thread_join(fed->thread_id, &thread_exit_status);
     pqueue_tag_free(fed->in_transit_message_tags);
-    lf_print("RTI: Federate %d thread exited.", fed->enclave.id);
+    lf_print_info("RTI: Federate %d thread exited.", fed->enclave.id);
   }
 
   rti_remote->all_federates_exited = true;

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -751,7 +751,7 @@ static void* listen_to_federates(void* _args) {
     bool bad_message = false;
     if (read_from_socket_close_on_error(socket_id, 1, buffer)) {
       // Socket has been closed.
-      lf_print("Socket from federate %d is closed.", fed_id);
+      lf_print_info("Socket from federate %d is closed.", fed_id);
       // Stop listening to this federate.
       socket_closed = true;
     } else {
@@ -949,7 +949,7 @@ static instant_t get_start_time_from_rti(instant_t my_physical_time) {
   tag_t tag = {.time = timestamp, .microstep = 0};
   // Trace the event when tracing is enabled
   tracepoint_federate_from_rti(receive_TIMESTAMP, _lf_my_fed_id, &tag);
-  lf_print("Starting timestamp is: " PRINTF_TIME ".", timestamp);
+  lf_print_info("Starting timestamp is: " PRINTF_TIME ".", timestamp);
   LF_PRINT_LOG("Current physical time is: " PRINTF_TIME ".", lf_time_physical());
 
   return timestamp;
@@ -1542,7 +1542,7 @@ static void* listen_to_rti_TCP(void* args) {
       }
     } else if (read_failed > 0) {
       // EOF received.
-      lf_print("Connection to the RTI closed with an EOF.");
+      lf_print_info("Connection to the RTI closed with an EOF.");
       shutdown_socket(&_fed.socket_TCP_RTI, false);
       return NULL;
     }
@@ -1831,7 +1831,7 @@ void lf_connect_to_federate(uint16_t remote_federate_id) {
                        remote_federate_id, ADDRESS_QUERY_RETRY_INTERVAL);
       continue;
     } else {
-      lf_print("Connected to federate %d, port %hu.", remote_federate_id, uport);
+      lf_print_info("Connected to federate %d, port %hu.", remote_federate_id, uport);
       // Trace the event when tracing is enabled
       tracepoint_federate_to_federate(receive_ACK, _lf_my_fed_id, remote_federate_id, NULL);
       break;

--- a/core/federated/network/socket_common.c
+++ b/core/federated/network/socket_common.c
@@ -105,7 +105,7 @@ static int set_socket_bind_option(int socket_descriptor, uint16_t specified_port
       server_fd.sin_port = htons(used_port);
       // Do not sleep.
     } else {
-      lf_print("Failed to bind socket on port %d. Will try again.", used_port);
+      lf_print_warning("Failed to bind socket on port %d. Will try again.", used_port);
       lf_sleep(PORT_BIND_RETRY_INTERVAL);
     }
     result = bind(socket_descriptor, (struct sockaddr*)&server_fd, sizeof(server_fd));
@@ -264,7 +264,7 @@ int connect_to_socket(int sock, const char* hostname, int port) {
     }
   }
   freeaddrinfo(result);
-  lf_print("Connected to %s:%d.", hostname, used_port);
+  lf_print_info("Connected to %s:%d.", hostname, used_port);
   return ret;
 }
 

--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -1182,7 +1182,7 @@ int process_args(int argc, const char* argv[]) {
       }
       const char* fid = argv[i++];
       lf_set_federation_id(fid);
-      lf_print("Federation ID for executable %s: %s", argv[0], fid);
+      lf_print_log("Federation ID for executable %s: %s", argv[0], fid);
     } else if (strcmp(arg, "-r") == 0 || strcmp(arg, "--rti") == 0) {
       if (argc < i + 1) {
         lf_print_error("--rti needs a string argument in the form of [user]@[host]:[port].");
@@ -1218,7 +1218,8 @@ int process_args(int argc, const char* argv[]) {
 #ifdef FEDERATED
       // In federated programs, arguments intended for other federates
       // may be forwarded here. Skip them silently.
-      lf_print("Ignoring unrecognized command-line argument: %s. Assuming it is intended for another federate.", arg);
+      lf_print_info("Ignoring unrecognized command-line argument: %s. Assuming it is intended for another federate.",
+                    arg);
 #else
       lf_print_error("Unrecognized command-line argument: %s", arg);
       usage(argc, argv);
@@ -1366,13 +1367,13 @@ void termination(void) {
       if (elapsed_time >= 0LL) {
         char time_buffer[29]; // 28 bytes is enough for the largest 64 bit number: 9,223,372,036,854,775,807
         lf_comma_separated_time(time_buffer, elapsed_time);
-        printf("---- Elapsed logical time (in nsec): %s\n", time_buffer);
+        lf_print_info("---- Elapsed logical time (in nsec): %s", time_buffer);
 
         // If start_time is 0, then execution didn't get far enough along
         // to initialize this.
         if (start_time > 0LL) {
           lf_comma_separated_time(time_buffer, lf_time_physical_elapsed());
-          printf("---- Elapsed physical time (in nsec): %s\n", time_buffer);
+          lf_print_info("---- Elapsed physical time (in nsec): %s", time_buffer);
         }
       }
     }

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -1054,7 +1054,7 @@ int lf_reactor_c_main(int argc, const char* argv[]) {
   LF_PRINT_DEBUG("Start time: " PRINTF_TIME "ns", start_time);
 
 #ifdef MINIMAL_STDLIB
-  lf_print("---- Start execution ----");
+  lf_print_info("---- Start execution ----");
 #else
   struct timespec physical_time_timespec = {start_time / BILLION, start_time % BILLION};
   struct tm* time_info = localtime(&physical_time_timespec.tv_sec);
@@ -1062,7 +1062,7 @@ int lf_reactor_c_main(int argc, const char* argv[]) {
   // Use strftime rather than ctime because as of C23, ctime is deprecated.
   strftime(buffer, sizeof(buffer), "%a %b %d %H:%M:%S %Y", time_info);
 
-  lf_print("---- Start execution on %s ---- plus %ld nanoseconds", buffer, physical_time_timespec.tv_nsec);
+  lf_print_info("---- Start execution on %s ---- plus %ld nanoseconds", buffer, physical_time_timespec.tv_nsec);
 #endif // MINIMAL_STDLIB
 
   // Create and initialize the environments for each enclave

--- a/core/utils/util.c
+++ b/core/utils/util.c
@@ -24,7 +24,23 @@
 #include <stdarg.h> // Defines va_list
 #include <time.h>   // Defines nanosleep()
 #include <stdbool.h>
-#include <unistd.h> // Defines isatty()
+
+/**
+ * Use POSIX isatty(3) to decide whether stdout gets ANSI color. Only enable on hosts where
+ * unistd.h and isatty are part of the normal POSIX toolchain (not native Windows, not bare-metal).
+ */
+#if defined(LF_NO_STDOUT_COLOR) || defined(PLATFORM_ARDUINO) || defined(PLATFORM_PATMOS) || defined(_WIN32) ||         \
+    defined(_WIN64)
+#define LF_USE_POSIX_ISATTY_FOR_COLOR 0
+#elif defined(__unix__) || defined(__unix) || defined(__APPLE__)
+#define LF_USE_POSIX_ISATTY_FOR_COLOR 1
+#else
+#define LF_USE_POSIX_ISATTY_FOR_COLOR 0
+#endif
+
+#if LF_USE_POSIX_ISATTY_FOR_COLOR
+#include <unistd.h>
+#endif
 
 #ifndef NUMBER_OF_FEDERATES
 #define NUMBER_OF_FEDERATES 1
@@ -49,11 +65,24 @@ print_message_function_t* print_message_function = NULL;
 int print_message_level = -1;
 
 // Centralized ANSI color definitions for runtime logging output.
+// `\x1b` is the escape character for ANSI color codes. Same as `\033` (octal 033), or 27.
 static const char* LF_COLOR_RED = "\x1b[31m";
 static const char* LF_COLOR_LIGHT_PURPLE = "\x1b[95m";
 static const char* LF_COLOR_BLUE = "\x1b[34m";
 static const char* LF_COLOR_CYAN = "\x1b[36m";
 static const char* LF_COLOR_RESET = "\x1b[0m";
+
+/**
+ * Whether stdout should get ANSI color escapes. Only POSIX-like hosts use isatty(); elsewhere
+ * (e.g. native Windows, Arduino, Patmos) we skip color.
+ */
+static bool lf_stdout_supports_ansi_color(void) {
+#if !LF_USE_POSIX_ISATTY_FOR_COLOR
+  return false;
+#else
+  return isatty(fileno(stdout)) != 0;
+#endif
+}
 
 uint16_t lf_fed_id() { return _lf_my_fed_id; }
 
@@ -100,19 +129,19 @@ void _lf_message_print(const char* color, const char* prefix, const char* format
     char* message;
     const char* active_color = "";
     const char* active_reset = "";
-    if (print_message_function == NULL && isatty(fileno(stdout)) != 0 && color != NULL) {
+    if (print_message_function == NULL && lf_stdout_supports_ansi_color() && color != NULL && color[0] != '\0') {
       active_color = color;
       active_reset = LF_COLOR_RESET;
     }
     if (_lf_my_fed_id == UINT16_MAX) {
       size_t length = strlen(active_color) + strlen(prefix) + strlen(format) + strlen(active_reset) + 32;
       message = (char*)malloc(length + 1);
-      snprintf(message, length, "%s%s%s%s\n", active_color, prefix, format, active_reset);
+      snprintf(message, length + 1, "%s%s%s%s\n", active_color, prefix, format, active_reset);
     } else {
 #if defined STANDALONE_RTI
       size_t length = strlen(active_color) + strlen(prefix) + strlen(format) + strlen(active_reset) + 37;
       message = (char*)malloc(length + 1);
-      snprintf(message, length, "%sRTI: %s%s%s\n", active_color, prefix, format, active_reset);
+      snprintf(message, length + 1, "%sRTI: %s%s%s\n", active_color, prefix, format, active_reset);
 #else
       // Get the federate name from the top-level environment, which by convention is the first.
       environment_t* envs;
@@ -124,7 +153,7 @@ void _lf_message_print(const char* color, const char* prefix, const char* format
       if (strncmp(name, "federate__", 10) == 0)
         name += 10;
 
-      snprintf(message, length, "%sFed %d (%s): %s%s%s\n", active_color, _lf_my_fed_id, name, prefix, format,
+      snprintf(message, length + 1, "%sFed %d (%s): %s%s%s\n", active_color, _lf_my_fed_id, name, prefix, format,
                active_reset);
 #endif // STANDALONE_RTI
     }

--- a/core/utils/util.c
+++ b/core/utils/util.c
@@ -68,6 +68,7 @@ int print_message_level = -1;
 // `\x1b` is the escape character for ANSI color codes. Same as `\033` (octal 033), or 27.
 static const char* LF_COLOR_RED = "\x1b[31m";
 static const char* LF_COLOR_LIGHT_PURPLE = "\x1b[95m";
+static const char* LF_COLOR_GREEN = "\x1b[92m";
 static const char* LF_COLOR_BLUE = "\x1b[34m";
 static const char* LF_COLOR_CYAN = "\x1b[36m";
 static const char* LF_COLOR_RESET = "\x1b[0m";
@@ -206,7 +207,7 @@ void lf_print_debug(const char* format, ...) {
 }
 
 void lf_vprint_debug(const char* format, va_list args) {
-  _lf_message_print("", "DEBUG: ", format, args, LOG_LEVEL_DEBUG);
+  _lf_message_print(LF_COLOR_GREEN, "DEBUG: ", format, args, LOG_LEVEL_DEBUG);
 }
 
 void lf_print_error(const char* format, ...) {

--- a/core/utils/util.c
+++ b/core/utils/util.c
@@ -24,6 +24,7 @@
 #include <stdarg.h> // Defines va_list
 #include <time.h>   // Defines nanosleep()
 #include <stdbool.h>
+#include <unistd.h> // Defines isatty()
 
 #ifndef NUMBER_OF_FEDERATES
 #define NUMBER_OF_FEDERATES 1
@@ -47,25 +48,32 @@ print_message_function_t* print_message_function = NULL;
 /** The level of messages to redirect to print_message_function. */
 int print_message_level = -1;
 
+// Centralized ANSI color definitions for runtime logging output.
+static const char* LF_COLOR_RED = "\x1b[31m";
+static const char* LF_COLOR_LIGHT_PURPLE = "\x1b[95m";
+static const char* LF_COLOR_BLUE = "\x1b[34m";
+static const char* LF_COLOR_CYAN = "\x1b[36m";
+static const char* LF_COLOR_RESET = "\x1b[0m";
+
 uint16_t lf_fed_id() { return _lf_my_fed_id; }
 
 // Declaration needed to attach attributes to suppress warnings of the form:
 // "warning: function '_lf_message_print' might be a candidate for 'gnu_printf'
 // format attribute [-Wsuggest-attribute=format]"
-void _lf_message_print(const char* prefix, const char* format, va_list args, int log_level)
-    ATTRIBUTE_FORMAT_PRINTF(2, 0);
+void _lf_message_print(const char* color, const char* prefix, const char* format, va_list args, int log_level)
+    ATTRIBUTE_FORMAT_PRINTF(3, 0);
 
 /**
  * Print a fatal error message. Internal function.
  */
 static void lf_vprint_fatal_error(const char* format, va_list args) {
-  _lf_message_print("FATAL ERROR: ", format, args, LOG_LEVEL_ERROR);
+  _lf_message_print(LF_COLOR_RED, "FATAL ERROR: ", format, args, LOG_LEVEL_ERROR);
 }
 
 /**
  * Internal implementation of the next few reporting functions.
  */
-void _lf_message_print(const char* prefix, const char* format, va_list args,
+void _lf_message_print(const char* color, const char* prefix, const char* format, va_list args,
                        int log_level) { // Disable warnings about format check.
   // The logging level may be set either by a LOG_LEVEL #define
   // (which is code generated based on the logging target property)
@@ -90,27 +98,34 @@ void _lf_message_print(const char* prefix, const char* format, va_list args,
     // interleaved between threads.
     // vprintf() is a version that takes an arg list rather than multiple args.
     char* message;
+    const char* active_color = "";
+    const char* active_reset = "";
+    if (print_message_function == NULL && isatty(fileno(stdout)) != 0 && color != NULL) {
+      active_color = color;
+      active_reset = LF_COLOR_RESET;
+    }
     if (_lf_my_fed_id == UINT16_MAX) {
-      size_t length = strlen(prefix) + strlen(format) + 32;
+      size_t length = strlen(active_color) + strlen(prefix) + strlen(format) + strlen(active_reset) + 32;
       message = (char*)malloc(length + 1);
-      snprintf(message, length, "%s%s\n", prefix, format);
+      snprintf(message, length, "%s%s%s%s\n", active_color, prefix, format, active_reset);
     } else {
 #if defined STANDALONE_RTI
-      size_t length = strlen(prefix) + strlen(format) + 37;
+      size_t length = strlen(active_color) + strlen(prefix) + strlen(format) + strlen(active_reset) + 37;
       message = (char*)malloc(length + 1);
-      snprintf(message, length, "RTI: %s%s\n", prefix, format);
+      snprintf(message, length, "%sRTI: %s%s%s\n", active_color, prefix, format, active_reset);
 #else
       // Get the federate name from the top-level environment, which by convention is the first.
       environment_t* envs;
       _lf_get_environments(&envs);
       char* name = envs->name;
-      size_t length = strlen(prefix) + strlen(format) + +strlen(name) + 32;
+      size_t length = strlen(active_color) + strlen(prefix) + strlen(format) + strlen(name) + strlen(active_reset) + 32;
       message = (char*)malloc(length + 1);
       // If the name has prefix "federate__", strip that out.
       if (strncmp(name, "federate__", 10) == 0)
         name += 10;
 
-      snprintf(message, length, "Fed %d (%s): %s%s\n", _lf_my_fed_id, name, prefix, format);
+      snprintf(message, length, "%sFed %d (%s): %s%s%s\n", active_color, _lf_my_fed_id, name, prefix, format,
+               active_reset);
 #endif // STANDALONE_RTI
     }
     if (print_message_function == NULL) {
@@ -130,7 +145,18 @@ void lf_print(const char* format, ...) {
   va_end(args);
 }
 
-void lf_vprint(const char* format, va_list args) { _lf_message_print("", format, args, LOG_LEVEL_INFO); }
+void lf_vprint(const char* format, va_list args) { _lf_message_print("", "", format, args, LOG_LEVEL_INFO); }
+
+void lf_print_info(const char* format, ...) {
+  va_list args;
+  va_start(args, format);
+  lf_vprint_info(format, args);
+  va_end(args);
+}
+
+void lf_vprint_info(const char* format, va_list args) {
+  _lf_message_print(LF_COLOR_CYAN, "", format, args, LOG_LEVEL_INFO);
+}
 
 void lf_print_log(const char* format, ...) {
   va_list args;
@@ -139,7 +165,9 @@ void lf_print_log(const char* format, ...) {
   va_end(args);
 }
 
-void lf_vprint_log(const char* format, va_list args) { _lf_message_print("LOG: ", format, args, LOG_LEVEL_LOG); }
+void lf_vprint_log(const char* format, va_list args) {
+  _lf_message_print(LF_COLOR_BLUE, "LOG: ", format, args, LOG_LEVEL_LOG);
+}
 
 void lf_print_debug(const char* format, ...) {
   va_list args;
@@ -148,7 +176,9 @@ void lf_print_debug(const char* format, ...) {
   va_end(args);
 }
 
-void lf_vprint_debug(const char* format, va_list args) { _lf_message_print("DEBUG: ", format, args, LOG_LEVEL_DEBUG); }
+void lf_vprint_debug(const char* format, va_list args) {
+  _lf_message_print("", "DEBUG: ", format, args, LOG_LEVEL_DEBUG);
+}
 
 void lf_print_error(const char* format, ...) {
   va_list args;
@@ -157,7 +187,9 @@ void lf_print_error(const char* format, ...) {
   va_end(args);
 }
 
-void lf_vprint_error(const char* format, va_list args) { _lf_message_print("ERROR: ", format, args, LOG_LEVEL_ERROR); }
+void lf_vprint_error(const char* format, va_list args) {
+  _lf_message_print(LF_COLOR_RED, "ERROR: ", format, args, LOG_LEVEL_ERROR);
+}
 
 void lf_print_warning(const char* format, ...) {
   va_list args;
@@ -167,7 +199,7 @@ void lf_print_warning(const char* format, ...) {
 }
 
 void lf_vprint_warning(const char* format, va_list args) {
-  _lf_message_print("WARNING: ", format, args, LOG_LEVEL_WARNING);
+  _lf_message_print(LF_COLOR_LIGHT_PURPLE, "WARNING: ", format, args, LOG_LEVEL_WARNING);
 }
 
 void lf_print_error_and_exit(const char* format, ...) {

--- a/include/core/utils/util.h
+++ b/include/core/utils/util.h
@@ -78,6 +78,12 @@ uint16_t lf_fed_id(void);
 void lf_vprint(const char* format, va_list args) ATTRIBUTE_FORMAT_PRINTF(1, 0);
 
 /**
+ * @brief varargs alternative of "lf_print_info"
+ * @ingroup Internal
+ */
+void lf_vprint_info(const char* format, va_list args) ATTRIBUTE_FORMAT_PRINTF(1, 0);
+
+/**
  * @brief varargs alternative of "lf_print_log"
  * @ingroup Internal
  */

--- a/logging/api/logging.h
+++ b/logging/api/logging.h
@@ -97,6 +97,19 @@
 void lf_print(const char* format, ...) ATTRIBUTE_FORMAT_PRINTF(1, 2);
 
 /**
+ * @brief Report an informational message on stdout with no prefix and a newline appended
+ * at the end.
+ * @ingroup API
+ *
+ * If this execution is federated, then the message will be prefaced by identifying
+ * information for the federate. The arguments are just like printf().
+ *
+ * @param format The format string to print.
+ * @param ... The arguments to print.
+ */
+void lf_print_info(const char* format, ...) ATTRIBUTE_FORMAT_PRINTF(1, 2);
+
+/**
  * @brief Report an log message on stdout with the prefix "LOG: " and a newline appended at the end.
  * @ingroup API
  *

--- a/low_level_platform/impl/src/lf_unix_clock_support.c
+++ b/low_level_platform/impl/src/lf_unix_clock_support.c
@@ -22,7 +22,7 @@ void _lf_initialize_clock() {
     lf_print_error_and_exit("Could not obtain resolution for CLOCK_REALTIME");
   }
 
-  lf_print("---- System clock resolution: %ld nsec", res.tv_nsec);
+  lf_print_log("---- System clock resolution: %ld nsec", res.tv_nsec);
 }
 
 /**


### PR DESCRIPTION
Colorize outputs to better separate user output from infrastructure outputs and to make warnings and errors stand out.