### PR TITLE
Update `sst-c-api`'s default branch from `master` to `main`.

### DIFF
--- a/network/impl/CMakeLists.txt
+++ b/network/impl/CMakeLists.txt
@@ -24,7 +24,7 @@ elseif(COMM_TYPE MATCHES SST)
         FetchContent_Declare(
             sst-lib
             GIT_REPOSITORY https://github.com/iotauth/sst-c-api.git
-            GIT_TAG        master
+            GIT_TAG        main
         )
         FetchContent_MakeAvailable(sst-lib)
 


### PR DESCRIPTION
`sst-c-api`'s default branch has changed from `master` to `main`.

Update the `cmake`'s `Fetch_content` part.