### PR TITLE
Add --start-time-multiple (-m) command-line option.

### DIFF
--- a/core/federated/RTI/main.c
+++ b/core/federated/RTI/main.c
@@ -112,6 +112,9 @@ void usage(int argc, const char* argv[]) {
   lf_print("          (period in nanoseconds, default is 5 msec). Only applies to 'on'.");
   lf_print("       - exchanges-per-interval <n>: Controls the number of messages that are exchanged for each");
   lf_print("          clock sync attempt (default is 10). Applies to 'init' and 'on'.\n");
+  lf_print("  -m, --start-time-multiple <value> <units>");
+  lf_print("   Delay the federation start so that the starting logical time is a multiple of the");
+  lf_print("   specified time, where units are one of ns, us, ms, s, min, hour, day, or week.\n");
   lf_print("  -a, --auth Turn on HMAC authentication options.\n");
   lf_print("  -t, --tracing Turn on tracing.\n");
   lf_print("  -d, --disable_dnet Turn off the use of DNET signals.\n");
@@ -295,6 +298,27 @@ int process_args(int argc, const char* argv[]) {
       lf_print_debug("RTI: TLS key path : %s", key_path);
       i += 2;
 #endif
+    } else if (strcmp(argv[i], "-m") == 0 || strcmp(argv[i], "--start-time-multiple") == 0) {
+      if (argc < i + 3) {
+        lf_print_error("--start-time-multiple needs a time value and units.");
+        usage(argc, argv);
+        return 0;
+      }
+      const char* time_spec = argv[i + 1];
+      const char* units = argv[i + 2];
+      int parse_result = lf_time_parse(time_spec, units, &rti.start_time_multiple);
+      if (parse_result != 0) {
+        lf_print_error("--start-time-multiple has an invalid time value or units: %s %s", time_spec, units);
+        usage(argc, argv);
+        return 0;
+      }
+      if (rti.start_time_multiple < 0LL) {
+        lf_print_error("--start-time-multiple needs a non-negative time value.");
+        usage(argc, argv);
+        return 0;
+      }
+      i += 2;
+      lf_print_info("RTI: Start time multiple: " PRINTF_TIME " ns", rti.start_time_multiple);
     } else if (strcmp(argv[i], "-t") == 0 || strcmp(argv[i], "--tracing") == 0) {
       rti.base.tracing_enabled = true;
     } else if (strcmp(argv[i], "-d") == 0 || strcmp(argv[i], "--dnet_disabled") == 0) {

--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -730,6 +730,14 @@ void handle_timestamp(federate_info_t* my_fed) {
   start_time_buffer[0] = MSG_TYPE_TIMESTAMP;
   // Add an offset to this start time to get everyone starting together.
   start_time = rti_remote->max_start_time + DELAY_START;
+  // If requested via the -m/--start-time-multiple command-line option, delay the
+  // start so that the starting logical time is a multiple of the given value.
+  if (rti_remote->start_time_multiple > 0LL) {
+    int64_t remainder = start_time % rti_remote->start_time_multiple;
+    if (remainder != 0LL) {
+      start_time += rti_remote->start_time_multiple - remainder;
+    }
+  }
   lf_tracing_set_start_time(start_time);
   encode_int64(swap_bytes_if_big_endian_int64(start_time), &start_time_buffer[1]);
 
@@ -1575,6 +1583,7 @@ void initialize_RTI(rti_remote_t* rti) {
 
   // federation_rti related initializations
   rti_remote->max_start_time = 0LL;
+  rti_remote->start_time_multiple = 0LL;
   rti_remote->num_feds_proposed_start = 0;
   rti_remote->all_federates_exited = false;
   rti_remote->federation_id = "Unidentified Federation";

--- a/core/federated/RTI/rti_remote.h
+++ b/core/federated/RTI/rti_remote.h
@@ -90,6 +90,16 @@ typedef struct rti_remote_t {
   /** @brief Maximum start time seen so far from the federates. */
   int64_t max_start_time;
 
+  /**
+   * @brief If nonzero, the federation start time is delayed so that the
+   * starting logical time is an integer multiple of this value (in nanoseconds).
+   *
+   * The default of 0 means that no such alignment is performed. This is set by
+   * the `-m` or `--start-time-multiple` command-line option, which the generated
+   * launch script forwards to the RTI.
+   */
+  int64_t start_time_multiple;
+
   /** @brief Number of federates that have proposed start times. */
   int num_feds_proposed_start;
 

--- a/core/reactor.c
+++ b/core/reactor.c
@@ -337,10 +337,10 @@ int lf_reactor_c_main(int argc, const char* argv[]) {
     start_time = lf_align_to_start_time_multiple(start_time);
     lf_tracing_set_start_time(start_time);
     // The single-threaded runtime does not wait for the start time elsewhere, so
-    // if the start time has been pushed into the future, sleep until then. In
-    // fast mode, the wait is skipped so that logical time may run ahead of
-    // physical time.
-    if (!fast && start_time_multiple > 0LL) {
+    // if the start time has been pushed into the future, sleep until then. This keeps
+    // lf_time_start() and lf_time_physical_elapsed() consistent with the physical start time.
+    // (This applies even when running with --fast.)
+    if (start_time_multiple > 0LL) {
       interval_t wait_duration = start_time - lf_time_physical();
       if (wait_duration > 0LL) {
         lf_sleep(wait_duration);

--- a/core/reactor.c
+++ b/core/reactor.c
@@ -331,7 +331,21 @@ int lf_reactor_c_main(int argc, const char* argv[]) {
     // Set start time
     start_time = lf_time_physical();
 #ifndef FEDERATED
+    // Optionally delay the start so that the starting logical time is a multiple
+    // of the value given with the -m/--start-time-multiple command-line option.
+    // In federated execution, this alignment is performed by the RTI instead.
+    start_time = lf_align_to_start_time_multiple(start_time);
     lf_tracing_set_start_time(start_time);
+    // The single-threaded runtime does not wait for the start time elsewhere, so
+    // if the start time has been pushed into the future, sleep until then. In
+    // fast mode, the wait is skipped so that logical time may run ahead of
+    // physical time.
+    if (!fast && start_time_multiple > 0LL) {
+      interval_t wait_duration = start_time - lf_time_physical();
+      if (wait_duration > 0LL) {
+        lf_sleep(wait_duration);
+      }
+    }
 #endif
 
     LF_PRINT_DEBUG("NOTE: FOREVER is displayed as " PRINTF_TAG " and NEVER as " PRINTF_TAG,

--- a/core/reactor_common.c
+++ b/core/reactor_common.c
@@ -91,8 +91,29 @@ unsigned int _lf_number_of_workers = 0u;
  */
 instant_t duration = -1LL;
 
+/**
+ * If nonzero, the start of the program is delayed so that the starting logical
+ * time is an integer multiple of this value (in nanoseconds). The default of 0
+ * means that no such alignment is performed and the program starts as soon as
+ * possible. This is set by the `-m` or `--start-time-multiple` command-line
+ * option. In federated execution, this alignment is performed by the RTI (which
+ * receives the option from the generated launch script), not by the individual
+ * federates, so this variable is unused in federates.
+ */
+instant_t start_time_multiple = 0LL;
+
 /** Indicator of whether the keepalive command-line option was given. */
 bool keepalive_specified = false;
+
+instant_t lf_align_to_start_time_multiple(instant_t time) {
+  if (start_time_multiple > 0LL) {
+    instant_t remainder = time % start_time_multiple;
+    if (remainder != 0LL) {
+      time += start_time_multiple - remainder;
+    }
+  }
+  return time;
+}
 
 void* lf_allocate(size_t count, size_t size, struct allocation_record_t** head) {
   void* mem = calloc(count, size);
@@ -989,6 +1010,9 @@ void usage(int argc, const char* argv[]) {
   printf("  -o, --timeout <duration> <units>\n");
   printf("      Stop after the specified amount of logical time, where units are one of\n");
   printf("      nsec, usec, msec, sec, minute, hour, day, week, or the plurals of those.\n\n");
+  printf("  -m, --start-time-multiple <value> <units>\n");
+  printf("      Delay the start of the program so that the starting logical time is a\n");
+  printf("      multiple of the specified time, where units are one of ns, us, ms, s, min, hour, day, or week.\n\n");
   printf("  -k, --keepalive <true|false>\n");
   printf("      Whether to continue execution even when there are no events to process.\n\n");
   printf("  -w, --workers <n>\n");
@@ -1150,6 +1174,26 @@ int process_args(int argc, const char* argv[]) {
       if (parse_result != 0) {
         lf_print_error(parse_result == -1 ? "Invalid time value: %s" : "Invalid time units: %s",
                        parse_result == -1 ? time_spec : units);
+        usage(argc, argv);
+        return 0;
+      }
+    } else if (strcmp(arg, "-m") == 0 || strcmp(arg, "--start-time-multiple") == 0) {
+      if (argc < i + 2) {
+        lf_print_error("--start-time-multiple needs time and units.");
+        usage(argc, argv);
+        return 0;
+      }
+      const char* time_spec = argv[i++];
+      const char* units = argv[i++];
+      int parse_result = lf_time_parse(time_spec, units, &start_time_multiple);
+      if (parse_result != 0) {
+        lf_print_error(parse_result == -1 ? "Invalid time value: %s" : "Invalid time units: %s",
+                       parse_result == -1 ? time_spec : units);
+        usage(argc, argv);
+        return 0;
+      }
+      if (start_time_multiple < 0LL) {
+        lf_print_error("--start-time-multiple needs a non-negative time value.");
         usage(argc, argv);
         return 0;
       }

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -1071,9 +1071,9 @@ int lf_reactor_c_main(int argc, const char* argv[]) {
   // sleep until that physical time before any tag (0,0) reactions execute. The
   // threaded runtime does not otherwise wait before executing the startup
   // reactions at the start tag, and this is done here, on the main thread,
-  // before the worker threads are created. In fast mode, the wait is skipped so
-  // that logical time is allowed to run ahead of physical time.
-  if (!fast && start_time_multiple > 0LL) {
+  // before the worker threads are created. If the aligned start time is in the
+  // future, sleep until then to keep lf_time_start()/lf_time_physical_elapsed() consistent.
+  if (start_time_multiple > 0LL) {
     interval_t wait_duration = start_time - lf_time_physical();
     if (wait_duration > 0LL) {
       lf_sleep(wait_duration);

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -1061,7 +1061,24 @@ int lf_reactor_c_main(int argc, const char* argv[]) {
   _lf_initialize_clock();
   start_time = lf_time_physical();
 #ifndef FEDERATED
+  // Optionally delay the start so that the starting logical time is a multiple
+  // of the value given with the -m/--start-time-multiple command-line option.
+  // In federated execution, this alignment is performed by the RTI instead, so
+  // it is only applied here for unfederated programs.
+  start_time = lf_align_to_start_time_multiple(start_time);
   lf_tracing_set_start_time(start_time);
+  // If the start time has been pushed into the future to align it to a multiple,
+  // sleep until that physical time before any tag (0,0) reactions execute. The
+  // threaded runtime does not otherwise wait before executing the startup
+  // reactions at the start tag, and this is done here, on the main thread,
+  // before the worker threads are created. In fast mode, the wait is skipped so
+  // that logical time is allowed to run ahead of physical time.
+  if (!fast && start_time_multiple > 0LL) {
+    interval_t wait_duration = start_time - lf_time_physical();
+    if (wait_duration > 0LL) {
+      lf_sleep(wait_duration);
+    }
+  }
 #endif
 
   LF_PRINT_DEBUG("Start time: " PRINTF_TIME "ns", start_time);

--- a/include/core/reactor_common.h
+++ b/include/core/reactor_common.h
@@ -91,6 +91,23 @@ extern const char** default_argv;
 extern instant_t duration;
 extern bool fast;
 extern bool keepalive_specified;
+extern instant_t start_time_multiple;
+
+/**
+ * @brief Round the given time up to the next integer multiple of `start_time_multiple`.
+ * @ingroup Internal
+ *
+ * If `start_time_multiple` is 0 (the default), the time is returned unchanged.
+ * Otherwise, the smallest multiple of `start_time_multiple` that is greater than
+ * or equal to `time` is returned. This is used to implement the
+ * `-m`/`--start-time-multiple` command-line option, which delays the start of
+ * the program so that the starting logical time is a multiple of the specified
+ * value.
+ *
+ * @param time The time to align.
+ * @return The aligned time.
+ */
+instant_t lf_align_to_start_time_multiple(instant_t time);
 
 #ifdef FEDERATED_DECENTRALIZED
 extern interval_t lf_fed_STA_offset;


### PR DESCRIPTION
This PR gives a way for federated or unfederated programs to control the start time via a command line option.  If, when running a program, you specify

```
bin/MyProgram --start-time-multiple <number> <units>
```
or

```
bin/MyProgram -m <number> <units>
```

then the start of the program will be delayed until the physical time on the platform (or the RTI's platform for federated) matches the next multiple of the specified time.  The starting logical time will be the same multiple of the specified time. For example,

```
bin/MyProgram --start-time-multiple 1 s
```

will ensure that the starting logical time is a multiple of one second and that the program start is delayed until the physical time matches that logical time.