### PR TITLE
Improve socket messages and add a needed mutex

### DIFF
--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -821,12 +821,14 @@ static void close_outbound_net(int fed_id) {
   // This will result in EOF being sent to the remote federate, except for
   // abnormal termination, in which case it will just close the network abstraction.
   if (_lf_normal_termination) {
+    LF_MUTEX_LOCK(&lf_outbound_net_mutex);
     if (_fed.net_for_outbound_p2p_connections[fed_id] != NULL) {
       // Close the network abstraction by sending a FIN packet indicating that no further writes
       // are expected.  Then read until we get an EOF indication.
       shutdown_net(_fed.net_for_outbound_p2p_connections[fed_id], true);
       _fed.net_for_outbound_p2p_connections[fed_id] = NULL;
     }
+    LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
   } else {
     shutdown_net(_fed.net_for_outbound_p2p_connections[fed_id], false);
     _fed.net_for_outbound_p2p_connections[fed_id] = NULL;
@@ -2234,7 +2236,9 @@ int lf_send_message(int message_type, unsigned short port, unsigned short federa
   net_abstraction_t net = _fed.net_for_outbound_p2p_connections[federate];
 
   if (net == NULL) {
-    lf_print_warning("Network connection to %s is closed. Dropping the message.", next_destination_str);
+    if (!_lf_termination_executed) {
+      lf_print_warning("Network connection to %s is closed. Dropping the message.", next_destination_str);
+    }
     LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
     return -1;
   }
@@ -2440,7 +2444,9 @@ void lf_send_port_absent_to_federate(environment_t* env, interval_t additional_d
   // Send the absent message through the RTI
   net_abstraction_t net = _fed.net_to_RTI;
   if (net == NULL) {
-    lf_print_warning("Network connection to federate %hu is closed. Dropping the message.", fed_ID);
+    if (!_lf_termination_executed) {
+      lf_print_warning("Network connection to federate %hu is closed. Dropping the message.", fed_ID);
+    }
     LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
     return;
   }
@@ -2449,7 +2455,9 @@ void lf_send_port_absent_to_federate(environment_t* env, interval_t additional_d
   // Send the absent message directly to the federate
   net_abstraction_t net = _fed.net_for_outbound_p2p_connections[fed_ID];
   if (net == NULL) {
-    lf_print_warning("Network connection to federate %hu is closed. Dropping the message.", fed_ID);
+    if (!_lf_termination_executed) {
+      lf_print_warning("Network connection to federate %hu is closed. Dropping the message.", fed_ID);
+    }
     LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
     return;
   }
@@ -2564,6 +2572,13 @@ int lf_send_tagged_message(environment_t* env, interval_t additional_delay, int 
   } else {
     net = _fed.net_to_RTI;
     tracepoint_federate_to_rti(send_TAGGED_MSG, _lf_my_fed_id, &current_message_intended_tag);
+  }
+  if (net == NULL) {
+    if (!_lf_termination_executed) {
+      lf_print_warning("Network connection to %s is closed. Dropping the message.", next_destination_str);
+    }
+    LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
+    return -1;
   }
 
   if (lf_tag_compare(_fed.last_DNET, current_message_intended_tag) > 0) {

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -2445,7 +2445,7 @@ void lf_send_port_absent_to_federate(environment_t* env, interval_t additional_d
   net_abstraction_t net = _fed.net_to_RTI;
   if (net == NULL) {
     if (!_lf_termination_executed) {
-      lf_print_warning("Network connection to federate %hu is closed. Dropping the message.", fed_ID);
+      lf_print_warning("Network connection to RTI %hu is closed. Dropping the message.", fed_ID);
     }
     LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
     return;

--- a/docs/markdown/1_landing_page.md
+++ b/docs/markdown/1_landing_page.md
@@ -39,6 +39,6 @@ then `lfc` will generate a Python program that uses this reactor-c runtime under
 
 The C, CCpp, and Python targets are tested nightly on Linux, macOS, and Windows (with WSL). The federated programs are tested on Linux and macOS only.
 
-For embedded platforms, there is support for C on Arduino and Zephyr, plus bare-metal (unthreaded) execution on the Raspberry Pi RP2040, nRF52, FlexPRET, and Patmos. For bare-metal, Zephyr, and RIoT, consider using the [reactor-uc](https://github.com/lf-lang/reactor-uc) target instead.
+For embedded platforms, there is support for C on Arduino and Zephyr, plus bare-metal (unthreaded) execution on the Raspberry Pi RP2040, nRF52, FlexPRET, and Patmos. For bare-metal, Zephyr, and RIoT, consider using the [micro-LF](https://github.com/lf-lang/reactor-uc) instead.
 
 

--- a/network/api/net_abstraction.h
+++ b/network/api/net_abstraction.h
@@ -105,12 +105,12 @@ net_abstraction_t connect_to_net(net_params_t params);
  * Read the specified number of bytes from the specified network abstraction into the specified buffer.
  * If an error occurs during reading, return -1 and set errno to indicate the cause.
  * If the read succeeds in reading the specified number of bytes, return 0.
- * If an EOF occurs before reading the specified number of bytes, return 1.
+ * If an EOF occurs before reading the specified number of bytes or the connection is closed, return 1.
  *
  * @param net_abs The network abstraction.
  * @param num_bytes The number of bytes to read.
  * @param buffer The buffer into which to put the bytes.
- * @return 0 for success, 1 for EOF, and -1 for an error.
+ * @return 0 for success, 1 for EOF or connection closed, and -1 for an error.
  */
 int read_from_net(net_abstraction_t net_abs, size_t num_bytes, unsigned char* buffer);
 

--- a/network/api/socket_common.h
+++ b/network/api/socket_common.h
@@ -238,7 +238,7 @@ int connect_to_socket(int sock, const char* hostname, const struct in_addr* ip_a
  *
  * If an error occurs during this reading, return -1 and set errno to indicate
  * the cause of the error. If the read succeeds in reading the specified number of bytes,
- * return 0. If an EOF occurs before reading the specified number of bytes, return 1.
+ * return 0. If an EOF occurs before reading the specified number of bytes or the connection is closed, return 1.
  * This function repeats the read attempt until the specified number of bytes
  * have been read, an EOF is read, or an error occurs. Specifically, errors EAGAIN,
  * EWOULDBLOCK, and EINTR are not considered errors and instead trigger
@@ -246,7 +246,7 @@ int connect_to_socket(int sock, const char* hostname, const struct in_addr* ip_a
  * @param socket The socket ID.
  * @param num_bytes The number of bytes to read.
  * @param buffer The buffer into which to put the bytes.
- * @return 0 for success, 1 for EOF, and -1 for an error.
+ * @return 0 for success, 1 for EOF or connection closed, and -1 for an error.
  */
 int read_from_socket(int socket, size_t num_bytes, unsigned char* buffer);
 

--- a/network/impl/src/socket_common.c
+++ b/network/impl/src/socket_common.c
@@ -284,11 +284,19 @@ int connect_to_socket(int sock, const char* hostname, const struct in_addr* ip_a
   return ret;
 }
 
+/**
+ * Return true if errno indicates the connection is no longer usable.
+ * This includes peer disconnect (RST/FIN) and local close (e.g. during termination
+ * to unblock a thread blocked in read()).
+ */
+static bool is_disconnect_errno(void) {
+  return errno == ECONNRESET || errno == EPIPE || errno == ENOTCONN || errno == EBADF;
+}
+
 int read_from_socket(int socket, size_t num_bytes, unsigned char* buffer) {
   if (socket < 0) {
-    // Socket is not open.
-    errno = EBADF;
-    return -1;
+    // Socket is already closed.
+    return 1;
   }
   ssize_t bytes_read = 0;
   while (bytes_read < (ssize_t)num_bytes) {
@@ -299,6 +307,10 @@ int read_from_socket(int socket, size_t num_bytes, unsigned char* buffer) {
       LF_PRINT_DEBUG("Reading from socket %d failed with error: `%s`. Will try again.", socket, strerror(errno));
       lf_sleep(DELAY_BETWEEN_SOCKET_RETRIES);
       continue;
+    } else if (more < 0 && is_disconnect_errno()) {
+      // Connection closed (by peer or locally during shutdown).
+      LF_PRINT_DEBUG("Socket %d closed during read.", socket);
+      return 1;
     } else if (more < 0) {
       // A more serious error occurred.
       lf_print_error("Reading from socket %d failed. With error: `%s`", socket, strerror(errno));
@@ -336,6 +348,10 @@ int write_to_socket(int socket, size_t num_bytes, unsigned char* buffer) {
       LF_PRINT_DEBUG("Writing to socket %d was blocked. Will try again.", socket);
       lf_sleep(DELAY_BETWEEN_SOCKET_RETRIES);
       continue;
+    } else if (more < 0 && is_disconnect_errno()) {
+      // Connection closed (by peer or locally during shutdown).
+      LF_PRINT_DEBUG("Socket %d closed during write.", socket);
+      return -1;
     } else if (more < 0) {
       // A more serious error occurred.
       lf_print_error("Writing to socket %d failed. With error: `%s`", socket, strerror(errno));


### PR DESCRIPTION
This PR cleans up misleading messages that occur when either a federate or the RTI are killed to shut down the federation.
It also adds one missing mutex on accesses to socket status.