### PR TITLE
Diagnosing test failures

### DIFF
--- a/core/federated/RTI/main.c
+++ b/core/federated/RTI/main.c
@@ -359,6 +359,7 @@ int process_args(int argc, const char* argv[]) {
     usage(argc, argv);
     return 0;
   }
+  rti.base.has_transients = (rti.number_of_transient_federates > 0);
   return 1;
 }
 int main(int argc, const char* argv[]) {

--- a/core/federated/RTI/rti_common.c
+++ b/core/federated/RTI/rti_common.c
@@ -213,10 +213,25 @@ tag_advance_grant_t tag_advance_grant_if_safe(scheduling_node_t* e) {
       return result;
     }
     // With transients, a disconnected upstream may be a transient that later reconnects and sends
-    // events, so we must not grant FOREVER (which would let this node terminate prematurely). Grant
-    // only a finite next event tag, preserving the original behavior.
-    if (lf_tag_compare(e->next_event, FOREVER_TAG) != 0) {
-      result.tag = e->next_event;
+    // events, so we must not grant FOREVER (which would let this node terminate prematurely and
+    // leave a rejoining transient with no downstream to receive its events). Granting this node's
+    // own next event is safe: a rejoining transient is assigned an effective_start_tag strictly
+    // greater than this node's last_granted (see the RTI join handler), so it can never send a
+    // message at or before a tag we have already granted here.
+    tag_t grant = e->next_event;
+    // With the DNET optimization e->next_event may be stale (behind last_granted) because the
+    // federate stopped sending NETs. During shutdown that stale value would make the grant
+    // redundant and get suppressed, stalling this node one microstep short of the stop tag (the
+    // same failure mode fixed above for the no-transient case). Once a stop tag has been
+    // established (max_stop_tag != NEVER), advance at least to it so the node can terminate. This
+    // is still bounded (never FOREVER while transients might rejoin) and safe for the same
+    // effective_start_tag reason.
+    if (lf_tag_compare(rti_common->max_stop_tag, NEVER_TAG) != 0 &&
+        lf_tag_compare(grant, rti_common->max_stop_tag) < 0) {
+      grant = rti_common->max_stop_tag;
+    }
+    if (lf_tag_compare(grant, FOREVER_TAG) != 0) {
+      result.tag = grant;
       return result;
     }
   } else if (lf_tag_compare(min_upstream_completed, e->last_granted) > 0 &&

--- a/core/federated/RTI/rti_common.c
+++ b/core/federated/RTI/rti_common.c
@@ -24,6 +24,7 @@ void initialize_rti_common(rti_common_t* _rti_common) {
   rti_common->max_stop_tag = NEVER_TAG;
   rti_common->number_of_scheduling_nodes = 0;
   rti_common->num_scheduling_nodes_handling_stop = 0;
+  rti_common->has_transients = false;
 }
 
 // FIXME: Should scheduling_nodes tracing use the same mechanism as federates?
@@ -200,7 +201,20 @@ tag_advance_grant_t tag_advance_grant_if_safe(scheduling_node_t* e) {
   }
 
   if (num_connected_upstream == 0) {
-    // When none of the upstream federates is connected (case of transients),
+    // None of the immediate upstream federates is currently connected.
+    if (!rti_common->has_transients) {
+      // With no transients, a disconnected upstream has resigned and can never send another
+      // message. Grant a tag advance all the way to FOREVER so this node can complete and shut
+      // down. Granting only e->next_event is not enough here: with the DNET optimization the
+      // federate may have stopped sending NETs, leaving e->next_event stale (behind last_granted),
+      // in which case the grant would be redundant and suppressed, stalling the federation at
+      // shutdown.
+      result.tag = FOREVER_TAG;
+      return result;
+    }
+    // With transients, a disconnected upstream may be a transient that later reconnects and sends
+    // events, so we must not grant FOREVER (which would let this node terminate prematurely). Grant
+    // only a finite next event tag, preserving the original behavior.
     if (lf_tag_compare(e->next_event, FOREVER_TAG) != 0) {
       result.tag = e->next_event;
       return result;

--- a/core/federated/RTI/rti_common.c
+++ b/core/federated/RTI/rti_common.c
@@ -189,8 +189,15 @@ tag_advance_grant_t tag_advance_grant_if_safe(scheduling_node_t* e) {
       min_upstream_completed = candidate;
     }
   }
-  LF_PRINT_LOG("RTI: Minimum upstream LTC for federate/enclave %d is " PRINTF_TAG "(adjusted by after delay).", e->id,
-               min_upstream_completed.time - start_time, min_upstream_completed.microstep);
+  if (lf_tag_compare(min_upstream_completed, NEVER_TAG) == 0) {
+    LF_PRINT_LOG("RTI: Minimum upstream LTC for federate/enclave %d is NEVER (no LTC from connected upstreams).",
+                 e->id);
+  } else if (lf_tag_compare(min_upstream_completed, FOREVER_TAG) == 0) {
+    LF_PRINT_LOG("RTI: Minimum upstream LTC for federate/enclave %d is FOREVER.", e->id);
+  } else {
+    LF_PRINT_LOG("RTI: Minimum upstream LTC for federate/enclave %d is " PRINTF_TAG "(adjusted by after delay).", e->id,
+                 min_upstream_completed.time - start_time, min_upstream_completed.microstep);
+  }
 
   if (num_connected_upstream == 0) {
     // When none of the upstream federates is connected (case of transients),
@@ -212,6 +219,32 @@ tag_advance_grant_t tag_advance_grant_if_safe(scheduling_node_t* e) {
   // Find the tag of the earliest event that may be later received from an upstream enclave
   // or federate (which includes any after delays on the connections).
   tag_t t_d = earliest_future_incoming_message_tag(e);
+
+  // Tighten EIMT using immediate upstreams: an upstream with NET=FOREVER (no local
+  // events) may still forward messages from further upstream. The transitive NET
+  // walk above usually captures that, but only while further upstreams remain
+  // connected and reflected in min_delays. Using min(NET, EIMT) per immediate
+  // upstream matches eimt_strict's bound (but includes ZDC nodes) and prevents
+  // over-granting when an intermediate's NET is FOREVER.
+  for (int j = 0; j < e->num_immediate_upstreams; j++) {
+    scheduling_node_t* upstream = rti_common->scheduling_nodes[e->immediate_upstreams[j]];
+    if (upstream->state == NOT_CONNECTED) {
+      continue;
+    }
+    if (lf_tag_compare(upstream->next_event, NEVER_TAG) == 0) {
+      tag_t start_tag = {.time = start_time, .microstep = 0};
+      upstream->next_event = start_tag;
+    }
+    tag_t earliest = earliest_future_incoming_message_tag(upstream);
+    if (lf_tag_compare(upstream->next_event, earliest) < 0) {
+      earliest = upstream->next_event;
+    }
+    tag_t candidate = lf_delay_tag(earliest, e->immediate_upstream_delays[j]);
+    if (lf_tag_compare(candidate, t_d) < 0) {
+      t_d = candidate;
+    }
+  }
+
   // Non-ZDC version of the above. This is a tag that must be strictly greater than
   // that of the next granted PTAG.
   tag_t t_d_strict = eimt_strict(e);

--- a/core/federated/RTI/rti_common.h
+++ b/core/federated/RTI/rti_common.h
@@ -117,6 +117,10 @@ typedef struct rti_common_t {
   bool tracing_enabled;
   /** @brief Boolean indicating that DNET is enabled. */
   bool dnet_disabled;
+  /** @brief True if the federation contains at least one transient federate. When false, a NOT_CONNECTED
+   * upstream is permanently gone (resigned), so a node whose upstreams are all disconnected can never
+   * receive another message and may be granted a tag advance all the way to FOREVER so it can shut down. */
+  bool has_transients;
   /** @brief The RTI mutex for making thread-safe access to the shared state. */
   lf_mutex_t* mutex;
 } rti_common_t;

--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -341,7 +341,7 @@ static void send_outbound_disconnected_locked(federate_info_t* my_fed) {
           lf_print_warning("RTI: Failed to send outbound disconnected message to federate %d.", fed->enclave.id);
         }
         if (rti_remote->base.tracing_enabled) {
-          tracepoint_rti_to_federate(send_OUTBOUND_DISCONNECTED, fed->enclave.id, NULL);
+          tracepoint_rti_to_federate(send_DOWNSTREAM_DISCONNECTED, fed->enclave.id, NULL);
         }
         break;
       }

--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -308,7 +308,7 @@ static void send_outbound_connected_locked(federate_info_t* my_fed) {
           lf_print_warning("RTI: Failed to send outbound connected message to federate %d.", fed->enclave.id);
         }
         if (rti_remote->base.tracing_enabled) {
-          tracepoint_rti_to_federate(send_OUTBOUND_CONNECTED, fed->enclave.id, NULL);
+          tracepoint_rti_to_federate(send_DOWNSTREAM_CONNECTED, fed->enclave.id, NULL);
         }
         break;
       }

--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -272,9 +272,9 @@ static void send_upstream_disconnected_locked(federate_info_t* destination, fede
 }
 
 /**
- * @brief Send MSG_TYPE_OUTBOUND_CONNECTED to the inbound of the specified federate.
+ * @brief Send MSG_TYPE_DOWNSTREAM_CONNECTED to the upstream federates of the specified transient federate.
  *
- * This notifies federates that have the specified transient federate as an outbound
+ * This notifies federates that have the specified transient federate as a downstream transient
  * peer that it has (re-)connected. The notification also includes the effective_start_tag
  * of the federate and shares its IP address and port, so they the destination establishes
  * (or re-establishs) the P2P connection.
@@ -283,8 +283,8 @@ static void send_upstream_disconnected_locked(federate_info_t* destination, fede
  * @param my_fed The transient federate that has just connected.
  */
 static void send_outbound_connected_locked(federate_info_t* my_fed) {
-  unsigned char buffer[MSG_TYPE_OUTBOUND_CONNECTED_LENGTH];
-  buffer[0] = MSG_TYPE_OUTBOUND_CONNECTED;
+  unsigned char buffer[MSG_TYPE_DOWNSTREAM_CONNECTED_LENGTH];
+  buffer[0] = MSG_TYPE_DOWNSTREAM_CONNECTED;
   encode_uint16(my_fed->enclave.id, &buffer[1]);
   // Iterate over all federates and notify those that have my_fed as an outbound transient.
   for (int i = 0; i < rti_remote->base.number_of_scheduling_nodes; i++) {
@@ -304,7 +304,7 @@ static void send_outbound_connected_locked(federate_info_t* my_fed) {
         encode_int32(server_port, &buffer[3 + 12]);
         encode_uint32(*ip_address, &buffer[3 + 12 + 4]);
 
-        if (write_to_net_close_on_error(fed->net, MSG_TYPE_OUTBOUND_CONNECTED_LENGTH, buffer)) {
+        if (write_to_net_close_on_error(fed->net, MSG_TYPE_DOWNSTREAM_CONNECTED_LENGTH, buffer)) {
           lf_print_warning("RTI: Failed to send outbound connected message to federate %d.", fed->enclave.id);
         }
         if (rti_remote->base.tracing_enabled) {
@@ -317,7 +317,7 @@ static void send_outbound_connected_locked(federate_info_t* my_fed) {
 }
 
 /**
- * @brief Send MSG_TYPE_OUTBOUND_DISCONNECTED to the upstream federates of a transient federate.
+ * @brief Send MSG_TYPE_DOWNSTREAM_DISCONNECTED to the upstream federates of a transient federate.
  *
  * This notifies upstream federates that a transient federate downstream of them has
  * disconnected, so they can close the outbound P2P connection to it.
@@ -326,8 +326,8 @@ static void send_outbound_connected_locked(federate_info_t* my_fed) {
  * @param my_fed The transient federate that has just disconnected.
  */
 static void send_outbound_disconnected_locked(federate_info_t* my_fed) {
-  unsigned char buffer[MSG_TYPE_OUTBOUND_DISCONNECTED_LENGTH];
-  buffer[0] = MSG_TYPE_OUTBOUND_DISCONNECTED;
+  unsigned char buffer[MSG_TYPE_DOWNSTREAM_DISCONNECTED_LENGTH];
+  buffer[0] = MSG_TYPE_DOWNSTREAM_DISCONNECTED;
   encode_uint16(my_fed->enclave.id, &buffer[1]);
   // Iterate over all federates and notify those that have my_fed as an outbound transient.
   for (int i = 0; i < rti_remote->base.number_of_scheduling_nodes; i++) {
@@ -337,7 +337,7 @@ static void send_outbound_disconnected_locked(federate_info_t* my_fed) {
     }
     for (int32_t j = 0; j < fed->number_of_outbound_transients; j++) {
       if (fed->outbound_transients[j] == (int32_t)my_fed->enclave.id) {
-        if (write_to_net_close_on_error(fed->net, MSG_TYPE_OUTBOUND_DISCONNECTED_LENGTH, buffer)) {
+        if (write_to_net_close_on_error(fed->net, MSG_TYPE_DOWNSTREAM_DISCONNECTED_LENGTH, buffer)) {
           lf_print_warning("RTI: Failed to send outbound disconnected message to federate %d.", fed->enclave.id);
         }
         if (rti_remote->base.tracing_enabled) {

--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -1704,6 +1704,21 @@ void* federate_info_thread_TCP(void* fed) {
     // free_in_transit_message_q(my_fed->in_transit_message_tags);
     lf_print_info("RTI: Transient Federate %d thread exited.", my_fed->enclave.id);
 
+    // Notify downstream and upstream federates that this transient has disconnected, mirroring
+    // notify_federate_disconnected(). A transient typically leaves without a MSG_TYPE_RESIGN
+    // handshake (e.g., it calls lf_stop() and simply closes its socket), so this abrupt-disconnect
+    // path is reached instead of handle_federate_resign(). Without these notifications, upstream
+    // federates keep a stale outbound P2P connection to the transient and never reconnect to it
+    // when it rejoins, silently dropping every message addressed to it. The federate-side handlers
+    // are idempotent, so this is safe even if the notifications were already sent via a resign.
+    for (int j = 0; j < my_fed->enclave.num_immediate_downstreams; j++) {
+      federate_info_t* downstream = GET_FED_INFO(my_fed->enclave.immediate_downstreams[j]);
+      if (downstream->enclave.state != NOT_CONNECTED) {
+        send_upstream_disconnected_locked(downstream, my_fed);
+      }
+    }
+    send_outbound_disconnected_locked(my_fed);
+
     // Update the number of connected transient federates
     rti_remote->number_of_connected_transient_federates--;
 
@@ -1914,16 +1929,13 @@ static int32_t receive_and_check_fed_id_message(net_abstraction_t fed_net) {
   fed->enclave.state = PENDING;
 
   LF_PRINT_DEBUG("RTI responding with MSG_TYPE_ACK to federate %d.", fed_id);
-  // Send an MSG_TYPE_ACK message with a tag payload.
-  // Use NEVER_TAG as filler, because it is unneeded in this case.
-  unsigned char ack_message[MSG_TYPE_ACK_LENGTH];
+  unsigned char ack_message[1];
   ack_message[0] = MSG_TYPE_ACK;
-  encode_tag(&ack_message[1], NEVER_TAG);
   if (rti_remote->base.tracing_enabled) {
     tracepoint_rti_to_federate(send_ACK, fed_id, NULL);
   }
   LF_MUTEX_LOCK(&rti_mutex);
-  if (write_to_net_close_on_error(fed->net, MSG_TYPE_ACK_LENGTH, ack_message)) {
+  if (write_to_net_close_on_error(fed->net, 1, ack_message)) {
     LF_MUTEX_UNLOCK(&rti_mutex);
     lf_print_error("RTI failed to write MSG_TYPE_ACK message to federate %d.", fed_id);
     return -1;

--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -1809,7 +1809,8 @@ static int32_t receive_and_check_fed_id_message(net_abstraction_t fed_net) {
     } else {
       send_reject(fed_net, UNEXPECTED_MESSAGE);
     }
-    lf_print_error("RTI expected a MSG_TYPE_FED_IDS or MSG_TYPE_TRANSIENT_FED_IDSmessage. Got %u (see net_common.h).", buffer[0]);
+    lf_print_error("RTI expected a MSG_TYPE_FED_IDS or MSG_TYPE_TRANSIENT_FED_IDSmessage. Got %u (see net_common.h).",
+                   buffer[0]);
     return -1;
   } else {
     // Received federate ID.

--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -1171,7 +1171,7 @@ static void send_start_tag_locked(federate_info_t* my_fed) {
 
 void handle_timestamp(federate_info_t* my_fed, int type) {
   size_t buffer_length =
-      (type == MSG_TYPE_TIMESTAMP) ? MSG_TYPE_TIMESTAMP_LENGTH : MSG_TYPE_TIMESTAMP_WITH_MICROSTEP_LENGTH;
+      (type == MSG_TYPE_TIMESTAMP) ? MSG_TYPE_TIMESTAMP_LENGTH : MSG_TYPE_TAG_LENGTH;
   unsigned char buffer[--buffer_length];
   // Read bytes from the network abstraction. We need 8 bytes, at least
   read_from_net_fail_on_error(my_fed->net, buffer_length, (unsigned char*)&buffer,
@@ -1179,7 +1179,7 @@ void handle_timestamp(federate_info_t* my_fed, int type) {
 
   instant_t timestamp = swap_bytes_if_big_endian_int64(*((instant_t*)(&buffer)));
   microstep_t microstep = 0u;
-  if (type == MSG_TYPE_TIMESTAMP_WITH_MICROSTEP) {
+  if (type == MSG_TYPE_TAG) {
     microstep = extract_uint32(&buffer[sizeof(instant_t)]);
   }
   if (rti_remote->base.tracing_enabled) {
@@ -1626,7 +1626,7 @@ void* federate_info_thread_TCP(void* fed) {
     LF_PRINT_DEBUG("RTI: Received message type %u from federate %d.", buffer[0], my_fed->enclave.id);
     switch (buffer[0]) {
     case MSG_TYPE_TIMESTAMP:
-    case MSG_TYPE_TIMESTAMP_WITH_MICROSTEP:
+    case MSG_TYPE_TAG:
       handle_timestamp(my_fed, buffer[0]);
       break;
     case MSG_TYPE_ADDRESS_QUERY:
@@ -1862,11 +1862,11 @@ static int32_t receive_and_check_fed_id_message(net_abstraction_t fed_net) {
   federate_info_t* fed;
   // If the federate is already connected (making the request a duplicate), and that
   // the federate is transient, and it is the execution phase, then  mark that a hot
-  // swap is in progreass and initialize the hot_swap_federate.
+  // swap is in progress and initialize the hot_swap_federate.
   // Otherwise, proceed with a normal transinet connection
   if (fed_twin->enclave.state != NOT_CONNECTED && is_transient && fed_twin->is_transient &&
       rti_remote->phase == execution_phase && !hot_swap_in_progress) {
-    // Allocate memory for the new federate and initilize it
+    // Allocate memory for the new federate and initialize it
     hot_swap_federate = (federate_info_t*)malloc(sizeof(federate_info_t));
     initialize_federate(hot_swap_federate, fed_id);
 
@@ -1875,7 +1875,6 @@ static int32_t receive_and_check_fed_id_message(net_abstraction_t fed_net) {
     hot_swap_in_progress = true;
     lf_mutex_unlock(&rti_mutex);
     hot_swap_old_resigned = false;
-    // free(fed);  // Free the old memory to prevent memory leak
     fed = hot_swap_federate;
     lf_print_info("RTI: Hot Swap starting for federate %d.", fed_id);
   } else {

--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -1170,8 +1170,7 @@ static void send_start_tag_locked(federate_info_t* my_fed) {
 }
 
 void handle_timestamp(federate_info_t* my_fed, int type) {
-  size_t buffer_length =
-      (type == MSG_TYPE_TIMESTAMP) ? MSG_TYPE_TIMESTAMP_LENGTH : MSG_TYPE_TAG_LENGTH;
+  size_t buffer_length = (type == MSG_TYPE_TIMESTAMP) ? MSG_TYPE_TIMESTAMP_LENGTH : MSG_TYPE_TAG_LENGTH;
   unsigned char buffer[--buffer_length];
   // Read bytes from the network abstraction. We need 8 bytes, at least
   read_from_net_fail_on_error(my_fed->net, buffer_length, (unsigned char*)&buffer,

--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -1769,7 +1769,7 @@ void send_reject(net_abstraction_t net_abs, rejection_code_t error_code) {
 }
 
 /**
- * Listen for a MSG_TYPE_FED_IDS message, which includes as a payload
+ * Listen for a MSG_TYPE_FED_IDS or MSG_TYPE_TRANSIENT_FED_IDSmessage, which includes as a payload
  * a federate ID and a federation ID. If the federation ID
  * matches this federation, send an MSG_TYPE_ACK and otherwise send
  * a MSG_TYPE_REJECT message.
@@ -1778,11 +1778,10 @@ void send_reject(net_abstraction_t net_abs, rejection_code_t error_code) {
  */
 static int32_t receive_and_check_fed_id_message(net_abstraction_t fed_net) {
   // Buffer for message ID, federate ID, type (persistent or transient), and federation ID length.
-  size_t length = 1 + sizeof(uint16_t) + 1; // Message ID, federate ID and length of federation ID.
-  unsigned char buffer[length];
+  unsigned char buffer[MSG_TYPE_FED_IDS_LENGTH];
 
   // Read bytes from the network abstraction. We need 4 bytes.
-  if (read_from_net_close_on_error(fed_net, length, buffer)) {
+  if (read_from_net_close_on_error(fed_net, MSG_TYPE_FED_IDS_LENGTH, buffer)) {
     lf_print_error("RTI failed to read from accepted connection.");
     return -1;
   }
@@ -1791,7 +1790,7 @@ static int32_t receive_and_check_fed_id_message(net_abstraction_t fed_net) {
   bool is_transient = false;
 
   // First byte received is the message type.
-  if (buffer[0] != MSG_TYPE_FED_IDS) {
+  if (buffer[0] != MSG_TYPE_FED_IDS && buffer[0] != MSG_TYPE_TRANSIENT_FED_IDS) {
     if (rti_remote->base.tracing_enabled) {
       tracepoint_rti_to_federate(send_REJECT, fed_id, NULL);
     }
@@ -1810,16 +1809,14 @@ static int32_t receive_and_check_fed_id_message(net_abstraction_t fed_net) {
     } else {
       send_reject(fed_net, UNEXPECTED_MESSAGE);
     }
-    lf_print_error("RTI expected a MSG_TYPE_FED_IDS message. Got %u (see net_common.h).", buffer[0]);
+    lf_print_error("RTI expected a MSG_TYPE_FED_IDS or MSG_TYPE_TRANSIENT_FED_IDSmessage. Got %u (see net_common.h).", buffer[0]);
     return -1;
   } else {
     // Received federate ID.
     fed_id = extract_uint16(buffer + 1);
     // Read the federation ID length, which is one byte.
     size_t federation_id_length = (size_t)buffer[sizeof(uint16_t) + 1];
-    unsigned char buf;
-    read_from_net_close_on_error(fed_net, 1, &buf);
-    is_transient = (buf == 1) ? true : false;
+    is_transient = (buffer[0] == MSG_TYPE_TRANSIENT_FED_IDS) ? true : false;
 
     if (is_transient) {
       LF_PRINT_LOG("RTI received federate ID: %d, which is transient.", fed_id);

--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -1754,7 +1754,7 @@ static int32_t receive_and_check_fed_id_message(net_abstraction_t fed_net) {
   bool is_transient = false;
 
   // First byte received is the message type.
-  if (buffer[0] != MSG_TYPE_FED_IDS && buffer[0] != MSG_TYPE_TRANSIENT_FED_IDS) {
+  if (buffer[0] != MSG_TYPE_FED_IDS) {
     if (rti_remote->base.tracing_enabled) {
       tracepoint_rti_to_federate(send_REJECT, fed_id, NULL);
     }
@@ -1780,11 +1780,9 @@ static int32_t receive_and_check_fed_id_message(net_abstraction_t fed_net) {
     fed_id = extract_uint16(buffer + 1);
     // Read the federation ID length, which is one byte.
     size_t federation_id_length = (size_t)buffer[sizeof(uint16_t) + 1];
-    if (buffer[0] == MSG_TYPE_TRANSIENT_FED_IDS) {
-      unsigned char buf;
-      read_from_net_close_on_error(fed_net, 1, &buf);
-      is_transient = (buf == 1) ? true : false;
-    }
+    unsigned char buf;
+    read_from_net_close_on_error(fed_net, 1, &buf);
+    is_transient = (buf == 1) ? true : false;
 
     if (is_transient) {
       LF_PRINT_LOG("RTI received federate ID: %d, which is transient.", fed_id);

--- a/core/federated/RTI/rti_remote.c
+++ b/core/federated/RTI/rti_remote.c
@@ -1156,6 +1156,12 @@ static void send_start_tag_locked(federate_info_t* my_fed) {
     // message has been sent. That MSG_TYPE_TIMESTAMP_START message grants time advance to
     // the federate to the my_fed->effective_start_tag.time.
     my_fed->enclave.state = GRANTED;
+    // Until the transient reports its first NET, bound downstream EIMT by its
+    // effective start (startup reactions, etc.). Otherwise NEVER is treated as
+    // federation start_time, which is wrong for late joiners.
+    if (my_fed->is_transient && lf_tag_compare(my_fed->enclave.next_event, NEVER_TAG) == 0) {
+      my_fed->enclave.next_event = my_fed->effective_start_tag;
+    }
     lf_cond_broadcast(&sent_start_time);
     LF_PRINT_LOG("RTI sent start time " PRINTF_TIME " to federate %d.", start_time, my_fed->enclave.id);
 
@@ -1311,12 +1317,12 @@ void handle_timestamp(federate_info_t* my_fed, int type) {
         }
       }
 
-      // For every downstream that has a pending grant that is higher than the
-      // effective_start_time of the federate, cancel it.
-      // FIXME: Should this be higher-than or equal to?
-      // FIXME: Also, won't the grant simply be lost?
-      // If the joining federate doesn't send anything, the downstream federate won't issue another
-      // NET.
+      // For every downstream that has a pending delayed grant at or after this
+      // federate's effective start tag, cancel it. Those grants were computed while
+      // this transient was absent and must not be sent once it can produce events
+      // at the effective start tag (e.g. TAG(t) must not race with a message at t).
+      // Grants strictly earlier than the effective start remain valid.
+      // TAG re-evaluation for downstreams happens after send_start_tag_locked below.
       for (int j = 0; j < my_fed->enclave.num_immediate_downstreams; j++) {
         federate_info_t* downstream = GET_FED_INFO(my_fed->enclave.immediate_downstreams[j]);
 
@@ -1325,12 +1331,18 @@ void handle_timestamp(federate_info_t* my_fed, int type) {
           continue;
         }
 
-        // Check the pending grants, if any, and keep it only if it is
-        // sooner than the effective start tag.
         pqueue_delayed_grant_element_t* dge =
             pqueue_delayed_grants_find_by_fed_id(rti_remote->delayed_grants, downstream->enclave.id);
-        if (dge != NULL && lf_tag_compare(dge->base.tag, my_fed->effective_start_tag) > 0) {
+        if (dge != NULL && lf_tag_compare(dge->base.tag, my_fed->effective_start_tag) >= 0) {
+          LF_PRINT_LOG("RTI: Canceling delayed grant of " PRINTF_TAG
+                       " for federate %d because transient federate %d rejoined with "
+                       "effective start " PRINTF_TAG ".",
+                       dge->base.tag.time - start_time, dge->base.tag.microstep, downstream->enclave.id,
+                       my_fed->enclave.id, my_fed->effective_start_tag.time - start_time,
+                       my_fed->effective_start_tag.microstep);
           pqueue_delayed_grants_remove(rti_remote->delayed_grants, dge);
+          free(dge);
+          lf_cond_signal(&updated_delayed_grants);
         }
       }
     } else {
@@ -1371,6 +1383,17 @@ void handle_timestamp(federate_info_t* my_fed, int type) {
     // get re-computed.
     // FIXME: Maybe optimize it to only invalidate those affected by the transient
     invalidate_min_delays();
+
+    // With the transient granted and min_delays refreshed, re-evaluate TAG/PTAG for
+    // downstreams (delayed grants at or after the effective start were canceled above).
+    if (type == MSG_TYPE_TIMESTAMP) {
+      for (int j = 0; j < my_fed->enclave.num_immediate_downstreams; j++) {
+        federate_info_t* downstream = GET_FED_INFO(my_fed->enclave.immediate_downstreams[j]);
+        if (downstream->enclave.state != NOT_CONNECTED) {
+          notify_advance_grant_if_safe(&(downstream->enclave));
+        }
+      }
+    }
 
     LF_MUTEX_UNLOCK(&rti_mutex);
   }
@@ -2428,12 +2451,28 @@ static void* lf_delayed_grants_thread(void* nothing) {
         if (next == new_next) {
           pqueue_delayed_grants_pop(rti_remote->delayed_grants);
           federate_info_t* fed = GET_FED_INFO(next->fed_id);
-          if (next->is_provisional) {
+          // If all upstream transients have reconnected, this delayed grant is stale:
+          // it was queued while an upstream was absent and must not bypass EIMT checks.
+          // Drop it and let the normal TAG/PTAG logic decide.
+          if (get_num_absent_upstream_transients(fed) == 0) {
+            LF_PRINT_LOG("RTI: Dropping delayed grant of " PRINTF_TAG
+                         " for federate %d because upstream transient(s) reconnected.",
+                         next->base.tag.time - start_time, next->base.tag.microstep, next->fed_id);
+            free(next);
+            notify_advance_grant_if_safe(&(fed->enclave));
+          } else if (lf_tag_compare(next->base.tag, fed->enclave.last_granted) <= 0 ||
+                     lf_tag_compare(next->base.tag, fed->enclave.last_provisionally_granted) <= 0) {
+            // Redundant with a grant already sent (e.g. while the transient was absent).
+            LF_PRINT_LOG("RTI: Dropping redundant delayed grant of " PRINTF_TAG " for federate %d.",
+                         next->base.tag.time - start_time, next->base.tag.microstep, next->fed_id);
+            free(next);
+          } else if (next->is_provisional) {
             notify_provisional_tag_advance_grant_immediate(&(fed->enclave), next->base.tag);
+            free(next);
           } else {
             notify_tag_advance_grant_immediate(&(fed->enclave), next->base.tag);
+            free(next);
           }
-          free(next);
         }
       } else if (ret != 0) {
         // An error occurred.

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -2031,7 +2031,7 @@ void lf_connect_to_federate(uint16_t remote_federate_id, tag_t joined_tag, int32
       _fed.downstream_p2p_joined_tag[remote_federate_id] = joined_tag;
 
       write_to_net_fail_on_error(_fed.net_to_RTI, 1 + sizeof(uint16_t) + 1, buffer, &lf_outbound_net_mutex,
-                                "Failed to send address query for federate %d to RTI.", remote_federate_id);
+                                 "Failed to send address query for federate %d to RTI.", remote_federate_id);
       LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
 
       // Read RTI's response.

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -108,15 +108,15 @@ static void send_time(unsigned char type, instant_t time, microstep_t microstep)
   LF_PRINT_DEBUG("Sending time " PRINTF_TIME " to the RTI.", time);
 
   size_t bytes_to_write;
-  if (type == MSG_TYPE_TIMESTAMP_WITH_MICROSTEP) {
-    bytes_to_write = MSG_TYPE_TIMESTAMP_WITH_MICROSTEP_LENGTH;
+  if (type == MSG_TYPE_TAG) {
+    bytes_to_write = MSG_TYPE_TAG_LENGTH;
   } else {
     bytes_to_write = MSG_TYPE_TIMESTAMP_LENGTH;
   }
   unsigned char buffer[bytes_to_write];
   buffer[0] = type;
   encode_int64(time, &(buffer[1]));
-  if (type == MSG_TYPE_TIMESTAMP_WITH_MICROSTEP) {
+  if (type == MSG_TYPE_TAG) {
     encode_uint32((microstep_t)microstep, &(buffer[1 + sizeof(instant_t)]));
   }
 
@@ -1083,7 +1083,7 @@ static void handle_downstream_disconnected_message(void) {
 static instant_t get_start_time_from_rti(instant_t my_physical_time, microstep_t my_microstep) {
   // Send the timestamp marker first.
 #ifdef FEDERATED_DECENTRALIZED
-  send_time(MSG_TYPE_TIMESTAMP_WITH_MICROSTEP, my_physical_time, my_microstep);
+  send_time(MSG_TYPE_TAG, my_physical_time, my_microstep);
 #else
   send_time(MSG_TYPE_TIMESTAMP, my_physical_time, my_microstep);
 #endif

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -1074,7 +1074,6 @@ static void handle_downstream_disconnected_message(void) {
  * may suggest a different timestamp, that is the max tag + microstep of the conetced outboud federates.
  * In such a case, it will be higher than the actual physical time.
  *
- *
  * This procedure blocks until the response is
  * received from the RTI.
  * @param my_physical_time The physical time at this federate, or the time in the tag
@@ -1094,7 +1093,8 @@ static instant_t get_start_time_from_rti(instant_t my_physical_time, microstep_t
   size_t buffer_length = (_fed.is_transient) ? MSG_TYPE_TIMESTAMP_TAG_LENGTH : MSG_TYPE_TIMESTAMP_LENGTH;
   unsigned char buffer[buffer_length];
 
-  // Deferred OUTBOUND_CONNECTED notifications: calling lf_connect_to_federate() inline
+  // FIXME: This comment is hard to understand.
+  // Deferred DOWNSTREAM_CONNECTED notifications: calling lf_connect_to_federate() inline
   // here is unsafe because the RTI may have already written MSG_TYPE_TIMESTAMP into this
   // federate's TCP stream immediately after MSG_TYPE_DOWNSTREAM_CONNECTED (from a concurrent
   // send_start_tag_locked call for the transient federate). If we call lf_connect_to_federate()
@@ -2158,7 +2158,7 @@ void lf_connect_to_federate(uint16_t remote_federate_id, tag_t joined_tag, int p
       read_from_net_fail_on_error(net, 1, (unsigned char*)buffer,
                                   "Failed to read error code from federate %d in response to sending fed_id.",
                                   remote_federate_id);
-      lf_print_error("Received MSG_TYPE_REJECT message from remote federate (%d).", buffer[0]);
+      lf_print_error("Received MSG_TYPE_REJECT message from remote federate (error code: %d).", buffer[0]);
       result = -1;
       // Wait ADDRESS_QUERY_RETRY_INTERVAL nanoseconds.
       lf_sleep(ADDRESS_QUERY_RETRY_INTERVAL);

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -2079,6 +2079,21 @@ void lf_connect_to_federate(uint16_t remote_federate_id, tag_t joined_tag, int32
   params.socket_params.server_ip_addr = &host_ip_addr;
 #endif
 
+  // Avoid opening a duplicate outbound connection to the same federate. More than one trigger
+  // can request a connection to a transient downstream federate: the startup outbound loop may
+  // obtain a valid port and connect, and the RTI may (concurrently or subsequently) send a
+  // MSG_TYPE_DOWNSTREAM_CONNECTED notification for the same join. A duplicate connection would
+  // push the remote federate beyond its expected inbound P2P connection count and cause it to
+  // abort. If a connection already exists, do not open another one.
+  LF_MUTEX_LOCK(&lf_outbound_net_mutex);
+  bool already_connected = _fed.net_for_outbound_p2p_connections[remote_federate_id] != NULL;
+  LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
+  if (already_connected) {
+    LF_PRINT_LOG("Outbound P2P connection to federate %d is already established. Not reconnecting.",
+                 remote_federate_id);
+    return;
+  }
+
   net_abstraction_t net = connect_to_net((net_params_t)&params);
   if (net == NULL) {
     lf_print_error_and_exit("Failed to connect to federate.");
@@ -2098,6 +2113,9 @@ void lf_connect_to_federate(uint16_t remote_federate_id, tag_t joined_tag, int32
       // treat it as a soft error condition and return.
       lf_print_error("Failed to connect to federate %d with timeout: " PRINTF_TIME ". Giving up.", remote_federate_id,
                      CONNECT_TIMEOUT);
+      if (net != NULL) {
+        shutdown_net(net, false);
+      }
       return;
     }
 
@@ -2105,6 +2123,17 @@ void lf_connect_to_federate(uint16_t remote_federate_id, tag_t joined_tag, int32
     if (rti_failed()) {
       break;
     }
+
+    // (Re)establish the TCP connection. On the first iteration this is the connection opened
+    // above. After a connection reset by the remote federate (handled below), net is NULL and
+    // we open a fresh connection before retrying the handshake.
+    if (net == NULL) {
+      net = connect_to_net((net_params_t)&params);
+      if (net == NULL) {
+        lf_print_error_and_exit("Failed to connect to federate.");
+      }
+    }
+
     // Send the federate ID to the remote federate.
     size_t buffer_length = 1 + sizeof(uint16_t) + 1 + 1;
     unsigned char buffer[buffer_length];
@@ -2126,16 +2155,25 @@ void lf_connect_to_federate(uint16_t remote_federate_id, tag_t joined_tag, int32
                                "Failed to send federation id to federate %d.", remote_federate_id);
 
     // For transient downstream connections, a connection reset from the remote side
-    // (e.g. macOS resets the TCP connection if the accept loop hasn't run yet) is
-    // a soft error: the RTI will resend MSG_TYPE_DOWNSTREAM_CONNECTED when the transient
-    // is ready. Using the non-fatal read here prevents a spurious fatal exit on macOS.
+    // (e.g. macOS resets the TCP connection if the accept loop hasn't run yet) is a soft
+    // error. Using the non-fatal read here prevents a spurious fatal exit on macOS.
     int ack_read_failed = read_from_net(net, 1, (unsigned char*)buffer);
     if (ack_read_failed) {
       if (is_transient) {
+        // The remote transient federate may not have run its accept loop yet, so its socket
+        // layer reset our connection. Close the reset connection and retry the handshake
+        // (bounded by CONNECT_TIMEOUT). We must retry here rather than give up: the RTI sends
+        // MSG_TYPE_DOWNSTREAM_CONNECTED only once per join and does not resend it, so waiting
+        // for another notification would leave this federate permanently unable to reach the
+        // transient, silently dropping every message addressed to it.
         lf_print_warning("Failed to read MSG_TYPE_ACK from transient federate %d. Connection may have been reset. "
-                         "Will retry when RTI notifies of reconnection.",
+                         "Retrying.",
                          remote_federate_id);
-        return;
+        shutdown_net(net, false);
+        net = NULL;
+        result = -1;
+        lf_sleep(ADDRESS_QUERY_RETRY_INTERVAL);
+        continue;
       }
       lf_print_error_and_exit("Failed to read MSG_TYPE_ACK from federate %d in response to sending fed_id.",
                               remote_federate_id);

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -2262,7 +2262,7 @@ void lf_connect_to_rti(const char* hostname, int port) {
   while (!CHECK_TIMEOUT(start_connect, CONNECT_TIMEOUT) && !_lf_termination_executed) {
 
     // Have connected to an RTI, but not sure it's the right RTI.
-    // Send a MSG_TYPE_FED_IDS message and wait for a reply.
+    // Send a MSG_TYPE_FED_IDS or MSG_TYPE_TRANSIENT_FED_IDS message and wait for a reply.
     // Notify the RTI of the ID of this federate and its federation.
 
 #ifdef FEDERATED_AUTHENTICATED
@@ -2281,7 +2281,11 @@ void lf_connect_to_rti(const char* hostname, int port) {
 
     unsigned char buffer[MSG_TYPE_FED_IDS_LENGTH];
     // Send the message type first.
-    buffer[0] = MSG_TYPE_FED_IDS;
+    if (_fed.is_transient) {
+      buffer[0] = MSG_TYPE_TRANSIENT_FED_IDS;
+    } else {
+      buffer[0] = MSG_TYPE_FED_IDS;
+    }
 
     // Next send the federate ID.
     if (_lf_my_fed_id == UINT16_MAX) {
@@ -2296,9 +2300,6 @@ void lf_connect_to_rti(const char* hostname, int port) {
 
     // Trace the event when tracing is enabled
     tracepoint_federate_to_rti(send_FED_ID, _lf_my_fed_id, NULL);
-
-    // Next send the federate type (persistent or transient)
-    buffer[2 + sizeof(uint16_t)] = _fed.is_transient ? 1 : 0;
 
     // No need for a mutex here because no other threads are writing to this network abstraction.
     if (write_to_net(_fed.net_to_RTI, MSG_TYPE_FED_IDS_LENGTH, buffer)) {

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -100,27 +100,16 @@ federation_metadata_t federation_metadata = {
 
 /**
  * Send a time to the RTI. This acquires the lf_outbound_net_mutex.
- * @param type The message type (MSG_TYPE_TIMESTAMP).
  * @param time The time.
- * @param microstep The microstep.
  */
-static void send_time(unsigned char type, instant_t time, microstep_t microstep) {
+static void send_time(instant_t time) {
   LF_PRINT_DEBUG("Sending time " PRINTF_TIME " to the RTI.", time);
 
-  size_t bytes_to_write;
-  if (type == MSG_TYPE_TAG) {
-    bytes_to_write = MSG_TYPE_TAG_LENGTH;
-  } else {
-    bytes_to_write = MSG_TYPE_TIMESTAMP_LENGTH;
-  }
+  size_t bytes_to_write = MSG_TYPE_TIMESTAMP_LENGTH;
   unsigned char buffer[bytes_to_write];
-  buffer[0] = type;
+  buffer[0] = MSG_TYPE_TIMESTAMP;
   encode_int64(time, &(buffer[1]));
-  if (type == MSG_TYPE_TAG) {
-    encode_uint32((microstep_t)microstep, &(buffer[1 + sizeof(instant_t)]));
-  }
-
-  tag_t tag = {.time = time, .microstep = microstep};
+  tag_t tag = {.time = time, .microstep = 0};
   tracepoint_federate_to_rti(send_TIMESTAMP, _lf_my_fed_id, &tag);
 
   LF_MUTEX_LOCK(&lf_outbound_net_mutex);
@@ -132,22 +121,24 @@ static void send_time(unsigned char type, instant_t time, microstep_t microstep)
 /**
  * Send a tag to the RTI.
  * This function acquires the lf_outbound_net_mutex.
- * @param type The message type (MSG_TYPE_NEXT_EVENT_TAG or MSG_TYPE_LATEST_TAG_CONFIRMED).
+ * @param type The message type (MSG_TYPE_TAG or MSG_TYPE_NEXT_EVENT_TAG or MSG_TYPE_LATEST_TAG_CONFIRMED).
  * @param tag The tag.
  */
 static void send_tag(unsigned char type, tag_t tag) {
-  LF_PRINT_DEBUG("Sending tag " PRINTF_TAG " to the RTI.", tag.time - start_time, tag.microstep);
+  LF_PRINT_DEBUG("Sending tag " PRINTF_TAG " to the RTI.", tag.time, tag.microstep);
   size_t bytes_to_write = 1 + sizeof(instant_t) + sizeof(microstep_t);
   unsigned char buffer[bytes_to_write];
   buffer[0] = type;
   encode_tag(&(buffer[1]), tag);
 
-  trace_event_t event_type = (type == MSG_TYPE_NEXT_EVENT_TAG) ? send_NET : send_LTC;
+  trace_event_t event_type = send_TAG;
+  if (type == MSG_TYPE_NEXT_EVENT_TAG) event_type = send_NET;
+  if (type == MSG_TYPE_LATEST_TAG_CONFIRMED) event_type = send_LTC;
   // Trace the event when tracing is enabled
   tracepoint_federate_to_rti(event_type, _lf_my_fed_id, &tag);
   LF_MUTEX_LOCK(&lf_outbound_net_mutex);
   write_to_net_fail_on_error(_fed.net_to_RTI, bytes_to_write, buffer, &lf_outbound_net_mutex,
-                             "Failed to send tag " PRINTF_TAG " to the RTI.", tag.time - start_time, tag.microstep);
+                             "Failed to send tag " PRINTF_TAG " to the RTI.", tag.time, tag.microstep);
   LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
 }
 
@@ -1033,7 +1024,7 @@ static void handle_downstream_connected_message(void) {
   tracepoint_federate_from_rti(receive_DOWNSTREAM_CONNECTED, _lf_my_fed_id, NULL);
   LF_PRINT_DEBUG("Received notification that downstream transient federate %d has connected.", remote_federate_id);
 
-  // Set the effective start tag of the connecting transient, so that a message is not sent.
+  // Get the effective start tag to be recorded in lf_connect_to_federate() after acquiring the lock.
   tag_t joined_tag = extract_tag(&buffer[2]);
 
   // Read the port number and IP address
@@ -1083,9 +1074,9 @@ static void handle_downstream_disconnected_message(void) {
 static instant_t get_start_time_from_rti(instant_t my_physical_time, microstep_t my_microstep) {
   // Send the timestamp marker first.
 #ifdef FEDERATED_DECENTRALIZED
-  send_time(MSG_TYPE_TAG, my_physical_time, my_microstep);
+  send_time(my_physical_time);
 #else
-  send_time(MSG_TYPE_TIMESTAMP, my_physical_time, my_microstep);
+  send_tag(MSG_TYPE_TAG, my_physical_time, my_microstep);
 #endif
 
   // Read bytes from the network abstraction. We need 9 bytes.

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -132,8 +132,10 @@ static void send_tag(unsigned char type, tag_t tag) {
   encode_tag(&(buffer[1]), tag);
 
   trace_event_t event_type = send_TAG;
-  if (type == MSG_TYPE_NEXT_EVENT_TAG) event_type = send_NET;
-  if (type == MSG_TYPE_LATEST_TAG_CONFIRMED) event_type = send_LTC;
+  if (type == MSG_TYPE_NEXT_EVENT_TAG)
+    event_type = send_NET;
+  if (type == MSG_TYPE_LATEST_TAG_CONFIRMED)
+    event_type = send_LTC;
   // Trace the event when tracing is enabled
   tracepoint_federate_to_rti(event_type, _lf_my_fed_id, &tag);
   LF_MUTEX_LOCK(&lf_outbound_net_mutex);

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -1990,79 +1990,81 @@ void lf_terminate_execution(environment_t* env) {
 //////////////////////////////////////////////////////////////////////////////////
 // Public functions (declared in federate.h, in alphabetical order)
 
-void lf_connect_to_federate(uint16_t remote_federate_id, tag_t joined_tag, int p, uint32_t adr) {
-  int result = -1;
+void lf_connect_to_federate(uint16_t remote_federate_id, tag_t joined_tag, int32_t port, uint32_t ip_address) {
 
   bool is_transient = lf_tag_compare(joined_tag, NEVER_TAG) > 0;
 
-  // Ask the RTI for port number of the remote federate.
-  // The buffer is used for both sending and receiving replies.
-  // The size is what is needed for receiving replies.
-  unsigned char buffer[sizeof(int32_t) + INET_ADDRSTRLEN + 1];
-  int port = p;
   struct in_addr host_ip_addr;
-  host_ip_addr.s_addr = (in_addr_t)adr;
+  host_ip_addr.s_addr = (in_addr_t)ip_address;
   instant_t start_connect = lf_time_physical();
+
+  // If the port number is provided, then simply record the joined tag.
+  // Otherwise, ask the RTI for the port number and IP address.
   if (port != -1) {
     LF_MUTEX_LOCK(&lf_outbound_net_mutex);
     // This should be set while holding the mutex.
     _fed.downstream_p2p_joined_tag[remote_federate_id] = joined_tag;
     LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
-  }
-  // If the remote federate if persistent, iterate until we get a valid port number from the RTI,
-  // If not, execute only once, as a request registration.
-  while (port == -1 && !_lf_termination_executed) {
-    buffer[0] = MSG_TYPE_ADDRESS_QUERY;
-    // NOTE: Sending messages in little endian.
-    encode_uint16(remote_federate_id, &(buffer[1]));
-    // Indicate whether the remote federate being queried is transient.
-    buffer[1 + sizeof(uint16_t)] = is_transient ? 1 : 0;
+  } else {
+    // Iterate until we get a valid port number from the RTI or time out.
+    // If the remote federate is transient, execute only once, even if the RTI
+    // does not reply with a valid port number.
+    while (port == -1 && !_lf_termination_executed) {
+      // The buffer is used for both sending and receiving replies.
+      // The size is what is needed for receiving replies.
+      unsigned char buffer[sizeof(int32_t) + INET_ADDRSTRLEN + 1];
 
-    LF_PRINT_DEBUG("Sending address query for federate %d.", remote_federate_id);
-    // Trace the event when tracing is enabled
-    tracepoint_federate_to_rti(send_ADR_QR, _lf_my_fed_id, NULL);
+      buffer[0] = MSG_TYPE_ADDRESS_QUERY;
+      encode_uint16(remote_federate_id, &(buffer[1]));
+      // Indicate whether the remote federate being queried is transient.
+      buffer[1 + sizeof(uint16_t)] = is_transient ? 1 : 0;
 
-    LF_MUTEX_LOCK(&lf_outbound_net_mutex);
-    // This should be set while holding the mutex.
-    _fed.downstream_p2p_joined_tag[remote_federate_id] = joined_tag;
+      LF_PRINT_DEBUG("Sending address query for federate %d.", remote_federate_id);
+      // Trace the event when tracing is enabled
+      tracepoint_federate_to_rti(send_ADR_QR, _lf_my_fed_id, NULL);
 
-    write_to_net_fail_on_error(_fed.net_to_RTI, 1 + sizeof(uint16_t) + 1, buffer, &lf_outbound_net_mutex,
-                               "Failed to send address query for federate %d to RTI.", remote_federate_id);
-    LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
+      LF_MUTEX_LOCK(&lf_outbound_net_mutex);
+      // This should be set while holding the mutex.
+      _fed.downstream_p2p_joined_tag[remote_federate_id] = joined_tag;
 
-    // Read RTI's response.
-    read_from_net_fail_on_error(_fed.net_to_RTI, sizeof(int32_t) + 1, buffer,
-                                "Failed to read the requested port number for federate %d from RTI.",
-                                remote_federate_id);
+      write_to_net_fail_on_error(_fed.net_to_RTI, 1 + sizeof(uint16_t) + 1, buffer, &lf_outbound_net_mutex,
+                                "Failed to send address query for federate %d to RTI.", remote_federate_id);
+      LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
 
-    if (buffer[0] != MSG_TYPE_ADDRESS_QUERY_REPLY) {
-      // Unexpected reply. Could be that RTI has failed and sent a resignation.
-      if (buffer[0] == MSG_TYPE_FAILED) {
-        lf_print_error_and_exit("RTI has failed.");
-      } else {
-        lf_print_error_and_exit("Unexpected reply of type %hhu from RTI (see net_common.h).", buffer[0]);
+      // Read RTI's response.
+      read_from_net_fail_on_error(_fed.net_to_RTI, sizeof(int32_t) + 1, buffer,
+                                  "Failed to read the requested port number for federate %d from RTI.",
+                                  remote_federate_id);
+
+      if (buffer[0] != MSG_TYPE_ADDRESS_QUERY_REPLY) {
+        // Unexpected reply. Could be that RTI has failed and sent a resignation.
+        if (buffer[0] == MSG_TYPE_FAILED) {
+          lf_print_error_and_exit("RTI has failed.");
+        } else {
+          lf_print_error_and_exit("Unexpected reply of type %hhu from RTI (see net_common.h).", buffer[0]);
+        }
       }
-    }
-    port = extract_int32(&buffer[1]);
+      port = extract_int32(&buffer[1]);
 
-    read_from_net_fail_on_error(_fed.net_to_RTI, sizeof(host_ip_addr), (unsigned char*)&host_ip_addr,
-                                "Failed to read the IP address for federate %d from RTI.", remote_federate_id);
-    tracepoint_federate_from_rti(receive_ADR_QR_REP, _lf_my_fed_id, NULL);
+      read_from_net_fail_on_error(_fed.net_to_RTI, sizeof(host_ip_addr), (unsigned char*)&host_ip_addr,
+                                  "Failed to read the IP address for federate %d from RTI.", remote_federate_id);
+      tracepoint_federate_from_rti(receive_ADR_QR_REP, _lf_my_fed_id, NULL);
 
-    // A reply of -1 for the port means that the RTI does not know
-    // the port number of the remote federate, presumably because the
-    // remote federate has not yet sent an MSG_TYPE_ADDRESS_ADVERTISEMENT message to the RTI.
-    // Sleep for some time before retrying.
-    if (port == -1 && !is_transient) {
-      if (CHECK_TIMEOUT(start_connect, CONNECT_TIMEOUT)) {
-        lf_print_error_and_exit("TIMEOUT obtaining IP/port for federate %d from the RTI.", remote_federate_id);
+      // A reply of -1 for the port means that the RTI does not know
+      // the port number of the remote federate, presumably because the
+      // remote federate has not yet sent an MSG_TYPE_ADDRESS_ADVERTISEMENT message to the RTI.
+      // Sleep for some time before retrying, but only if the remote federate is not transient.
+      if (port == -1 && !is_transient) {
+        if (CHECK_TIMEOUT(start_connect, CONNECT_TIMEOUT)) {
+          lf_print_error_and_exit("TIMEOUT obtaining IP/port for federate %d from the RTI.", remote_federate_id);
+        }
+        // Wait ADDRESS_QUERY_RETRY_INTERVAL nanoseconds.
+        lf_sleep(ADDRESS_QUERY_RETRY_INTERVAL);
+      } else if (port == -1 && is_transient) {
+        // For transient federates, we only execute once, as a request registration. If the RTI does
+        // not reply with a valid port number, we treat it normally and return.
+        return;
       }
-      // Wait ADDRESS_QUERY_RETRY_INTERVAL nanoseconds.
-      lf_sleep(ADDRESS_QUERY_RETRY_INTERVAL);
-    } else if (port == -1 && is_transient) {
-      // For transient federates, we only execute once, as a request registration. If the RTI does
-      // not reply with a valid port number, we treat it normally and return.
-      return;
     }
   }
   assert(port < 65536);
@@ -2092,8 +2094,10 @@ void lf_connect_to_federate(uint16_t remote_federate_id, tag_t joined_tag, int p
     lf_print_error_and_exit("Failed to connect to federate.");
   }
 
+  // Now that we have an IP address and port number, we can connect to the remote federate.
   // Iterate until we either successfully connect or we exceed the CONNECT_TIMEOUT
   start_connect = lf_time_physical();
+  int result = -1;
   while (result < 0 && !_lf_termination_executed) {
     // Try again after some time if the connection failed.
     // Note that this should not really happen since the remote federate should be
@@ -2111,7 +2115,7 @@ void lf_connect_to_federate(uint16_t remote_federate_id, tag_t joined_tag, int p
     if (rti_failed()) {
       break;
     }
-    // Connect was successful.
+    // Send the federate ID to the remote federate.
     size_t buffer_length = 1 + sizeof(uint16_t) + 1 + 1;
     unsigned char buffer[buffer_length];
     buffer[0] = MSG_TYPE_P2P_SENDING_FED_ID;
@@ -2131,7 +2135,7 @@ void lf_connect_to_federate(uint16_t remote_federate_id, tag_t joined_tag, int p
     write_to_net_fail_on_error(net, federation_id_length, (unsigned char*)federation_metadata.federation_id, NULL,
                                "Failed to send federation id to federate %d.", remote_federate_id);
 
-    // For transient outbound connections, a connection reset from the remote side
+    // For transient downstream connections, a connection reset from the remote side
     // (e.g. macOS resets the TCP connection if the accept loop hasn't run yet) is
     // a soft error: the RTI will resend MSG_TYPE_DOWNSTREAM_CONNECTED when the transient
     // is ready. Using the non-fatal read here prevents a spurious fatal exit on macOS.
@@ -2139,7 +2143,7 @@ void lf_connect_to_federate(uint16_t remote_federate_id, tag_t joined_tag, int p
     if (ack_read_failed) {
       if (is_transient) {
         lf_print_warning("Failed to read MSG_TYPE_ACK from transient federate %d. Connection may have been reset. "
-                         "Will retry when RTI notifies reconnection.",
+                         "Will retry when RTI notifies of reconnection.",
                          remote_federate_id);
         return;
       }

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -98,6 +98,7 @@ federation_metadata_t federation_metadata = {
 //////////////////////////////////////////////////////////////////////////////////
 // Static functions (used only internally)
 
+#ifdef FEDERATED_DECENTRALIZED
 /**
  * Send a time to the RTI. This acquires the lf_outbound_net_mutex.
  * @param time The time.
@@ -117,6 +118,7 @@ static void send_time(instant_t time) {
                              "Failed to send time " PRINTF_TIME " to the RTI.", time - start_time);
   LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
 }
+#endif // FEDERATED_DECENTRALIZED
 
 /**
  * Send a tag to the RTI.
@@ -1076,6 +1078,7 @@ static void handle_downstream_disconnected_message(void) {
 static instant_t get_start_time_from_rti(instant_t my_physical_time, microstep_t my_microstep) {
   // Send the timestamp marker first.
 #ifdef FEDERATED_DECENTRALIZED
+  SUPPRESS_UNUSED_WARNING(my_microstep);
   send_time(my_physical_time);
 #else
   send_tag(MSG_TYPE_TAG, my_physical_time, my_microstep);

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -420,8 +420,8 @@ static trigger_handle_t schedule_message_received_from_network_locked(environmen
     _lf_done_using(token);
     LF_MUTEX_UNLOCK(&env->mutex);
     lf_print_error_and_exit(
-        "Received a message at tag " PRINTF_TAG " that has a tag " PRINTF_TAG " that has violated the STP offset. "
-        "Centralized coordination should not have these types of messages.",
+        "Received a message at current tag " PRINTF_TAG " that has a tag " PRINTF_TAG ". "
+        "Centralized coordination should not have tardy messages.",
         env->current_tag.time - start_time, env->current_tag.microstep, tag.time - start_time, tag.microstep);
 #else
     // Set the delay back to 0

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -419,10 +419,10 @@ static trigger_handle_t schedule_message_received_from_network_locked(environmen
     // time advance mechanism is not working correctly.
     _lf_done_using(token);
     LF_MUTEX_UNLOCK(&env->mutex);
-    lf_print_error_and_exit(
-        "Received a message at current tag " PRINTF_TAG " that has a tag " PRINTF_TAG ". "
-        "Centralized coordination should not have tardy messages.",
-        env->current_tag.time - start_time, env->current_tag.microstep, tag.time - start_time, tag.microstep);
+    lf_print_error_and_exit("Received a message at current tag " PRINTF_TAG " that has a tag " PRINTF_TAG ". "
+                            "Centralized coordination should not have tardy messages.",
+                            env->current_tag.time - start_time, env->current_tag.microstep, tag.time - start_time,
+                            tag.microstep);
 #else
     // Set the delay back to 0
     extra_delay = 0LL;

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -2220,7 +2220,7 @@ void lf_connect_to_rti(const char* hostname, int port) {
   while (!CHECK_TIMEOUT(start_connect, CONNECT_TIMEOUT) && !_lf_termination_executed) {
 
     // Have connected to an RTI, but not sure it's the right RTI.
-    // Send a MSG_TYPE_FED_IDS or MSG_TYPE_TRANSIENT_FED_IDS message and wait for a reply.
+    // Send a MSG_TYPE_FED_IDS message and wait for a reply.
     // Notify the RTI of the ID of this federate and its federation.
 
 #ifdef FEDERATED_AUTHENTICATED
@@ -2237,19 +2237,16 @@ void lf_connect_to_rti(const char* hostname, int port) {
     LF_PRINT_LOG("Connected to an RTI. Sending federation ID for authentication.");
 #endif
 
-    unsigned char buffer[5];
+    unsigned char buffer[MSG_TYPE_FED_IDS_LENGTH];
     // Send the message type first.
-    if (_fed.is_transient) {
-      buffer[0] = MSG_TYPE_TRANSIENT_FED_IDS;
-    } else {
-      buffer[0] = MSG_TYPE_FED_IDS;
-    }
+    buffer[0] = MSG_TYPE_FED_IDS;
 
     // Next send the federate ID.
     if (_lf_my_fed_id == UINT16_MAX) {
       lf_print_error_and_exit("Too many federates! More than %d.", UINT16_MAX - 1);
     }
     encode_uint16((uint16_t)_lf_my_fed_id, &buffer[1]);
+
     // Next send the federation ID length.
     // The federation ID is limited to 255 bytes.
     size_t federation_id_length = strnlen(federation_metadata.federation_id, 255);
@@ -2258,14 +2255,11 @@ void lf_connect_to_rti(const char* hostname, int port) {
     // Trace the event when tracing is enabled
     tracepoint_federate_to_rti(send_FED_ID, _lf_my_fed_id, NULL);
 
-    size_t size = 1 + sizeof(uint16_t) + 1;
-    if (_fed.is_transient) {
-      // Next send the federate type (persistent or transient)
-      buffer[2 + sizeof(uint16_t)] = _fed.is_transient ? 1 : 0;
-      size++;
-    }
+    // Next send the federate type (persistent or transient)
+    buffer[2 + sizeof(uint16_t)] = _fed.is_transient ? 1 : 0;
+
     // No need for a mutex here because no other threads are writing to this network abstraction.
-    if (write_to_net(_fed.net_to_RTI, size, buffer)) {
+    if (write_to_net(_fed.net_to_RTI, MSG_TYPE_FED_IDS_LENGTH, buffer)) {
       continue; // Try again, possibly on a new port.
     }
 

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -1019,31 +1019,28 @@ static void handle_upstream_disconnected_message(void) {
 }
 
 /**
- * @brief Handle message from the RTI that a transient outbound federate has connected.
+ * @brief Handle a message from the RTI that a transient downstream federate has connected.
  *
- * Reads the outbound federate's ID, together with the its effective start tag, port and
- * address. Then establish (or re-establish) the outbound P2P connection to it.
- * This function is called inline from listen_to_rti_TCP or get_start_time_from_rti,
- * so it reads the address-query reply directly from net_to_RTI.
+ * This function reads the downstream federate's ID, together with the its effective start tag,
+ * port and IP address. Then it establishes (or re-establishes) the P2P connection to it.
  */
-static void handle_outbound_connected_message(void) {
-  size_t bytes_to_read = MSG_TYPE_OUTBOUND_CONNECTED_LENGTH - 1;
+static void handle_downstream_connected_message(void) {
+  size_t bytes_to_read = MSG_TYPE_DOWNSTREAM_CONNECTED_LENGTH - 1;
   unsigned char buffer[bytes_to_read];
   read_from_net_fail_on_error(_fed.net_to_RTI, bytes_to_read, buffer, NULL,
-                              "Failed to read outbound connected message from RTI.");
+                              "Failed to read downstream connected message from RTI.");
   uint16_t remote_federate_id = extract_uint16(buffer);
-  tracepoint_federate_from_rti(receive_OUTBOUND_CONNECTED, _lf_my_fed_id, NULL);
-  LF_PRINT_DEBUG("Received notification that outbound transient federate %d has connected.", remote_federate_id);
+  tracepoint_federate_from_rti(receive_DOWNSTREAM_CONNECTED, _lf_my_fed_id, NULL);
+  LF_PRINT_DEBUG("Received notification that downstream transient federate %d has connected.", remote_federate_id);
 
-  // Set the effective start tag of the connectng trasient, so that a message is not sent.
-  tag_t t = extract_tag(&buffer[2]);
-  _fed.outbound_p2p_connection_is_transient[remote_federate_id] = t;
+  // Set the effective start tag of the connecting transient, so that a message is not sent.
+  tag_t joined_tag = extract_tag(&buffer[2]);
 
-  // Read the port numbr and ip_address
+  // Read the port number and IP address
   int32_t server_port = extract_int32(&buffer[2 + 12]);
   uint32_t ip_address = extract_uint32(&buffer[2 + 12 + 4]);
 
-  lf_connect_to_federate(remote_federate_id, true, server_port, ip_address);
+  lf_connect_to_federate(remote_federate_id, joined_tag, server_port, ip_address);
 }
 
 /**
@@ -1051,7 +1048,7 @@ static void handle_outbound_connected_message(void) {
  *
  * Reads the downstream federate's ID and closes the outbound P2P net to it.
  */
-static void handle_outbound_disconnected_message(void) {
+static void handle_downstream_disconnected_message(void) {
   size_t bytes_to_read = sizeof(uint16_t);
   unsigned char buffer[bytes_to_read];
   read_from_net_fail_on_error(_fed.net_to_RTI, bytes_to_read, buffer, NULL,
@@ -1099,7 +1096,7 @@ static instant_t get_start_time_from_rti(instant_t my_physical_time, microstep_t
 
   // Deferred OUTBOUND_CONNECTED notifications: calling lf_connect_to_federate() inline
   // here is unsafe because the RTI may have already written MSG_TYPE_TIMESTAMP into this
-  // federate's TCP stream immediately after MSG_TYPE_OUTBOUND_CONNECTED (from a concurrent
+  // federate's TCP stream immediately after MSG_TYPE_DOWNSTREAM_CONNECTED (from a concurrent
   // send_start_tag_locked call for the transient federate). If we call lf_connect_to_federate()
   // now it will read from the net_abs expecting MSG_TYPE_ADDRESS_QUERY_REPLY but will instead
   // consume the queued MSG_TYPE_TIMESTAMP bytes, causing a fatal "Unexpected reply of type 2".
@@ -1123,23 +1120,23 @@ static instant_t get_start_time_from_rti(instant_t my_physical_time, microstep_t
         // We need to handle this message and continue waiting for MSG_TYPE_TIMESTAMP to arrive
         handle_upstream_disconnected_message();
         continue;
-      } else if (buffer[0] == MSG_TYPE_OUTBOUND_DISCONNECTED) {
+      } else if (buffer[0] == MSG_TYPE_DOWNSTREAM_DISCONNECTED) {
         // A transient outbound federate disconnected before we even got our start time.
         // Drain the federate ID payload and continue waiting for MSG_TYPE_TIMESTAMP.
-        handle_outbound_disconnected_message();
+        handle_downstream_disconnected_message();
         continue;
-      } else if (buffer[0] == MSG_TYPE_OUTBOUND_CONNECTED) {
+      } else if (buffer[0] == MSG_TYPE_DOWNSTREAM_CONNECTED) {
         // Defer lf_connect_to_federate() until after MSG_TYPE_TIMESTAMP is received.
         // Read the federate ID payload now to drain the net_abs, but do not attempt the
         // address query yet: the RTI may have written MSG_TYPE_TIMESTAMP into this net_abs
-        // right after MSG_TYPE_OUTBOUND_CONNECTED (from send_start_tag_locked running
+        // right after MSG_TYPE_DOWNSTREAM_CONNECTED (from send_start_tag_locked running
         // concurrently for the joining transient), so any read inside lf_connect_to_federate
         // would consume those bytes and crash with "Unexpected reply of type 2".
         // Drain the start_tag, as well as the port and IP address
-        unsigned char oc_buf[MSG_TYPE_OUTBOUND_CONNECTED_LENGTH - 1];
-        read_from_net_fail_on_error(_fed.net_to_RTI, MSG_TYPE_OUTBOUND_CONNECTED_LENGTH - 1, oc_buf, NULL,
+        unsigned char oc_buf[MSG_TYPE_DOWNSTREAM_CONNECTED_LENGTH - 1];
+        read_from_net_fail_on_error(_fed.net_to_RTI, MSG_TYPE_DOWNSTREAM_CONNECTED_LENGTH - 1, oc_buf, NULL,
                                     "Failed to read outbound connected federate ID.");
-        tracepoint_federate_from_rti(receive_OUTBOUND_CONNECTED, _lf_my_fed_id, NULL);
+        tracepoint_federate_from_rti(receive_DOWNSTREAM_CONNECTED, _lf_my_fed_id, NULL);
         uint16_t remote_federate_id = extract_uint16(oc_buf);
         LF_PRINT_DEBUG("Deferring P2P connection to downstream transient federate %d until after "
                        "start time is received.",
@@ -1166,7 +1163,7 @@ static instant_t get_start_time_from_rti(instant_t my_physical_time, microstep_t
   lf_print_info("Federation start time is: " PRINTF_TIME ".", timestamp);
   if (_fed.is_transient) {
     effective_start_tag = extract_tag(&(buffer[9]));
-    lf_print_info("Effective relative start tag is: (" PRINTF_TAG ").", effective_start_tag.time - timestamp,
+    lf_print_info("Effective relative start tag is: " PRINTF_TAG ".", effective_start_tag.time - timestamp,
                   effective_start_tag.microstep);
   } else {
     effective_start_tag = (tag_t){.time = timestamp, .microstep = 0u};
@@ -1185,8 +1182,7 @@ static instant_t get_start_time_from_rti(instant_t my_physical_time, microstep_t
   for (size_t i = 0; i < num_pending_downstream; i++) {
     LF_PRINT_DEBUG("Establishing deferred P2P connection to downstream transient federate %d.",
                    pending_downstream_ids[i]);
-    lf_connect_to_federate(pending_downstream_ids[i], true, -1, 0);
-    _fed.outbound_p2p_connection_is_transient[pending_downstream_ids[i]] = effective_start_tag;
+    lf_connect_to_federate(pending_downstream_ids[i], effective_start_tag, -1, 0);
   }
 
   return timestamp;
@@ -1856,11 +1852,11 @@ static void* listen_to_rti_net(void* args) {
     case MSG_TYPE_UPSTREAM_DISCONNECTED:
       handle_upstream_disconnected_message();
       break;
-    case MSG_TYPE_OUTBOUND_CONNECTED:
-      handle_outbound_connected_message();
+    case MSG_TYPE_DOWNSTREAM_CONNECTED:
+      handle_downstream_connected_message();
       break;
-    case MSG_TYPE_OUTBOUND_DISCONNECTED:
-      handle_outbound_disconnected_message();
+    case MSG_TYPE_DOWNSTREAM_DISCONNECTED:
+      handle_downstream_disconnected_message();
       break;
     case MSG_TYPE_CLOCK_SYNC_T1:
     case MSG_TYPE_CLOCK_SYNC_T4:
@@ -2001,8 +1997,10 @@ void lf_terminate_execution(environment_t* env) {
 //////////////////////////////////////////////////////////////////////////////////
 // Public functions (declared in federate.h, in alphabetical order)
 
-void lf_connect_to_federate(uint16_t remote_federate_id, bool is_transient, int p, uint32_t adr) {
+void lf_connect_to_federate(uint16_t remote_federate_id, tag_t joined_tag, int p, uint32_t adr) {
   int result = -1;
+
+  bool is_transient = lf_tag_compare(joined_tag, NEVER_TAG) > 0;
 
   // Ask the RTI for port number of the remote federate.
   // The buffer is used for both sending and receiving replies.
@@ -2012,7 +2010,13 @@ void lf_connect_to_federate(uint16_t remote_federate_id, bool is_transient, int 
   struct in_addr host_ip_addr;
   host_ip_addr.s_addr = (in_addr_t)adr;
   instant_t start_connect = lf_time_physical();
-  // If the remote federate if oersistent, iterate until we get a valid port number from the RTI,
+  if (port != -1) {
+    LF_MUTEX_LOCK(&lf_outbound_net_mutex);
+    // This should be set while holding the mutex.
+    _fed.downstream_p2p_joined_tag[remote_federate_id] = joined_tag;
+    LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
+  }
+  // If the remote federate if persistent, iterate until we get a valid port number from the RTI,
   // If not, execute only once, as a request registration.
   while (port == -1 && !_lf_termination_executed) {
     buffer[0] = MSG_TYPE_ADDRESS_QUERY;
@@ -2026,15 +2030,17 @@ void lf_connect_to_federate(uint16_t remote_federate_id, bool is_transient, int 
     tracepoint_federate_to_rti(send_ADR_QR, _lf_my_fed_id, NULL);
 
     LF_MUTEX_LOCK(&lf_outbound_net_mutex);
+    // This should be set while holding the mutex.
+    _fed.downstream_p2p_joined_tag[remote_federate_id] = joined_tag;
+
     write_to_net_fail_on_error(_fed.net_to_RTI, 1 + sizeof(uint16_t) + 1, buffer, &lf_outbound_net_mutex,
                                "Failed to send address query for federate %d to RTI.", remote_federate_id);
+    LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
 
     // Read RTI's response.
     read_from_net_fail_on_error(_fed.net_to_RTI, sizeof(int32_t) + 1, buffer,
                                 "Failed to read the requested port number for federate %d from RTI.",
                                 remote_federate_id);
-
-    LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
 
     if (buffer[0] != MSG_TYPE_ADDRESS_QUERY_REPLY) {
       // Unexpected reply. Could be that RTI has failed and sent a resignation.
@@ -2134,7 +2140,7 @@ void lf_connect_to_federate(uint16_t remote_federate_id, bool is_transient, int 
 
     // For transient outbound connections, a connection reset from the remote side
     // (e.g. macOS resets the TCP connection if the accept loop hasn't run yet) is
-    // a soft error: the RTI will resend MSG_TYPE_OUTBOUND_CONNECTED when the transient
+    // a soft error: the RTI will resend MSG_TYPE_DOWNSTREAM_CONNECTED when the transient
     // is ready. Using the non-fatal read here prevents a spurious fatal exit on macOS.
     int ack_read_failed = read_from_net(net, 1, (unsigned char*)buffer);
     if (ack_read_failed) {
@@ -2606,7 +2612,8 @@ void lf_reset_status_fields_on_input_port_triggers() {
   lf_cond_broadcast(&lf_port_status_changed);
 }
 
-int lf_send_message(int message_type, unsigned short port, unsigned short federate, const char* next_destination_str,
+int lf_send_message(int message_type, unsigned short port, unsigned short federate,
+                    const char* next_destination_str,
                     size_t length, unsigned char* message) {
   unsigned char header_buffer[1 + sizeof(uint16_t) + sizeof(uint16_t) + sizeof(uint32_t)];
   // First byte identifies this as a timed message.
@@ -2614,23 +2621,6 @@ int lf_send_message(int message_type, unsigned short port, unsigned short federa
     lf_print_error("lf_send_message: Unsupported message type (%d).", message_type);
     return -1;
   }
-
-  // If there are outbound transients, check whether the destination is one of them.
-  // If it is and its net_abs is shut, or the transient did not start yet, gracefully skip the send.
-#ifdef FEDERATED_DECENTRALIZED
-  if ((lf_tag_compare(_fed.outbound_p2p_connection_is_transient[federate], NEVER_TAG) > 0)) {
-    if (_fed.net_for_outbound_p2p_connections[federate] == NULL) {
-      lf_print_info("The destination transient federate %d is not connected. Abort sending!", federate);
-      return 0;
-    } else if (lf_tag_compare(_fed.outbound_p2p_connection_is_transient[federate],
-                              (tag_t){.time = lf_time_physical(), .microstep = 0u}) > 0) {
-      // Check that the message tag is not earlier than than the effective start tag of the destination
-      lf_print_info("The destination transient federate %d is connected but did not start yet. Abort sending!",
-                    federate);
-      return 0;
-    }
-  }
-#endif
 
   header_buffer[0] = (unsigned char)message_type;
   // Next two bytes identify the destination port.
@@ -2652,6 +2642,19 @@ int lf_send_message(int message_type, unsigned short port, unsigned short federa
   LF_MUTEX_LOCK(&lf_outbound_net_mutex);
 
   net_abstraction_t net = _fed.net_for_outbound_p2p_connections[federate];
+
+#ifdef FEDERATED_DECENTRALIZED
+  // If the destination is a transient federate, check whether it is connected and has started yet.
+  // This must be done while holding the mutex.
+  if (lf_tag_compare(_fed.downstream_p2p_joined_tag[federate], NEVER_TAG) > 0) {
+    // Downstream is transient.
+    if (net == NULL) {
+      lf_print_info("The destination transient federate %d is not connected. Dropping message.", federate);
+      LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
+      return 0;
+    }
+  }
+#endif
 
   if (net == NULL) {
     if (!_lf_termination_executed) {
@@ -2959,22 +2962,6 @@ int lf_send_tagged_message(environment_t* env, interval_t additional_delay, int 
     return -1;
   }
 
-  // If there are outbound transients, check whether the destination is one of them.
-  // If it is and its net_abs is shut, or the transient did not start yet, gracefully skip the send.
-#ifdef FEDERATED_DECENTRALIZED
-  if ((lf_tag_compare(_fed.outbound_p2p_connection_is_transient[federate], NEVER_TAG) > 0)) {
-    if (_fed.net_for_outbound_p2p_connections[federate] == NULL) {
-      lf_print_info("The destination transient federate %d is not connected. Abort sending!", federate);
-      return 0;
-    } else if (lf_tag_compare(_fed.outbound_p2p_connection_is_transient[federate], current_message_intended_tag) > 0) {
-      // Check that the message tag is not earlier than than the effective start tag of the destination
-      lf_print_info("The destination transient federate %d is connected but did not start yet. Abort sending!",
-                    federate);
-      return 0;
-    }
-  }
-#endif
-
   size_t buffer_head = 0;
   // First byte is the message type.
   header_buffer[buffer_head] = (unsigned char)message_type;
@@ -3000,6 +2987,27 @@ int lf_send_tagged_message(environment_t* env, interval_t additional_delay, int 
 
   // Use a mutex lock to prevent multiple threads from simultaneously sending.
   LF_MUTEX_LOCK(&lf_outbound_net_mutex);
+
+#ifdef FEDERATED_DECENTRALIZED
+  // If the destination is a transient federate, check whether it is connected and has started yet.
+  // This must be done while holding the mutex.
+  // If it is and its net_abs is shut, or the transient did not start yet, drop the message.
+  if (lf_tag_compare(_fed.downstream_p2p_joined_tag[federate], NEVER_TAG) > 0) {
+    // Downstream is transient.
+    if (_fed.net_for_outbound_p2p_connections[federate] == NULL) {
+      lf_print_info("The destination transient federate %d is not connected. Dropping message at tag "
+         PRINTF_TAG ".", federate, env->current_tag.time - start_time, env->current_tag.microstep);
+      LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
+      return 0;
+    } else if (lf_tag_compare(_fed.downstream_p2p_joined_tag[federate], current_message_intended_tag) > 0) {
+      // The message is earlier than than the effective start tag of the destination.
+      lf_print_info("The destination transient federate %d is connected but did not start yet. Dropping message with intended tag "
+         PRINTF_TAG ".", federate, current_message_intended_tag.time - start_time, current_message_intended_tag.microstep);
+      LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
+      return 0;
+    }
+  }
+#endif
 
   net_abstraction_t net;
   if (message_type == MSG_TYPE_P2P_TAGGED_MESSAGE) {

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -1066,22 +1066,21 @@ static void handle_downstream_disconnected_message(void) {
  * The specified timestamp should be current physical time of the
  * federate, and the response will be the designated start time for
  * the federate. In case of decentralized coordination, the federate
- * may suggest a different timestamp, that is the max tag + microstep of the conetced outboud federates.
+ * may suggest a different timestamp, that is the max tag and microstep
+ * of the connected downstream federates.
  * In such a case, it will be higher than the actual physical time.
  *
  * This procedure blocks until the response is
  * received from the RTI.
- * @param my_physical_time The physical time at this federate, or the time in the tag
- * @param my_microstep microstep
+ * @param suggested_start_tag The suggested start tag by the federate.
  * @return The designated start time for the federate.
  */
-static instant_t get_start_time_from_rti(instant_t my_physical_time, microstep_t my_microstep) {
+static instant_t get_start_time_from_rti(tag_t suggested_start_tag) {
   // Send the timestamp marker first.
 #ifdef FEDERATED_DECENTRALIZED
-  SUPPRESS_UNUSED_WARNING(my_microstep);
-  send_time(my_physical_time);
+  send_time(suggested_start_tag.time);
 #else
-  send_tag(MSG_TYPE_TAG, my_physical_time, my_microstep);
+  send_tag(MSG_TYPE_TAG, suggested_start_tag);
 #endif
 
   // Read bytes from the network abstraction. We need 9 bytes.
@@ -3076,18 +3075,16 @@ void lf_synchronize_with_other_federates(void) {
 
   // Reset the start time to the coordinated start time for all federates.
   // Note that this does not grant execution to this federate.
-  instant_t t_physical = lf_time_physical();
-  microstep_t m = 0u;
+  tag_t suggested_start_tag = {.time = lf_time_physical(), .microstep = 0u};
 #ifdef FEDERATED_DECENTRALIZED
   if (_fed.is_transient) {
-    if (temp_effective_start_tag.time >= t_physical) {
-      t_physical = temp_effective_start_tag.time;
-      m = temp_effective_start_tag.microstep;
-      m++;
+    if (temp_effective_start_tag.time >= suggested_start_tag.time) {
+      suggested_start_tag = temp_effective_start_tag;
+      suggested_start_tag.microstep++;
     }
   }
 #endif
-  start_time = get_start_time_from_rti(t_physical, m);
+  start_time = get_start_time_from_rti(suggested_start_tag);
 
   lf_print_info("Starting timestamp is: " PRINTF_TIME " and effective start tag is: " PRINTF_TAG ".", lf_time_start(),
                 effective_start_tag.time - lf_time_start(), effective_start_tag.microstep);

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -2612,8 +2612,7 @@ void lf_reset_status_fields_on_input_port_triggers() {
   lf_cond_broadcast(&lf_port_status_changed);
 }
 
-int lf_send_message(int message_type, unsigned short port, unsigned short federate,
-                    const char* next_destination_str,
+int lf_send_message(int message_type, unsigned short port, unsigned short federate, const char* next_destination_str,
                     size_t length, unsigned char* message) {
   unsigned char header_buffer[1 + sizeof(uint16_t) + sizeof(uint16_t) + sizeof(uint32_t)];
   // First byte identifies this as a timed message.
@@ -2995,14 +2994,15 @@ int lf_send_tagged_message(environment_t* env, interval_t additional_delay, int 
   if (lf_tag_compare(_fed.downstream_p2p_joined_tag[federate], NEVER_TAG) > 0) {
     // Downstream is transient.
     if (_fed.net_for_outbound_p2p_connections[federate] == NULL) {
-      lf_print_info("The destination transient federate %d is not connected. Dropping message at tag "
-         PRINTF_TAG ".", federate, env->current_tag.time - start_time, env->current_tag.microstep);
+      lf_print_info("The destination transient federate %d is not connected. Dropping message at tag " PRINTF_TAG ".",
+                    federate, env->current_tag.time - start_time, env->current_tag.microstep);
       LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
       return 0;
     } else if (lf_tag_compare(_fed.downstream_p2p_joined_tag[federate], current_message_intended_tag) > 0) {
       // The message is earlier than than the effective start tag of the destination.
-      lf_print_info("The destination transient federate %d is connected but did not start yet. Dropping message with intended tag "
-         PRINTF_TAG ".", federate, current_message_intended_tag.time - start_time, current_message_intended_tag.microstep);
+      lf_print_info("The destination transient federate %d is connected but did not start yet. Dropping message with "
+                    "intended tag " PRINTF_TAG ".",
+                    federate, current_message_intended_tag.time - start_time, current_message_intended_tag.microstep);
       LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
       return 0;
     }

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -2082,16 +2082,27 @@ void lf_connect_to_federate(uint16_t remote_federate_id, tag_t joined_tag, int32
   // Avoid opening a duplicate outbound connection to the same federate. More than one trigger
   // can request a connection to a transient downstream federate: the startup outbound loop may
   // obtain a valid port and connect, and the RTI may (concurrently or subsequently) send a
-  // MSG_TYPE_DOWNSTREAM_CONNECTED notification for the same join. A duplicate connection would
-  // push the remote federate beyond its expected inbound P2P connection count and cause it to
-  // abort. If a connection already exists, do not open another one.
+  // MSG_TYPE_DOWNSTREAM_CONNECTED notification for the same join. A duplicate live connection
+  // would push the remote federate beyond its expected inbound P2P connection count and cause it
+  // to abort. However, only skip when the recorded connection is still open: a stale, closed
+  // connection (e.g., left behind when the transient previously resigned) must be replaced so the
+  // transient can be reached again after it rejoins.
   LF_MUTEX_LOCK(&lf_outbound_net_mutex);
-  bool already_connected = _fed.net_for_outbound_p2p_connections[remote_federate_id] != NULL;
+  net_abstraction_t existing = _fed.net_for_outbound_p2p_connections[remote_federate_id];
+  bool existing_is_open = existing != NULL && is_net_open(existing);
+  if (!existing_is_open) {
+    // Drop any stale reference so a fresh connection can be recorded below.
+    _fed.net_for_outbound_p2p_connections[remote_federate_id] = NULL;
+  }
   LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
-  if (already_connected) {
+  if (existing_is_open) {
     LF_PRINT_LOG("Outbound P2P connection to federate %d is already established. Not reconnecting.",
                  remote_federate_id);
     return;
+  }
+  if (existing != NULL) {
+    // The previously recorded connection is closed; release it before reconnecting.
+    shutdown_net(existing, false);
   }
 
   net_abstraction_t net = connect_to_net((net_params_t)&params);
@@ -2166,7 +2177,7 @@ void lf_connect_to_federate(uint16_t remote_federate_id, tag_t joined_tag, int32
         // MSG_TYPE_DOWNSTREAM_CONNECTED only once per join and does not resend it, so waiting
         // for another notification would leave this federate permanently unable to reach the
         // transient, silently dropping every message addressed to it.
-        lf_print_warning("Failed to read MSG_TYPE_ACK from transient federate %d. Connection may have been reset. "
+        lf_print_warning("Failed to read response from transient federate %d. Connection may have been reset. "
                          "Retrying.",
                          remote_federate_id);
         shutdown_net(net, false);
@@ -2175,10 +2186,10 @@ void lf_connect_to_federate(uint16_t remote_federate_id, tag_t joined_tag, int32
         lf_sleep(ADDRESS_QUERY_RETRY_INTERVAL);
         continue;
       }
-      lf_print_error_and_exit("Failed to read MSG_TYPE_ACK from federate %d in response to sending fed_id.",
+      lf_print_error_and_exit("Failed to read response from federate %d in response to sending fed_id.",
                               remote_federate_id);
     }
-    if (buffer[0] != MSG_TYPE_ACK) {
+    if (buffer[0] == MSG_TYPE_REJECT) {
       // Get the error code.
       read_from_net_fail_on_error(net, 1, (unsigned char*)buffer,
                                   "Failed to read error code from federate %d in response to sending fed_id.",
@@ -2190,15 +2201,21 @@ void lf_connect_to_federate(uint16_t remote_federate_id, tag_t joined_tag, int32
       lf_print_warning("Could not connect to federate %d. Will try again every " PRINTF_TIME "nanoseconds.\n",
                        remote_federate_id, ADDRESS_QUERY_RETRY_INTERVAL);
       continue;
-    } else {
-      // Drain the tag payload from the ACK message.
+    } else if (buffer[0] == MSG_TYPE_TAG) {
+      // Drain the tag payload from the tag message.
       unsigned char tag_buffer[sizeof(instant_t) + sizeof(microstep_t)];
       read_from_net_fail_on_error(net, sizeof(tag_buffer), tag_buffer,
-                                  "Failed to read tag from MSG_TYPE_ACK from federate %d.", remote_federate_id);
+                                  "Failed to read tag from MSG_TYPE_TAG from federate %d.", remote_federate_id);
       tag_t t = extract_tag(tag_buffer);
       if (lf_tag_compare(t, temp_effective_start_tag) > 0) {
         temp_effective_start_tag = t;
       }
+      lf_print_info("Connected to federate %d, port %hu.", remote_federate_id, uport);
+      // Trace the event when tracing is enabled
+      tracepoint_federate_to_federate(receive_TAG, _lf_my_fed_id, remote_federate_id, NULL);
+      break;
+    } else {
+      // Message type must be MSG_TYPE_ACK.
       lf_print_info("Connected to federate %d, port %hu.", remote_federate_id, uport);
       // Trace the event when tracing is enabled
       tracepoint_federate_to_federate(receive_ACK, _lf_my_fed_id, remote_federate_id, NULL);
@@ -2314,11 +2331,6 @@ void lf_connect_to_rti(const char* hostname, int port) {
         continue;
       }
     } else if (response == MSG_TYPE_ACK) {
-      // Drain the tag payload from the ACK message.
-      unsigned char tag_buffer[sizeof(instant_t) + sizeof(microstep_t)];
-      read_from_net_fail_on_error(_fed.net_to_RTI, sizeof(tag_buffer), tag_buffer,
-                                  "Failed to read tag from MSG_TYPE_ACK from the RTI.");
-      extract_tag(tag_buffer);
       // Trace the event when tracing is enabled
       tracepoint_federate_from_rti(receive_ACK, _lf_my_fed_id, NULL);
       LF_PRINT_LOG("Received acknowledgment from the RTI.");
@@ -2541,19 +2553,23 @@ void* lf_handle_p2p_connections_from_federates(void* env_arg) {
 
     // Send ACK after the listener thread exists so the source cannot start sending
     // messages before this federate has a thread ready to receive them.
-    unsigned char response[MSG_TYPE_ACK_LENGTH];
-    response[0] = MSG_TYPE_ACK;
+    unsigned char response[MSG_TYPE_TAG_LENGTH];
     if (remote_fed_is_transient && (lf_tag_compare(effective_start_tag, NEVER_TAG) != 0)) {
       environment_t* env;
       _lf_get_environments(&env);
+      response[0] = MSG_TYPE_TAG;
       encode_tag(&response[1], env->current_tag);
+      tracepoint_federate_to_federate(send_TAG, _lf_my_fed_id, remote_fed_id, NULL);
+      write_to_net_fail_on_error(_fed.net_for_inbound_p2p_connections[remote_fed_id], MSG_TYPE_TAG_LENGTH, response,
+                                 &lf_outbound_net_mutex, "Failed to write MSG_TYPE_TAG in response to federate %d.",
+                                 remote_fed_id);
     } else {
-      encode_tag(&response[1], NEVER_TAG);
+      response[0] = MSG_TYPE_ACK;
+      tracepoint_federate_to_federate(send_ACK, _lf_my_fed_id, remote_fed_id, NULL);
+      write_to_net_fail_on_error(_fed.net_for_inbound_p2p_connections[remote_fed_id], 1, response,
+                                 &lf_outbound_net_mutex, "Failed to write MSG_TYPE_ACK in response to federate %d.",
+                                 remote_fed_id);
     }
-    tracepoint_federate_to_federate(send_ACK, _lf_my_fed_id, remote_fed_id, NULL);
-    write_to_net_fail_on_error(_fed.net_for_inbound_p2p_connections[remote_fed_id], MSG_TYPE_ACK_LENGTH, response,
-                               &lf_outbound_net_mutex, "Failed to write MSG_TYPE_ACK in response to federate %d.",
-                               remote_fed_id);
     LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
   }
 

--- a/core/federated/federate.c
+++ b/core/federated/federate.c
@@ -216,7 +216,7 @@ static void update_last_known_status_on_input_ports(tag_t tag, environment_t* en
       notify = true;
     }
   }
-  // FIXME: We could put a condition variable into the trigger_t
+  // NOTE: We could put a condition variable into the trigger_t
   // struct for each network input port, in which case this won't
   // be a broadcast but rather a targetted signal.
   if (notify && lf_update_max_level(tag, false)) {
@@ -314,7 +314,7 @@ static void mark_inputs_known_absent(int fed_id) {
   // current_tag is equivalent to "absent at the current logical time" — sufficient
   // to unblock the scheduler, but small enough that any future message from the
   // rejoining federate at a tag >= current_tag will update the port normally.
-  bool is_transient = _fed.inbound_p2p_connection_is_transient[fed_id];
+  bool is_transient = _fed.upstream_fed_is_transient[fed_id];
   tag_t absent_until = is_transient ? env->current_tag : FOREVER_TAG;
 
   for (size_t i = 0; i < _lf_action_table_size; i++) {
@@ -857,7 +857,7 @@ static void* listen_to_federates(void* _args) {
       // For decentralized execution, once this network abstraction is closed, we
       // update last known tags of all ports connected to the specified federate,
       // which would eliminate the need to wait for STAA to assume an input is absent.
-      _fed.inbound_p2p_is_connected[fed_id] = false;
+      _fed.upstream_fed_is_connected[fed_id] = false;
       mark_inputs_known_absent(fed_id);
 
       break; // while loop
@@ -1047,9 +1047,9 @@ static void handle_downstream_disconnected_message(void) {
   size_t bytes_to_read = sizeof(uint16_t);
   unsigned char buffer[bytes_to_read];
   read_from_net_fail_on_error(_fed.net_to_RTI, bytes_to_read, buffer, NULL,
-                              "Failed to read outbound disconnected message from RTI.");
+                              "Failed to read downstream disconnected message from RTI.");
   uint16_t remote_federate_id = extract_uint16(buffer);
-  tracepoint_federate_from_rti(receive_OUTBOUND_DISCONNECTED, _lf_my_fed_id, NULL);
+  tracepoint_federate_from_rti(receive_DOWNSTREAM_DISCONNECTED, _lf_my_fed_id, NULL);
   LF_PRINT_DEBUG("Received notification that downstream transient federate %d has disconnected.", remote_federate_id);
 
   LF_MUTEX_LOCK(&lf_outbound_net_mutex);
@@ -1062,13 +1062,10 @@ static void handle_downstream_disconnected_message(void) {
 }
 
 /**
- * Send the specified timestamp to the RTI and wait for a response.
- * The specified timestamp should be current physical time of the
+ * Send the specified tag to the RTI and wait for a response.
+ * The timestamp in the specified tag should be current physical time of the
  * federate, and the response will be the designated start time for
- * the federate. In case of decentralized coordination, the federate
- * may suggest a different timestamp, that is the max tag and microstep
- * of the connected downstream federates.
- * In such a case, it will be higher than the actual physical time.
+ * the federate. See net_common.h for more details.
  *
  * This procedure blocks until the response is
  * received from the RTI.
@@ -1088,17 +1085,9 @@ static instant_t get_start_time_from_rti(tag_t suggested_start_tag) {
   size_t buffer_length = (_fed.is_transient) ? MSG_TYPE_TIMESTAMP_TAG_LENGTH : MSG_TYPE_TIMESTAMP_LENGTH;
   unsigned char buffer[buffer_length];
 
-  // FIXME: This comment is hard to understand.
-  // Deferred DOWNSTREAM_CONNECTED notifications: calling lf_connect_to_federate() inline
-  // here is unsafe because the RTI may have already written MSG_TYPE_TIMESTAMP into this
-  // federate's TCP stream immediately after MSG_TYPE_DOWNSTREAM_CONNECTED (from a concurrent
-  // send_start_tag_locked call for the transient federate). If we call lf_connect_to_federate()
-  // now it will read from the net_abs expecting MSG_TYPE_ADDRESS_QUERY_REPLY but will instead
-  // consume the queued MSG_TYPE_TIMESTAMP bytes, causing a fatal "Unexpected reply of type 2".
-  // Fix: read and save each downstream federate ID, then call lf_connect_to_federate() for
-  // each one only after MSG_TYPE_TIMESTAMP has been received and the loop has exited.
-  uint16_t
-      pending_downstream_ids[_fed.number_of_outbound_p2p_transients > 0 ? _fed.number_of_outbound_p2p_transients : 1];
+  uint16_t pending_downstream_ids[_fed.number_of_downstream_p2p_transients > 0
+                                      ? _fed.number_of_downstream_p2p_transients
+                                      : 1];
   size_t num_pending_downstream = 0;
 
   while (true) {
@@ -1116,7 +1105,7 @@ static instant_t get_start_time_from_rti(tag_t suggested_start_tag) {
         handle_upstream_disconnected_message();
         continue;
       } else if (buffer[0] == MSG_TYPE_DOWNSTREAM_DISCONNECTED) {
-        // A transient outbound federate disconnected before we even got our start time.
+        // A transient downstream federate disconnected before we even got our start time.
         // Drain the federate ID payload and continue waiting for MSG_TYPE_TIMESTAMP.
         handle_downstream_disconnected_message();
         continue;
@@ -1130,13 +1119,13 @@ static instant_t get_start_time_from_rti(tag_t suggested_start_tag) {
         // Drain the start_tag, as well as the port and IP address
         unsigned char oc_buf[MSG_TYPE_DOWNSTREAM_CONNECTED_LENGTH - 1];
         read_from_net_fail_on_error(_fed.net_to_RTI, MSG_TYPE_DOWNSTREAM_CONNECTED_LENGTH - 1, oc_buf, NULL,
-                                    "Failed to read outbound connected federate ID.");
+                                    "Failed to read downstream connected federate ID.");
         tracepoint_federate_from_rti(receive_DOWNSTREAM_CONNECTED, _lf_my_fed_id, NULL);
         uint16_t remote_federate_id = extract_uint16(oc_buf);
         LF_PRINT_DEBUG("Deferring P2P connection to downstream transient federate %d until after "
                        "start time is received.",
                        remote_federate_id);
-        if (num_pending_downstream < _fed.number_of_outbound_p2p_transients) {
+        if (num_pending_downstream < _fed.number_of_downstream_p2p_transients) {
           pending_downstream_ids[num_pending_downstream++] = remote_federate_id;
         }
         // We do not save the remaining information
@@ -1172,7 +1161,7 @@ static instant_t get_start_time_from_rti(tag_t suggested_start_tag) {
 
   // Now that MSG_TYPE_TIMESTAMP has been received and the start time is known, it is safe
   // to establish outbound P2P connections to any transient downstream federates that sent
-  // OUTBOUND_CONNECTED notifications while we were waiting. The ADDRESS_QUERY round-trip
+  // DOWNSTREAM_CONNECTED notifications while we were waiting. The ADDRESS_QUERY round-trip
   // can proceed without risk of consuming queued TIMESTAMP bytes.
   for (size_t i = 0; i < num_pending_downstream; i++) {
     LF_PRINT_DEBUG("Establishing deferred P2P connection to downstream transient federate %d.",
@@ -1285,7 +1274,7 @@ static int id_of_action(lf_action_base_t* input_port_action) {
 static bool inputs_known_to(tag_t tag) {
   for (size_t i = 0; i < _lf_action_table_size; i++) {
     int src = _lf_action_table[i]->source_id;
-    if (src >= 0 && _fed.inbound_p2p_connection_is_transient[src] && !_fed.inbound_p2p_is_connected[src])
+    if (src >= 0 && _fed.upstream_fed_is_transient[src] && !_fed.upstream_fed_is_connected[src])
       continue; // absent transient: known to be absent for all time
     tag_t known_to = _lf_action_table[i]->trigger->last_known_status_tag;
     if (lf_tag_compare(known_to, tag) < 0)
@@ -1351,8 +1340,7 @@ static void* update_ports_from_staa_offsets(void* args) {
         lf_action_base_t* input_port_action = staa_elem->actions[j];
         int src = input_port_action->source_id;
 
-        bool upstream_is_absent_transient =
-            _fed.inbound_p2p_connection_is_transient[src] && !_fed.inbound_p2p_is_connected[src];
+        bool upstream_is_absent_transient = _fed.upstream_fed_is_transient[src] && !_fed.upstream_fed_is_connected[src];
         if (upstream_is_absent_transient) { //} && input_port_action->trigger->status == unknown) {
           input_port_action->trigger->status = absent;
           LF_PRINT_DEBUG("**** (update thread) Transient absent, marking port absent at tag " PRINTF_TAG,
@@ -2269,8 +2257,7 @@ void lf_connect_to_rti(const char* hostname, int port) {
 
     // Wait for a response.
     // The response will be MSG_TYPE_REJECT if the federation ID doesn't match.
-    // Otherwise, it will be either MSG_TYPE_ACK or MSG_TYPE_UDP_PORT, where the latter
-    // is used if clock synchronization will be performed.
+    // Otherwise, it will be MSG_TYPE_ACK.
     unsigned char response;
 
     LF_PRINT_DEBUG("Waiting for response to federation ID from the RTI.");
@@ -2452,7 +2439,7 @@ void* lf_handle_p2p_connections_from_federates(void* env_arg) {
     // Extract the ID of the sending federate.
     uint16_t remote_fed_id = extract_uint16((unsigned char*)&(buffer[1]));
     bool remote_fed_is_transient = buffer[1 + sizeof(uint16_t)];
-    _fed.inbound_p2p_connection_is_transient[remote_fed_id] = remote_fed_is_transient;
+    _fed.upstream_fed_is_transient[remote_fed_id] = remote_fed_is_transient;
     if (remote_fed_is_transient) {
       LF_PRINT_DEBUG("Received sending federate ID %d, which is transient.", remote_fed_id);
     } else {
@@ -2468,7 +2455,7 @@ void* lf_handle_p2p_connections_from_federates(void* env_arg) {
     // Otherwise, there can be race condition where, during termination,
     // two threads attempt to simultaneously close the network abstraction.
     _fed.net_for_inbound_p2p_connections[remote_fed_id] = net;
-    _fed.inbound_p2p_is_connected[remote_fed_id] = true;
+    _fed.upstream_fed_is_connected[remote_fed_id] = true;
 
     // Determine the listener-array slot and start the listener thread BEFORE sending the
     // ACK. This ensures the source cannot start delivering messages (at start_time) before

--- a/core/threaded/reactor_threaded.c
+++ b/core/threaded/reactor_threaded.c
@@ -213,8 +213,8 @@ tag_t get_next_event_tag(environment_t* env) {
   if (event != NULL) {
     // There is an event in the event queue.
     if (lf_tag_compare(event->base.tag, env->current_tag) < 0) {
-      lf_print_error_and_exit("get_next_event_tag(): Earliest event on the event queue (" PRINTF_TAG ") is "
-                              "earlier than the current tag (" PRINTF_TAG ").",
+      lf_print_error_and_exit("get_next_event_tag(): Earliest event on the event queue " PRINTF_TAG " is "
+                              "earlier than the current tag " PRINTF_TAG ".",
                               event->base.tag.time - start_time, event->base.tag.microstep,
                               env->current_tag.time - start_time, env->current_tag.microstep);
     }

--- a/core/threaded/scheduler_adaptive.c
+++ b/core/threaded/scheduler_adaptive.c
@@ -381,9 +381,9 @@ static bool worker_states_finished_with_level_locked(lf_scheduler_t* scheduler, 
   assert(((int64_t)worker_assignments->num_reactions_by_worker[worker]) <= 0);
   // Why use an atomic operation when we are supposed to be "as good as locked"? Because I took a
   // shortcut, and the shortcut was imperfect.
-  size_t ret = lf_atomic_add_fetch((int*)&worker_states->num_loose_threads, -1);
+  int ret = lf_atomic_add_fetch((int*)&worker_states->num_loose_threads, -1);
   assert(ret <= worker_assignments->max_num_workers); // Check for underflow
-  return !ret;
+  return (ret == 0);
 }
 
 /**

--- a/core/threaded/scheduler_adaptive.c
+++ b/core/threaded/scheduler_adaptive.c
@@ -381,7 +381,7 @@ static bool worker_states_finished_with_level_locked(lf_scheduler_t* scheduler, 
   assert(((int64_t)worker_assignments->num_reactions_by_worker[worker]) <= 0);
   // Why use an atomic operation when we are supposed to be "as good as locked"? Because I took a
   // shortcut, and the shortcut was imperfect.
-  size_t ret = lf_atomic_add_fetch(&worker_states->num_loose_threads, -1);
+  size_t ret = lf_atomic_add_fetch((int*)&worker_states->num_loose_threads, -1);
   assert(ret <= worker_assignments->max_num_workers); // Check for underflow
   return !ret;
 }

--- a/include/core/federated/federate.h
+++ b/include/core/federated/federate.h
@@ -80,7 +80,7 @@ typedef struct federate_instance_t {
   /**
    * Number of outbound peer-to-peer connections to transient federates.
    */
-  size_t number_of_outbound_p2p_transients;
+  size_t number_of_downstream_p2p_transients;
 
   /**
    * An array that holds the tag at which the downstream federate joined.
@@ -113,7 +113,7 @@ typedef struct federate_instance_t {
    * reveals the remote federate's type. Used by mark_inputs_known_absent()
    * to avoid permanently stamping FOREVER_TAG on ports whose source may rejoin.
    */
-  bool inbound_p2p_connection_is_transient[NUMBER_OF_FEDERATES];
+  bool upstream_fed_is_transient[NUMBER_OF_FEDERATES];
 
   /**
    * An array indexed by federate ID indicating whether the corresponding
@@ -123,7 +123,7 @@ typedef struct federate_instance_t {
    * Used by a_port_is_unknown() to skip waiting for ports whose transient upstream
    * federate is currently disconnected.
    */
-  bool inbound_p2p_is_connected[NUMBER_OF_FEDERATES];
+  bool upstream_fed_is_connected[NUMBER_OF_FEDERATES];
 
   /**
    * An array that holds the network abstractions for outbound direct

--- a/include/core/federated/federate.h
+++ b/include/core/federated/federate.h
@@ -83,18 +83,20 @@ typedef struct federate_instance_t {
   size_t number_of_outbound_p2p_transients;
 
   /**
-   * An array indexed by federate ID. For persistent federates, the value is
-   * NEVER_TAG. For transient federates, the value is either FOREVER_TAG
-   * (not yet joined) or the tag at which the transient federate joined.
+   * An array that holds the tag at which the downstream federate joined.
+   * For persistent federates, the value is NEVER_TAG. For transient federates,
+   * the value is either FOREVER_TAG (not yet joined) or the tag at which the
+   * transient federate joined.
+   * This is an array indexed by federate ID.
    */
-  tag_t outbound_p2p_connection_is_transient[NUMBER_OF_FEDERATES];
+  tag_t downstream_p2p_joined_tag[NUMBER_OF_FEDERATES];
 
   /**
    * An array that holds the network abstractions for inbound
    * connections from each federate. The index will be the federate
    * ID of the remote sending federate. This is initialized at startup
    * to NULL and is set to the pointer of the network abstraction by lf_connect_to_federate()
-   * when the network abstractions is opened.
+   * when the network abstraction is opened.
    *
    * @note There will not be an inbound network abstraction unless a physical connection
    * or a p2p logical connection (by setting the coordination target property
@@ -128,7 +130,7 @@ typedef struct federate_instance_t {
    * connections to each remote federate. The index will be the federate
    * ID of the remote receiving federate. This is initialized at startup
    * to NULL and is set to the pointer of the network abstraction by lf_connect_to_federate()
-   * when the network abstractions is opened.
+   * when the network abstraction is opened.
    *
    * @note This federate will not open an outbound network abstractions unless a physical
    * connection or a p2p logical connection (by setting the coordination target
@@ -299,7 +301,7 @@ extern lf_cond_t lf_port_status_changed;
 // Public functions (in alphabetical order)
 
 /**
- * @brief Connect to the federate with the specified id, based if it is transient or not.
+ * @brief Connect to the federate with the specified id.
  * @ingroup Federated
  *
  * The established connection will then be used in functions such as lf_send_tagged_message()
@@ -312,15 +314,13 @@ extern lf_cond_t lf_port_status_changed;
  * refer to the network abstraction for communicating directly with the federate.
  *
  * @param remote_federate_id The ID of the remote federate.
- * @param is_transient Whether the remote federate is transient. This affects
- *   connection behavior: a transient remote federate may not be immediately
- *   available, so the connection attempt is handled differently than for a
- *   persistent federate.
+ * @param joined_tag The tag at which the remote federate joined. This is NEVER_TAG for persistent federates,
+ *   and either FOREVER_TAG (not yet joined) or the tag at which the transient federate joined for transient federates.
  * @param port The port number of the remote federate. Pass -1 if it is to be queried.
  * @param ip_address The IP address of the remote federate, in network byte order. Pass 0
  *   if it is to be queried.
  */
-void lf_connect_to_federate(uint16_t remote_federate_id, bool is_transient, int32_t port, uint32_t ip_address);
+void lf_connect_to_federate(uint16_t remote_federate_id, tag_t joined_tag, int32_t port, uint32_t ip_address);
 
 /**
  * @brief Connect to the RTI at the specified host and port.
@@ -420,7 +420,8 @@ void lf_reset_status_fields_on_input_port_triggers(void);
  *
  * This function is used for physical connections
  * between federates. If the connection to the remote federate or the RTI has been broken,
- * then this returns -1 without sending. Otherwise, it returns 0.
+ * then this returns -1 without sending, unless the destination is a transient federate
+ * that is not connected, in which case it returns 0. Otherwise, it returns 0.
  *
  * This method assumes that the caller does not hold the lf_outbound_net_mutex lock,
  * which it acquires to perform the send.
@@ -431,7 +432,7 @@ void lf_reset_status_fields_on_input_port_triggers(void);
  * @param next_destination_str The name of the next destination in string format (for reporting).
  * @param length The message length.
  * @param message The message.
- * @return 0 if the message has been sent, -1 otherwise.
+ * @return 0 if the message has been sent or the destination is a transient federate that is not connected, -1 otherwise.
  */
 int lf_send_message(int message_type, unsigned short port, unsigned short federate, const char* next_destination_str,
                     size_t length, unsigned char* message);
@@ -550,7 +551,8 @@ int lf_send_stop_request_to_rti(tag_t stop_tag);
  * MSG_TYPE_P2P_TAGGED_MESSAGE, then the failure is not critical. It may be due to the
  * remote federate having exited, for example, because its safe-to-process offset led it
  * to believe that there were no messages forthcoming.  In this case, on failure to send
- * the message, this function returns -11.
+ * the message, this function returns -1. If the destination is a transient federate that is not connected,
+ * then this function returns 0.
  *
  * This method assumes that the caller does not hold the lf_outbound_net_mutex lock,
  * which it acquires to perform the send.
@@ -566,7 +568,7 @@ int lf_send_stop_request_to_rti(tag_t stop_tag);
  *  (used for reporting errors).
  * @param length The message length.
  * @param message The message.
- * @return 0 if the message has been sent, 1 otherwise.
+ * @return 0 if the message has been sent or the destination is a transient federate that is not connected, -1 otherwise.
  */
 int lf_send_tagged_message(environment_t* env, interval_t additional_delay, int message_type, unsigned short port,
                            unsigned short federate, const char* next_destination_str, size_t length,

--- a/include/core/federated/federate.h
+++ b/include/core/federated/federate.h
@@ -420,10 +420,7 @@ void lf_reset_status_fields_on_input_port_triggers(void);
  * @brief Send a message to another federate.
  * @ingroup Federated
  *
- * This function is used for physical connections
- * between federates. If the connection to the remote federate or the RTI has been broken,
- * then this returns -1 without sending, unless the destination is a transient federate
- * that is not connected, in which case it returns 0. Otherwise, it returns 0.
+ * This function is used for physical connections between federates.
  *
  * This method assumes that the caller does not hold the lf_outbound_net_mutex lock,
  * which it acquires to perform the send.

--- a/include/core/federated/federate.h
+++ b/include/core/federated/federate.h
@@ -432,7 +432,8 @@ void lf_reset_status_fields_on_input_port_triggers(void);
  * @param next_destination_str The name of the next destination in string format (for reporting).
  * @param length The message length.
  * @param message The message.
- * @return 0 if the message has been sent or the destination is a transient federate that is not connected, -1 otherwise.
+ * @return 0 if the message has been sent or the destination is a transient federate that is not connected, -1
+ * otherwise.
  */
 int lf_send_message(int message_type, unsigned short port, unsigned short federate, const char* next_destination_str,
                     size_t length, unsigned char* message);
@@ -568,7 +569,8 @@ int lf_send_stop_request_to_rti(tag_t stop_tag);
  *  (used for reporting errors).
  * @param length The message length.
  * @param message The message.
- * @return 0 if the message has been sent or the destination is a transient federate that is not connected, -1 otherwise.
+ * @return 0 if the message has been sent or the destination is a transient federate that is not connected, -1
+ * otherwise.
  */
 int lf_send_tagged_message(environment_t* env, interval_t additional_delay, int message_type, unsigned short port,
                            unsigned short federate, const char* next_destination_str, size_t length,

--- a/include/core/federated/federate.h
+++ b/include/core/federated/federate.h
@@ -301,24 +301,24 @@ extern lf_cond_t lf_port_status_changed;
 // Public functions (in alphabetical order)
 
 /**
- * @brief Connect to the federate with the specified id.
+ * @brief Connect to the downstreamfederate with the specified id.
  * @ingroup Federated
  *
  * The established connection will then be used in functions such as lf_send_tagged_message()
  * to send messages directly to the specified federate.
  * This function first sends an MSG_TYPE_ADDRESS_QUERY message to the RTI to obtain
  * the IP address and port number of the specified federate. It then attempts
- * to establish a network abstraction connection to the specified federate.
- * If this fails, the program exits. If it succeeds, it sets element [id] of
- * the _fed.net_for_outbound_p2p_connections global array to
+ * to establish a network connection to the specified federate.
+ * If this fails, the program exits. If it succeeds, it sets
+ * _fed.net_for_outbound_p2p_connections[remote_federate_id] to
  * refer to the network abstraction for communicating directly with the federate.
  *
  * @param remote_federate_id The ID of the remote federate.
  * @param joined_tag The tag at which the remote federate joined. This is NEVER_TAG for persistent federates,
  *   and either FOREVER_TAG (not yet joined) or the tag at which the transient federate joined for transient federates.
- * @param port The port number of the remote federate. Pass -1 if it is to be queried.
- * @param ip_address The IP address of the remote federate, in network byte order. Pass 0
- *   if it is to be queried.
+ * @param port The port number of the remote federate or -1 to ask for the port number from the RTI.
+ * @param ip_address The IP address of the remote federate, in network byte order, or 0
+ *   to ask for the IP address from the RTI.
  */
 void lf_connect_to_federate(uint16_t remote_federate_id, tag_t joined_tag, int32_t port, uint32_t ip_address);
 

--- a/include/core/federated/federate.h
+++ b/include/core/federated/federate.h
@@ -301,11 +301,12 @@ extern lf_cond_t lf_port_status_changed;
 // Public functions (in alphabetical order)
 
 /**
- * @brief Connect to the downstreamfederate with the specified id.
+ * @brief Connect to the downstream federate with the specified id.
  * @ingroup Federated
  *
- * The established connection will then be used in functions such as lf_send_tagged_message()
- * to send messages directly to the specified federate.
+ * The established connection will then be used in functions such as lf_send_message()
+ * (for physical connections) or lf_send_tagged_message() (for logical connections with
+ * decentralized coordination) to send messages directly to the specified federate.
  * This function first sends an MSG_TYPE_ADDRESS_QUERY message to the RTI to obtain
  * the IP address and port number of the specified federate. It then attempts
  * to establish a network connection to the specified federate.
@@ -314,8 +315,9 @@ extern lf_cond_t lf_port_status_changed;
  * refer to the network abstraction for communicating directly with the federate.
  *
  * @param remote_federate_id The ID of the remote federate.
- * @param joined_tag The tag at which the remote federate joined. This is NEVER_TAG for persistent federates,
- *   and either FOREVER_TAG (not yet joined) or the tag at which the transient federate joined for transient federates.
+ * @param joined_tag The tag at which the remote federate joined. This is NEVER_TAG
+ *   for persistent federates, and either FOREVER_TAG (not yet joined) or the tag at
+ *   which the transient federate joined for transient federates (obtained from the RTI).
  * @param port The port number of the remote federate or -1 to ask for the port number from the RTI.
  * @param ip_address The IP address of the remote federate, in network byte order, or 0
  *   to ask for the IP address from the RTI.

--- a/lingua-franca-ref.txt
+++ b/lingua-franca-ref.txt
@@ -1,1 +1,1 @@
-transient-fed
+transient-fed-eal

--- a/low_level_platform/impl/src/lf_patmos_support.c
+++ b/low_level_platform/impl/src/lf_patmos_support.c
@@ -29,10 +29,14 @@ static volatile int _lf_num_nested_critical_sections = 0;
  * @return int 0 if successful sleep, -1 if awoken by async event
  */
 
-__attribute__((noinline)) int _lf_interruptable_sleep_until_locked(environment_t* env, instant_t wakeup) {
+int _lf_interruptable_sleep_until_locked(environment_t* env, instant_t wakeup) {
   instant_t now;
   _lf_async_event = false;
   lf_enable_interrupts_nested();
+
+  _lf_clock_gettime(&now);
+  printf("[PATMOS] interruptable_sleep_until_locked: now=%lld wakeup=%lld delta_ns=%lld\n", (long long)now,
+         (long long)wakeup, (long long)(wakeup - now));
 
   // Do busy sleep
   do {
@@ -43,8 +47,10 @@ __attribute__((noinline)) int _lf_interruptable_sleep_until_locked(environment_t
 
   if (_lf_async_event) {
     _lf_async_event = false;
+    printf("[PATMOS] interruptable_sleep_until_locked: woken by async event at now=%lld\n", (long long)now);
     return -1;
   } else {
+    printf("[PATMOS] interruptable_sleep_until_locked: wakeup reached at now=%lld\n", (long long)now);
     return 0;
   }
 }
@@ -54,11 +60,15 @@ int lf_sleep(interval_t sleep_duration) {
   _lf_clock_gettime(&now);
   instant_t wakeup = now + sleep_duration;
 
+  printf("[PATMOS] lf_sleep: now=%lld duration_ns=%lld wakeup=%lld\n", (long long)now, (long long)sleep_duration,
+         (long long)wakeup);
+
   // Do busy sleep
   do {
     _lf_clock_gettime(&now);
   } while ((now < wakeup));
 
+  printf("[PATMOS] lf_sleep: done at now=%lld\n", (long long)now);
   return 0;
 }
 

--- a/low_level_platform/impl/src/lf_patmos_support.c
+++ b/low_level_platform/impl/src/lf_patmos_support.c
@@ -60,7 +60,8 @@ int lf_sleep(interval_t sleep_duration) {
   _lf_clock_gettime(&now);
   instant_t wakeup = now + sleep_duration;
 
-  printf("[PATMOS] lf_sleep: now=%lld duration_ns=%lld wakeup=%lld\n", (long long)now, (long long)sleep_duration, (long long)wakeup);
+  printf("[PATMOS] lf_sleep: now=%lld duration_ns=%lld wakeup=%lld\n", (long long)now, (long long)sleep_duration,
+         (long long)wakeup);
 
   // Do busy sleep
   do {

--- a/low_level_platform/impl/src/lf_patmos_support.c
+++ b/low_level_platform/impl/src/lf_patmos_support.c
@@ -29,14 +29,10 @@ static volatile int _lf_num_nested_critical_sections = 0;
  * @return int 0 if successful sleep, -1 if awoken by async event
  */
 
-int _lf_interruptable_sleep_until_locked(environment_t* env, instant_t wakeup) {
+__attribute__((noinline)) int _lf_interruptable_sleep_until_locked(environment_t* env, instant_t wakeup) {
   instant_t now;
   _lf_async_event = false;
   lf_enable_interrupts_nested();
-
-  _lf_clock_gettime(&now);
-  printf("[PATMOS] interruptable_sleep_until_locked: now=%lld wakeup=%lld delta_ns=%lld\n", (long long)now,
-         (long long)wakeup, (long long)(wakeup - now));
 
   // Do busy sleep
   do {
@@ -47,10 +43,8 @@ int _lf_interruptable_sleep_until_locked(environment_t* env, instant_t wakeup) {
 
   if (_lf_async_event) {
     _lf_async_event = false;
-    printf("[PATMOS] interruptable_sleep_until_locked: woken by async event at now=%lld\n", (long long)now);
     return -1;
   } else {
-    printf("[PATMOS] interruptable_sleep_until_locked: wakeup reached at now=%lld\n", (long long)now);
     return 0;
   }
 }
@@ -60,15 +54,11 @@ int lf_sleep(interval_t sleep_duration) {
   _lf_clock_gettime(&now);
   instant_t wakeup = now + sleep_duration;
 
-  printf("[PATMOS] lf_sleep: now=%lld duration_ns=%lld wakeup=%lld\n", (long long)now, (long long)sleep_duration,
-         (long long)wakeup);
-
   // Do busy sleep
   do {
     _lf_clock_gettime(&now);
   } while ((now < wakeup));
 
-  printf("[PATMOS] lf_sleep: done at now=%lld\n", (long long)now);
   return 0;
 }
 

--- a/low_level_platform/impl/src/lf_patmos_support.c
+++ b/low_level_platform/impl/src/lf_patmos_support.c
@@ -30,7 +30,7 @@ static volatile int _lf_num_nested_critical_sections = 0;
  */
 
 int _lf_interruptable_sleep_until_locked(environment_t* env, instant_t wakeup) {
-  instant_t now;
+  volatile instant_t now;
   _lf_async_event = false;
   lf_enable_interrupts_nested();
 
@@ -56,7 +56,7 @@ int _lf_interruptable_sleep_until_locked(environment_t* env, instant_t wakeup) {
 }
 
 int lf_sleep(interval_t sleep_duration) {
-  instant_t now;
+  volatile instant_t now;
   _lf_clock_gettime(&now);
   instant_t wakeup = now + sleep_duration;
 

--- a/low_level_platform/impl/src/lf_patmos_support.c
+++ b/low_level_platform/impl/src/lf_patmos_support.c
@@ -34,9 +34,9 @@ int _lf_interruptable_sleep_until_locked(environment_t* env, instant_t wakeup) {
   _lf_async_event = false;
   lf_enable_interrupts_nested();
 
-  _lf_clock_gettime(&now);
-  printf("[PATMOS] interruptable_sleep_until_locked: now=%lld wakeup=%lld delta_ns=%lld\n", (long long)now,
-         (long long)wakeup, (long long)(wakeup - now));
+  // _lf_clock_gettime(&now);
+  // printf("[PATMOS] interruptable_sleep_until_locked: now=%lld wakeup=%lld delta_ns=%lld\n", (long long)now,
+  //        (long long)wakeup, (long long)(wakeup - now));
 
   // Do busy sleep
   do {
@@ -47,10 +47,10 @@ int _lf_interruptable_sleep_until_locked(environment_t* env, instant_t wakeup) {
 
   if (_lf_async_event) {
     _lf_async_event = false;
-    printf("[PATMOS] interruptable_sleep_until_locked: woken by async event at now=%lld\n", (long long)now);
+    // printf("[PATMOS] interruptable_sleep_until_locked: woken by async event at now=%lld\n", (long long)now);
     return -1;
   } else {
-    printf("[PATMOS] interruptable_sleep_until_locked: wakeup reached at now=%lld\n", (long long)now);
+    // printf("[PATMOS] interruptable_sleep_until_locked: wakeup reached at now=%lld\n", (long long)now);
     return 0;
   }
 }
@@ -60,15 +60,15 @@ int lf_sleep(interval_t sleep_duration) {
   _lf_clock_gettime(&now);
   instant_t wakeup = now + sleep_duration;
 
-  printf("[PATMOS] lf_sleep: now=%lld duration_ns=%lld wakeup=%lld\n", (long long)now, (long long)sleep_duration,
-         (long long)wakeup);
+  // printf("[PATMOS] lf_sleep: now=%lld duration_ns=%lld wakeup=%lld\n", (long long)now, (long long)sleep_duration,
+  //        (long long)wakeup);
 
   // Do busy sleep
   do {
     _lf_clock_gettime(&now);
   } while ((now < wakeup));
 
-  printf("[PATMOS] lf_sleep: done at now=%lld\n", (long long)now);
+  // printf("[PATMOS] lf_sleep: done at now=%lld\n", (long long)now);
   return 0;
 }
 

--- a/low_level_platform/impl/src/lf_patmos_support.c
+++ b/low_level_platform/impl/src/lf_patmos_support.c
@@ -30,13 +30,13 @@ static volatile int _lf_num_nested_critical_sections = 0;
  */
 
 int _lf_interruptable_sleep_until_locked(environment_t* env, instant_t wakeup) {
-  volatile instant_t now;
+  instant_t now;
   _lf_async_event = false;
   lf_enable_interrupts_nested();
 
-  // _lf_clock_gettime(&now);
-  // printf("[PATMOS] interruptable_sleep_until_locked: now=%lld wakeup=%lld delta_ns=%lld\n", (long long)now,
-  //        (long long)wakeup, (long long)(wakeup - now));
+  _lf_clock_gettime(&now);
+  printf("[PATMOS] interruptable_sleep_until_locked: now=%lld wakeup=%lld delta_ns=%lld\n", (long long)now,
+         (long long)wakeup, (long long)(wakeup - now));
 
   // Do busy sleep
   do {
@@ -47,28 +47,27 @@ int _lf_interruptable_sleep_until_locked(environment_t* env, instant_t wakeup) {
 
   if (_lf_async_event) {
     _lf_async_event = false;
-    // printf("[PATMOS] interruptable_sleep_until_locked: woken by async event at now=%lld\n", (long long)now);
+    printf("[PATMOS] interruptable_sleep_until_locked: woken by async event at now=%lld\n", (long long)now);
     return -1;
   } else {
-    // printf("[PATMOS] interruptable_sleep_until_locked: wakeup reached at now=%lld\n", (long long)now);
+    printf("[PATMOS] interruptable_sleep_until_locked: wakeup reached at now=%lld\n", (long long)now);
     return 0;
   }
 }
 
 int lf_sleep(interval_t sleep_duration) {
-  volatile instant_t now;
+  instant_t now;
   _lf_clock_gettime(&now);
   instant_t wakeup = now + sleep_duration;
 
-  // printf("[PATMOS] lf_sleep: now=%lld duration_ns=%lld wakeup=%lld\n", (long long)now, (long long)sleep_duration,
-  //        (long long)wakeup);
+  printf("[PATMOS] lf_sleep: now=%lld duration_ns=%lld wakeup=%lld\n", (long long)now, (long long)sleep_duration, (long long)wakeup);
 
   // Do busy sleep
   do {
     _lf_clock_gettime(&now);
   } while ((now < wakeup));
 
-  // printf("[PATMOS] lf_sleep: done at now=%lld\n", (long long)now);
+  printf("[PATMOS] lf_sleep: done at now=%lld\n", (long long)now);
   return 0;
 }
 

--- a/network/api/net_common.h
+++ b/network/api/net_common.h
@@ -169,7 +169,7 @@
  * and upstream neighbors with @ref MSG_TYPE_DOWNSTREAM_CONNECTED. The upstream
  * neighbors will (re-)establish P2P connections to the transient, while the
  * transient will (re-)establish P2P connections to its downstream neighbors.
- * 
+ *
  * Under decentralized coordination, downstream neighbors acknowledge the
  * (re)connection with a @ref MSG_TYPE_ACK that carries the current tag (when
  * it (re)connects) of the downstream federate. The transient federate
@@ -178,7 +178,7 @@
  * assumed to not prematurely advance its tag beyond this current tag by using
  * its `maxwait` parameter because, now that its upstream transient is connected,
  * it cannot simply assume that the input from the transient is absent.
- * 
+ *
  * When a transient disconnects, @ref MSG_TYPE_UPSTREAM_DISCONNECTED
  * and @ref MSG_TYPE_DOWNSTREAM_DISCONNECTED are sent to neighbors.
  * Downstream neighbors will then treat inputs from the transient as absent

--- a/network/api/net_common.h
+++ b/network/api/net_common.h
@@ -308,7 +308,7 @@
  *  * One byte giving the type of the federate (1 if transient, 0 if persistent)
  *  * N bytes containing the federation ID.
  *  Each federate needs to have a unique ID between 0 and NUMBER_OF_FEDERATES-1.
- *  Each federate, when starting up, should send this message to the RTI. 
+ *  Each federate, when starting up, should send this message to the RTI.
  *  This is its first message to the RTI.
  *  The RTI will respond with either MSG_TYPE_REJECT, MSG_TYPE_ACK, or MSG_TYPE_UDP_PORT.
  *  If the federate is a C target LF program, the generated federate

--- a/network/api/net_common.h
+++ b/network/api/net_common.h
@@ -149,62 +149,43 @@
  *
  * A federate may be marked transient, meaning it is allowed to join the
  * federation after execution has begun, and to disconnect and later rejoin.
+ * While a transient federate is absent, its downstream neighbors will treat
+ * inputs from it as absent. Its upstream neighbors will not send messages to
+ * it.
+ *
  * If a transient federate joins during the RTI's startup phase
  * (before all persistent federates have proposed a start time), it is
  * treated like any other federate and simply receives the common start time.
  *
- * FIXME: This is about centralized coordination only? Also, should be "no later" rather than "no earlier"?
- * If a transient joins later, the RTI computes an effective start tag for it
- * that is no earlier than the tag of any message already routed to it and no
- * earlier than the federation's current tag. This tag is returned together
- * with the common start time in an extended @ref MSG_TYPE_TIMESTAMP message
- * (see MSG_TYPE_TIMESTAMP_TAG_LENGTH); the transient does not begin
- * executing tags until then.
- * FIXME: I don't like MSG_TYPE_TIMESTAMP having two different lengths.
+ * How a later joining is handled depends on the coordination type.
  *
- * Because a transient can appear or disappear at any point, its neighbors
- * must be told when to treat it as absent. When a transient (re-)connects,
- * the RTI notifies downstream neighbors with @ref MSG_TYPE_UPSTREAM_CONNECTED
- * and upstream neighbors with @ref MSG_TYPE_DOWNSTREAM_CONNECTED. The upstream
- * neighbors will (re-)establish P2P connections to the transient, while the
- * transient will (re-)establish P2P connections to its downstream neighbors.
+ * Under centralized coordination, when a transient federate joins during execution,
+ * the RTI sets its effective start tag to the maximum of several candidates, then
+ * advances the microstep by one wherever that candidate is taken from an
+ * already-observed tag. It starts from the join timestamp at microstep 0,
+ * but never earlier than the federation start time `(start_time, 0)`. It then
+ * raises that tag if needed so it is strictly after the joining federate's
+ * latest completed logical tag, after every immediate downstream's latest
+ * TAG or PTAG, and after the latest in-transit message tag known from any
+ * immediate upstream. The result is sent while the RTI still holds its mutex,
+ * so no upstream message can be forwarded before that start tag, and any pending
+ * delayed grants to downstreams at or after the new effective start are canceled
+ * so they cannot race with messages the rejoined transient may produce at that tag.
  *
- * Under decentralized coordination, downstream neighbors acknowledge the
- * (re)connection with a @ref MSG_TYPE_ACK that carries the current tag (when
- * it (re)connects) of the downstream federate. The transient federate
- * uses this to ensure that its effective start tag is never set earlier than
- * the current tag of its downstream neighbors.  The downstream federate is
- * assumed to not prematurely advance its tag beyond this current tag by using
- * its `maxwait` parameter because, now that its upstream transient is connected,
- * it cannot simply assume that the input from the transient is absent.
- *
- * When a transient disconnects, @ref MSG_TYPE_UPSTREAM_DISCONNECTED
- * and @ref MSG_TYPE_DOWNSTREAM_DISCONNECTED are sent to neighbors.
- * Downstream neighbors will then treat inputs from the transient as absent
- * rather than blocking on them, and upstream neighbors will refrain from sending
- * messages to the transient.
- *
- * The next step depends on the coordination type.
- *
- * FIXME: Unclear:
- * Under centralized coordination, each federate will send a
- * `MSG_TYPE_NEXT_EVENT_TAG` to the RTI with the start tag. That is to say that
- * each federate has a valid event at the start tag (start time, 0) and it will
- * inform the RTI of this event.
- * Subsequently, at the conclusion of each tag, each federate will send a
- * `MSG_TYPE_LATEST_TAG_CONFIRMED` followed by a `MSG_TYPE_NEXT_EVENT_TAG` (see
- * the comment for each message for further explanation). Each federate would
- * have to wait for a `MSG_TYPE_TAG_ADVANCE_GRANT` or a
- * `MSG_TYPE_PROVISIONAL_TAG_ADVANCE_GRANT` before it can advance to a
- * particular tag.
- *
- * FIXME: Obsolete:
- * Under decentralized coordination, the coordination is governed by STA and
- * STAAs, as further explained in https://doi.org/10.48550/arXiv.2109.07771.
- *
- * FIXME: Expand this. Explain port absent reactions.
+ * Under decentralized coordination, when a transient federate joins during execution,
+ * the RTI takes the `(timestamp, microstep)` the federate proposed as its candidate
+ * effective start tag. If that timestamp is earlier than the federation start time,
+ * the tag is raised to (start_time, 0). Otherwise, if the federate has any upstream
+ * peer (some connected federate lists it among its downstream transients), the RTI
+ * instead uses `(timestamp + DELAY_START, 0)`, under the assumption that `DELAY_START`
+ * is large enough to cover clock-synchronization error plus network latency so
+ * upstreams cannot advance past the join before the newcomer's start. If there are
+ * no upstream peers, the proposed `(timestamp, microstep)` is kept (or the federation
+ * start floor above). As with centralized joins, the RTI sends this effective start
+ * tag while still holding the mutex.
  *
  * ### Requesting a stop
+ *
  * Overview of the algorithm:
  *  When any federate calls lf_request_stop(), it will
  *  send a MSG_TYPE_STOP_REQUEST message to the RTI, which will then
@@ -312,8 +293,7 @@
  *  Each federate needs to have a unique ID between 0 and NUMBER_OF_FEDERATES-1.
  *  Each federate, when starting up, should send this message to the RTI.
  *  This is its first message to the RTI.
- *  FIXME: Does it really send MSG_TYPE_UDP_PORT?
- *  The RTI will respond with either MSG_TYPE_REJECT, MSG_TYPE_ACK, or MSG_TYPE_UDP_PORT.
+ *  The RTI will respond with either MSG_TYPE_REJECT or MSG_TYPE_ACK.
  *  If the federate is a C target LF program, the generated federate
  *  code does this by calling lf_synchronize_with_other_federates(),
  *  passing to it its federate ID.

--- a/network/api/net_common.h
+++ b/network/api/net_common.h
@@ -149,6 +149,8 @@
  *
  * A federate may be marked transient, meaning it is allowed to join the
  * federation after execution has begun, and to disconnect and later rejoin.
+ * A transient identifies itself with @ref MSG_TYPE_TRANSIENT_FED_IDS instead
+ * of @ref MSG_TYPE_FED_IDS.
  * While a transient federate is absent, its downstream neighbors will treat
  * inputs from it as absent. Its upstream neighbors will not send messages to
  * it.
@@ -265,7 +267,7 @@
 #define MSG_TYPE_ACK 255
 
 /**
- * @brief Byte identifying an acknowledgment of the previously received MSG_TYPE_FED_IDS message.
+ * @brief Byte identifying an acknowledgment of the previously received MSG_TYPE_FED_IDS or MSG_TYPE_TRANSIENT_FED_IDS message.
  * @ingroup Network
  *
  * This message is sent by the RTI to the federate with a payload indicating the UDP port to use
@@ -277,14 +279,13 @@
 
 /**
  * @brief Byte identifying a message from a federate to an RTI containing
- * the federation ID, the federate ID, and the federate type (persistent or transient).
+ * the federation ID, the federate ID.
  * @ingroup Network
  *
  * The message contains, in this order:
- *  * One byte equal to MSG_TYPE_FED_IDS.
+ *  * One byte equal to MSG_TYPE_FED_IDS or MSG_TYPE_TRANSIENT_FED_IDS, depending on the federate type.
  *  * Two bytes (ushort) giving the federate ID.
  *  * One byte (uchar) giving the length N of the federation ID.
- *  * One byte giving the type of the federate (1 if transient, 0 if persistent)
  *  * N bytes containing the federation ID.
  *  Each federate needs to have a unique ID between 0 and NUMBER_OF_FEDERATES-1.
  *  Each federate, when starting up, should send this message to the RTI.
@@ -295,7 +296,8 @@
  *  passing to it its federate ID.
  */
 #define MSG_TYPE_FED_IDS 1
-#define MSG_TYPE_FED_IDS_LENGTH (1 + sizeof(uint16_t) + 1 + 1)
+#define MSG_TYPE_TRANSIENT_FED_IDS 103
+#define MSG_TYPE_FED_IDS_LENGTH (1 + sizeof(uint16_t) + 1)
 
 /////////// Messages used for authenticated federation. ///////////////
 /**

--- a/network/api/net_common.h
+++ b/network/api/net_common.h
@@ -267,7 +267,8 @@
 #define MSG_TYPE_ACK 255
 
 /**
- * @brief Byte identifying an acknowledgment of the previously received MSG_TYPE_FED_IDS or MSG_TYPE_TRANSIENT_FED_IDS message.
+ * @brief Byte identifying an acknowledgment of the previously received MSG_TYPE_FED_IDS or MSG_TYPE_TRANSIENT_FED_IDS
+ * message.
  * @ingroup Network
  *
  * This message is sent by the RTI to the federate with a payload indicating the UDP port to use

--- a/network/api/net_common.h
+++ b/network/api/net_common.h
@@ -153,12 +153,14 @@
  * (before all persistent federates have proposed a start time), it is
  * treated like any other federate and simply receives the common start time.
  *
+ * FIXME: This is about centralized coordination only? Also, should be "no later" rather than "no earlier"?
  * If a transient joins later, the RTI computes an effective start tag for it
  * that is no earlier than the tag of any message already routed to it and no
  * earlier than the federation's current tag. This tag is returned together
  * with the common start time in an extended @ref MSG_TYPE_TIMESTAMP message
  * (see MSG_TYPE_TIMESTAMP_TAG_LENGTH); the transient does not begin
  * executing tags until then.
+ * FIXME: I don't like MSG_TYPE_TIMESTAMP having two different lengths.
  *
  * Because a transient can appear or disappear at any point, its neighbors
  * must be told when to treat it as absent. When a transient (re-)connects,
@@ -310,6 +312,7 @@
  *  Each federate needs to have a unique ID between 0 and NUMBER_OF_FEDERATES-1.
  *  Each federate, when starting up, should send this message to the RTI.
  *  This is its first message to the RTI.
+ *  FIXME: Does it really send MSG_TYPE_UDP_PORT?
  *  The RTI will respond with either MSG_TYPE_REJECT, MSG_TYPE_ACK, or MSG_TYPE_UDP_PORT.
  *  If the federate is a C target LF program, the generated federate
  *  code does this by calling lf_synchronize_with_other_federates(),
@@ -401,20 +404,19 @@
 #define MSG_TYPE_TIMESTAMP_TAG_LENGTH (1 + sizeof(instant_t) + sizeof(instant_t) + sizeof(microstep_t))
 
 /**
- * @brief Byte identifying a timestamp message with a microstep, which is 64 + 32 bits long.
+ * @brief Byte identifying a message with a tag, which is 64 + 32 bits long.
  * @ingroup Network
  *
  * Like MSG_TYPE_TIMESTAMP, but carries an additional microstep field (microstep_t)
- * after the 64-bit timestamp. This is useful for decentralized coordination, when a
- * transient federate with outbound P2P connections wants to join.
+ * after the 64-bit timestamp.
  */
-#define MSG_TYPE_TIMESTAMP_WITH_MICROSTEP 32
+#define MSG_TYPE_TAG 32
 
 /**
- * @brief The length of a timestamp-with-microstep message.
+ * @brief The length of a tag message.
  * @ingroup Network
  */
-#define MSG_TYPE_TIMESTAMP_WITH_MICROSTEP_LENGTH (1 + sizeof(instant_t) + sizeof(microstep_t))
+#define MSG_TYPE_TAG_LENGTH (1 + sizeof(instant_t) + sizeof(microstep_t))
 
 /**
  * @brief Byte identifying a message to forward to another federate.

--- a/network/api/net_common.h
+++ b/network/api/net_common.h
@@ -21,14 +21,12 @@
  * use DEFAULT_PORT.
  *
  * When it has successfully opened a TCP connection, the first message it sends
- * to the RTI is either a @ref MSG_TYPE_FED_IDS message, if it is a persistent
- * federate, or a @ref MSG_TYPE_TRANSIENT_FED_IDS message, if it is a transient
- * federate (see "Transient federates" below). Either message contains the ID
+ * to the RTI is a @ref MSG_TYPE_FED_IDS message. The message contains the ID
  * of this federate within the federation, contained in the global variable
  * _lf_my_fed_id in the federate code (which is initialized by the code
  * generator), and the unique ID of the federation, a GUID that is created at
  * run time by the generated script that launches the federation. The
- * transient variant additionally carries a byte giving the federate's type
+ * transient additionally carries a byte giving the federate's type
  * (persistent (0) or transient (1)).
  * If you launch the federates and the RTI manually, rather than using the script,
  * then the federation ID is a string that is optionally given to the federate
@@ -151,8 +149,7 @@
  *
  * A federate may be marked transient, meaning it is allowed to join the
  * federation after execution has begun, and to disconnect and later rejoin.
- * A transient identifies itself with @ref MSG_TYPE_TRANSIENT_FED_IDS instead
- * of @ref MSG_TYPE_FED_IDS. If it joins during the RTI's startup phase
+ * If a transient federate joins during the RTI's startup phase
  * (before all persistent federates have proposed a start time), it is
  * treated like any other federate and simply receives the common start time.
  *
@@ -301,40 +298,25 @@
 
 /**
  * @brief Byte identifying a message from a federate to an RTI containing
- * the federation ID and the federate ID.
+ * the federation ID, the federate ID, and th federate type (persistent or transient).
  * @ingroup Network
  *
  * The message contains, in this order:
  *  * One byte equal to MSG_TYPE_FED_IDS.
  *  * Two bytes (ushort) giving the federate ID.
  *  * One byte (uchar) giving the length N of the federation ID.
+ *  * One byte giving the type of the federate (1 if transient, 0 if persistent)
  *  * N bytes containing the federation ID.
  *  Each federate needs to have a unique ID between 0 and NUMBER_OF_FEDERATES-1.
- *  Each federate, when starting up, should send either this message, or MSG_TYPE_TRANSIENT_FED_IDS
- *  to the RTI, as its first message to the RTI.
+ *  Each federate, when starting up, should send this message to the RTI. 
+ *  This is its first message to the RTI.
  *  The RTI will respond with either MSG_TYPE_REJECT, MSG_TYPE_ACK, or MSG_TYPE_UDP_PORT.
  *  If the federate is a C target LF program, the generated federate
  *  code does this by calling lf_synchronize_with_other_federates(),
  *  passing to it its federate ID.
  */
 #define MSG_TYPE_FED_IDS 1
-
-/** Byte identifying a message from a transient federate to an RTI containing
- *  the federate ID and the federation ID. The message contains, in this order:
- *  * One byte equal to MSG_TYPE_TRANSIENT_FED_IDS.
- *  * Two bytes (ushort) giving the federate ID.
- *  * One byte (uchar) giving the length N of the federation ID.
- *  * One byte giving the type of the federate (1 if transient, 0 if persistent)
- *  * N bytes containing the federation ID.
- *  Each federate needs to have a unique ID between 0 and NUMBER_OF_FEDERATES-1.
- *  Each federate, when starting up, should send either this message, or MSG_TYPE_FED_IDS
- *  to the RTI, as its first message to the RTI.
- *  The RTI will respond with either MSG_TYPE_REJECT, MSG_TYPE_ACK, or MSG_TYPE_UDP_PORT.
- *  If the federate is a C target LF program, the generated federate
- *  code does this by calling lf_synchronize_with_other_federates(),
- *  passing to it its federate ID.
- */
-#define MSG_TYPE_TRANSIENT_FED_IDS 103
+#define MSG_TYPE_FED_IDS_LENGTH (1 + sizeof(uint16_t) + 1 + 1)
 
 /////////// Messages used for authenticated federation. ///////////////
 /**

--- a/network/api/net_common.h
+++ b/network/api/net_common.h
@@ -277,7 +277,7 @@
 
 /**
  * @brief Byte identifying a message from a federate to an RTI containing
- * the federation ID, the federate ID, and th federate type (persistent or transient).
+ * the federation ID, the federate ID, and the federate type (persistent or transient).
  * @ingroup Network
  *
  * The message contains, in this order:

--- a/network/api/net_common.h
+++ b/network/api/net_common.h
@@ -804,8 +804,8 @@
  * Upon receiving this, the upstream federate should query the RTI for the downstream's
  * address and establish (or re-establish) the outbound P2P connection.
  */
-#define MSG_TYPE_OUTBOUND_CONNECTED 30
-#define MSG_TYPE_OUTBOUND_CONNECTED_LENGTH                                                                             \
+#define MSG_TYPE_DOWNSTREAM_CONNECTED 30
+#define MSG_TYPE_DOWNSTREAM_CONNECTED_LENGTH                                                                             \
   (1 + sizeof(uint16_t) + sizeof(instant_t) + sizeof(microstep_t) + sizeof(int32_t) + sizeof(uint32_t))
 
 /**
@@ -814,8 +814,8 @@
  * Upon receiving this, the upstream federate should close its outbound P2P connection
  * to the downstream.
  */
-#define MSG_TYPE_OUTBOUND_DISCONNECTED 31
-#define MSG_TYPE_OUTBOUND_DISCONNECTED_LENGTH (1 + sizeof(uint16_t))
+#define MSG_TYPE_DOWNSTREAM_DISCONNECTED 31
+#define MSG_TYPE_DOWNSTREAM_DISCONNECTED_LENGTH (1 + sizeof(uint16_t))
 
 /**
  * Byte sent by the RTI ordering the federate to stop. Upon receiving the message,

--- a/network/api/net_common.h
+++ b/network/api/net_common.h
@@ -164,19 +164,30 @@
  * executing tags until then.
  *
  * Because a transient can appear or disappear at any point, its neighbors
- * must be told when to treat it as absent versus when to wait for it. When a
- * transient (re-)connects, the RTI notifies downstream neighbors with
- * @ref MSG_TYPE_UPSTREAM_CONNECTED and upstream neighbors with
- * @ref MSG_TYPE_OUTBOUND_CONNECTED so that they (re-)establish P2P
- * connections to it. When it disconnects, @ref MSG_TYPE_UPSTREAM_DISCONNECTED
- * and @ref MSG_TYPE_OUTBOUND_DISCONNECTED are sent instead, so neighbors
- * treat it as absent rather than blocking on it. Under decentralized
- * coordination, the @ref MSG_TYPE_ACK a transient receives on (re-)connect
- * also carries the current tag of each of its outbound federates, so its
- * effective start tag is never set earlier than theirs.
+ * must be told when to treat it as absent. When a transient (re-)connects,
+ * the RTI notifies downstream neighbors with @ref MSG_TYPE_UPSTREAM_CONNECTED
+ * and upstream neighbors with @ref MSG_TYPE_DOWNSTREAM_CONNECTED. The upstream
+ * neighbors will (re-)establish P2P connections to the transient, while the
+ * transient will (re-)establish P2P connections to its downstream neighbors.
+ * 
+ * Under decentralized coordination, downstream neighbors acknowledge the
+ * (re)connection with a @ref MSG_TYPE_ACK that carries the current tag (when
+ * it (re)connects) of the downstream federate. The transient federate
+ * uses this to ensure that its effective start tag is never set earlier than
+ * the current tag of its downstream neighbors.  The downstream federate is
+ * assumed to not prematurely advance its tag beyond this current tag by using
+ * its `maxwait` parameter because, now that its upstream transient is connected,
+ * it cannot simply assume that the input from the transient is absent.
+ * 
+ * When a transient disconnects, @ref MSG_TYPE_UPSTREAM_DISCONNECTED
+ * and @ref MSG_TYPE_DOWNSTREAM_DISCONNECTED are sent to neighbors.
+ * Downstream neighbors will then treat inputs from the transient as absent
+ * rather than blocking on them, and upstream neighbors will refrain from sending
+ * messages to the transient.
  *
  * The next step depends on the coordination type.
  *
+ * FIXME: Unclear:
  * Under centralized coordination, each federate will send a
  * `MSG_TYPE_NEXT_EVENT_TAG` to the RTI with the start tag. That is to say that
  * each federate has a valid event at the start tag (start time, 0) and it will
@@ -188,6 +199,7 @@
  * `MSG_TYPE_PROVISIONAL_TAG_ADVANCE_GRANT` before it can advance to a
  * particular tag.
  *
+ * FIXME: Obsolete:
  * Under decentralized coordination, the coordination is governed by STA and
  * STAAs, as further explained in https://doi.org/10.48550/arXiv.2109.07771.
  *

--- a/network/api/net_common.h
+++ b/network/api/net_common.h
@@ -260,13 +260,9 @@
  * @brief Byte identifying an acknowledgment of the previously received message.
  * @ingroup Network
  *
- * This message carries a tag as payload (instant_t + microstep_t).
- * The tag is useful in decentralized coordination. When a transient joins, it
- * learns about outbound federates' current tags, so that it does not set its
- * effective_start_tag to be before theirs.
+ * This message carries no payload.
  */
 #define MSG_TYPE_ACK 255
-#define MSG_TYPE_ACK_LENGTH (1 + sizeof(instant_t) + sizeof(microstep_t))
 
 /**
  * @brief Byte identifying an acknowledgment of the previously received MSG_TYPE_FED_IDS message.

--- a/network/api/net_common.h
+++ b/network/api/net_common.h
@@ -805,7 +805,7 @@
  * address and establish (or re-establish) the outbound P2P connection.
  */
 #define MSG_TYPE_DOWNSTREAM_CONNECTED 30
-#define MSG_TYPE_DOWNSTREAM_CONNECTED_LENGTH                                                                             \
+#define MSG_TYPE_DOWNSTREAM_CONNECTED_LENGTH                                                                           \
   (1 + sizeof(uint16_t) + sizeof(instant_t) + sizeof(microstep_t) + sizeof(int32_t) + sizeof(uint32_t))
 
 /**

--- a/trace/api/types/trace_types.h
+++ b/trace/api/types/trace_types.h
@@ -87,7 +87,7 @@ typedef enum {
   receive_STOP,
   send_DOWNSTREAM_CONNECTED,
   receive_DOWNSTREAM_CONNECTED,
-  send_OUTBOUND_DISCONNECTED,
+  send_DOWNSTREAM_DISCONNECTED,
   receive_DOWNSTREAM_DISCONNECTED,
   NUM_EVENT_TYPES
 } trace_event_t;
@@ -166,8 +166,8 @@ static const char* trace_event_names[] = {
     "Receiving STOP",
     "Sending DOWNSTREAM_CONNECTED",
     "Receiving DOWNSTREAM_CONNECTED",
-    "Sending OUTBOUND_DISCONNECTED",
-    "Receiving OUTBOUND_DISCONNECTED",
+    "Sending DOWNSTREAM_DISCONNECTED",
+    "Receiving DOWNSTREAM_DISCONNECTED",
 };
 
 static inline void _suppress_unused_variable_warning_for_static_variable() { (void)trace_event_names; }

--- a/trace/api/types/trace_types.h
+++ b/trace/api/types/trace_types.h
@@ -86,7 +86,7 @@ typedef enum {
   send_STOP,
   receive_STOP,
   send_OUTBOUND_CONNECTED,
-  receive_OUTBOUND_CONNECTED,
+  receive_DOWNSTREAM_CONNECTED,
   send_OUTBOUND_DISCONNECTED,
   receive_OUTBOUND_DISCONNECTED,
   NUM_EVENT_TYPES

--- a/trace/api/types/trace_types.h
+++ b/trace/api/types/trace_types.h
@@ -85,10 +85,10 @@ typedef enum {
   receive_UPSTREAM_DISCONNECTED,
   send_STOP,
   receive_STOP,
-  send_OUTBOUND_CONNECTED,
+  send_DOWNSTREAM_CONNECTED,
   receive_DOWNSTREAM_CONNECTED,
   send_OUTBOUND_DISCONNECTED,
-  receive_OUTBOUND_DISCONNECTED,
+  receive_DOWNSTREAM_DISCONNECTED,
   NUM_EVENT_TYPES
 } trace_event_t;
 
@@ -164,8 +164,8 @@ static const char* trace_event_names[] = {
     "Receiving UPSTREAM_DISCONNECTED",
     "Sending STOP",
     "Receiving STOP",
-    "Sending OUTBOUND_CONNECTED",
-    "Receiving OUTBOUND_CONNECTED",
+    "Sending DOWNSTREAM_CONNECTED",
+    "Receiving DOWNSTREAM_CONNECTED",
     "Sending OUTBOUND_DISCONNECTED",
     "Receiving OUTBOUND_DISCONNECTED",
 };

--- a/util/tracing/visualization/fedsd.py
+++ b/util/tracing/visualization/fedsd.py
@@ -32,7 +32,7 @@ css_style = ' <style> \
     .FED_ID     { stroke: #80DD99; fill: #80DD99; } \
     .UPSTREAM_CONNECTED { stroke: #f4a261; fill: #f4a261; } \
     .UPSTREAM_DISCONNECTED { stroke: #e76f51; fill: #e76f51; } \
-    .OUTBOUND_CONNECTED { stroke: #2a9d8f; fill: #2a9d8f; } \
+    .DOWNSTREAM_CONNECTED { stroke: #2a9d8f; fill: #2a9d8f; } \
     .OUTBOUND_DISCONNECTED { stroke: #264653; fill: #264653; } \
     .ACK        { stroke: #52b788; fill: #52b788; } \
     .FAILED     { stroke: #c1121f; fill: #c1121f; } \
@@ -72,7 +72,7 @@ prune_event_name = {
     "Sending FED_ID": "FED_ID",
     "Sending UPSTREAM_CONNECTED": "UPSTREAM_CONNECTED",
     "Sending UPSTREAM_DISCONNECTED": "UPSTREAM_DISCONNECTED",
-    "Sending OUTBOUND_CONNECTED": "OUTBOUND_CONNECTED",
+    "Sending DOWNSTREAM_CONNECTED": "DOWNSTREAM_CONNECTED",
     "Sending OUTBOUND_DISCONNECTED": "OUTBOUND_DISCONNECTED",
     "Sending PTAG": "PTAG",
     "Sending TAG": "TAG",
@@ -99,7 +99,7 @@ prune_event_name = {
     "Receiving FED_ID": "FED_ID",
     "Receiving UPSTREAM_CONNECTED": "UPSTREAM_CONNECTED",
     "Receiving UPSTREAM_DISCONNECTED": "UPSTREAM_DISCONNECTED",
-    "Receiving OUTBOUND_CONNECTED": "OUTBOUND_CONNECTED",
+    "Receiving DOWNSTREAM_CONNECTED": "DOWNSTREAM_CONNECTED",
     "Receiving OUTBOUND_DISCONNECTED": "OUTBOUND_DISCONNECTED",
     "Receiving PTAG": "PTAG",
     "Receiving TAG": "TAG",
@@ -162,7 +162,7 @@ parser.add_argument('-e', '--end', type=str, nargs=2,
 # Events matching at the sender and receiver ends depend on whether they are tagged
 # (the elapsed logical time and microstep have to be the same) or not. 
 # Set of non-tagged events (messages)
-non_tagged_messages = {'FED_ID', 'UPSTREAM_CONNECTED', 'UPSTREAM_DISCONNECTED', 'OUTBOUND_CONNECTED', 'OUTBOUND_DISCONNECTED',
+non_tagged_messages = {'FED_ID', 'UPSTREAM_CONNECTED', 'UPSTREAM_DISCONNECTED', 'DOWNSTREAM_CONNECTED', 'OUTBOUND_DISCONNECTED',
                        'ACK', 'RESIGN', 'FAILED', 'REJECT', 'ADR_QR', 'ADR_QR_REP', 'ADR_AD', 'MSG', 'P2P_MSG', 'STOP'}
 
 

--- a/util/tracing/visualization/fedsd.py
+++ b/util/tracing/visualization/fedsd.py
@@ -33,7 +33,7 @@ css_style = ' <style> \
     .UPSTREAM_CONNECTED { stroke: #f4a261; fill: #f4a261; } \
     .UPSTREAM_DISCONNECTED { stroke: #e76f51; fill: #e76f51; } \
     .DOWNSTREAM_CONNECTED { stroke: #2a9d8f; fill: #2a9d8f; } \
-    .OUTBOUND_DISCONNECTED { stroke: #264653; fill: #264653; } \
+    .DOWNSTREAM_DISCONNECTED { stroke: #264653; fill: #264653; } \
     .ACK        { stroke: #52b788; fill: #52b788; } \
     .FAILED     { stroke: #c1121f; fill: #c1121f; } \
     .STOP       {stroke: #d0b7eb; fill: #d0b7eb} \
@@ -73,7 +73,7 @@ prune_event_name = {
     "Sending UPSTREAM_CONNECTED": "UPSTREAM_CONNECTED",
     "Sending UPSTREAM_DISCONNECTED": "UPSTREAM_DISCONNECTED",
     "Sending DOWNSTREAM_CONNECTED": "DOWNSTREAM_CONNECTED",
-    "Sending OUTBOUND_DISCONNECTED": "OUTBOUND_DISCONNECTED",
+    "Sending DOWNSTREAM_DISCONNECTED": "DOWNSTREAM_DISCONNECTED",
     "Sending PTAG": "PTAG",
     "Sending TAG": "TAG",
     "Sending REJECT": "REJECT",
@@ -100,7 +100,7 @@ prune_event_name = {
     "Receiving UPSTREAM_CONNECTED": "UPSTREAM_CONNECTED",
     "Receiving UPSTREAM_DISCONNECTED": "UPSTREAM_DISCONNECTED",
     "Receiving DOWNSTREAM_CONNECTED": "DOWNSTREAM_CONNECTED",
-    "Receiving OUTBOUND_DISCONNECTED": "OUTBOUND_DISCONNECTED",
+    "Receiving DOWNSTREAM_DISCONNECTED": "DOWNSTREAM_DISCONNECTED",
     "Receiving PTAG": "PTAG",
     "Receiving TAG": "TAG",
     "Receiving REJECT": "REJECT",
@@ -162,7 +162,7 @@ parser.add_argument('-e', '--end', type=str, nargs=2,
 # Events matching at the sender and receiver ends depend on whether they are tagged
 # (the elapsed logical time and microstep have to be the same) or not. 
 # Set of non-tagged events (messages)
-non_tagged_messages = {'FED_ID', 'UPSTREAM_CONNECTED', 'UPSTREAM_DISCONNECTED', 'DOWNSTREAM_CONNECTED', 'OUTBOUND_DISCONNECTED',
+non_tagged_messages = {'FED_ID', 'UPSTREAM_CONNECTED', 'UPSTREAM_DISCONNECTED', 'DOWNSTREAM_CONNECTED', 'DOWNSTREAM_DISCONNECTED',
                        'ACK', 'RESIGN', 'FAILED', 'REJECT', 'ADR_QR', 'ADR_QR_REP', 'ADR_AD', 'MSG', 'P2P_MSG', 'STOP'}
 
 


### PR DESCRIPTION
This PR fixes a number of race conditions and deadlocks in the support for transient federates.
Cursor did most of the work.

# First batch:

**1. Delayed-grant cancellation on transient rejoin** (`rti_remote.c`)
- Cancel if grant tag **`>=`** effective start (was `>`), so TAG `(t)` is not left queued when the transient rejoins at `(t)`.
- Free the removed entry and wake the delayed-grants thread.
- After start tag + `invalidate_min_delays`, re-run `notify_advance_grant_if_safe` on downstreams.

**2. Revalidate before sending delayed grants** (`lf_delayed_grants_thread`)
- If no upstream transients are absent, **drop** the grant (do not bypass EIMT) and re-evaluate normally.
- Drop redundant grants (`<= last_granted` / PTAG).

**3. EIMT tightening** (`rti_common.c`)
- For TAG decisions, tighten EIMT with `min(upstream.NET, EIMT(upstream))` per immediate upstream (including ZDC nodes), so a `FOREVER` NET intermediate cannot over-grant.

**4. Transient rejoin NET bound**
- On start-tag grant, if `next_event` is still `NEVER`, set it to the effective start so late joiners are not treated as federation `start_time`.

**5. Logging**
- Print LTC as `NEVER` / `FOREVER` instead of the wrapped numeric value.

# Next batch

The next batch fixed transient failures in `test/C/src/federated/TransientDecentralizedStatePersistence.lf`.

### 1. Retry the P2P handshake on a transient ACK failure (the actual bug fix)

Previously, if the ACK read failed while connecting to a transient (the macOS "connection reset because the accept loop hasn't accepted yet" window), the code logged a warning and `return`ed, leaving `net_for_outbound_p2p_connections[mid] == NULL` — on the false assumption that "the RTI will resend `MSG_TYPE_DOWNSTREAM_CONNECTED`." Since the RTI sends that notification exactly once (from `send_start_tag_locked` when the transient joins), `up` never reconnected and dropped every message to `mid` for the rest of the run.

Now, on that soft error, it closes the reset socket and retries the connection (opening a fresh socket each attempt), bounded by `CONNECT_TIMEOUT`:

```2160:2180:core/src/main/resources/lib/c/reactor-c/core/federated/federate.c
    int ack_read_failed = read_from_net(net, 1, (unsigned char*)buffer);
    if (ack_read_failed) {
      if (is_transient) {
        ...
        lf_print_warning("Failed to read MSG_TYPE_ACK from transient federate %d. Connection may have been reset. "
                         "Retrying.",
                         remote_federate_id);
        shutdown_net(net, false);
        net = NULL;
        result = -1;
        lf_sleep(ADDRESS_QUERY_RETRY_INTERVAL);
        continue;
      }
      lf_print_error_and_exit(...);
    }
```

The connection loop now (re)creates the socket at the top of each iteration when `net == NULL`, so the retry uses a fresh connection.

### 2. Guard against duplicate outbound connections

While analyzing option 2, I found that the address-query reply already returns the transient's real port whenever it's known, so `up` connects directly from it. That makes an RTI resend redundant — but it also exposes a latent crash: the startup outbound loop (getting a real port) and a subsequent `DOWNSTREAM_CONNECTED` for the *same* join can both call `lf_connect_to_federate`, opening two connections and pushing the transient past its expected inbound P2P count, aborting it. I added a guard so a second attempt is a no-op when a connection already exists:

```2082:2095:core/src/main/resources/lib/c/reactor-c/core/federated/federate.c
  LF_MUTEX_LOCK(&lf_outbound_net_mutex);
  bool already_connected = _fed.net_for_outbound_p2p_connections[remote_federate_id] != NULL;
  LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
  if (already_connected) {
    LF_PRINT_LOG("Outbound P2P connection to federate %d is already established. Not reconnecting.",
                 remote_federate_id);
    return;
  }
```

# Third batch

This fixes failures in `test/Python/src/federated/TransientDecentralizedDownstreamWithTimer.lf`.

Key finding: `write_to_net_close_on_error` closes the socket fd but does **not** reset `_fed.net_for_outbound_p2p_connections[federate]` to NULL. So after a failed send, `up`'s outbound net to `mid` stays non-NULL but dead. Combined with my new guard (which skips reconnect when the entry is non-NULL), `up` can never reconnect on rejoin. Let me look at `shutdown_net`/`is_net_open` to design the fix safely.

**1. RTI notifies upstreams on abrupt transient disconnect** (`rti_remote.c`, socket-close cleanup):

```1707:1720:core/src/main/resources/lib/c/reactor-c/core/federated/RTI/rti_remote.c
    // Notify downstream and upstream federates that this transient has disconnected, mirroring
    // notify_federate_disconnected(). A transient typically leaves without a MSG_TYPE_RESIGN
    // handshake ...
    for (int j = 0; j < my_fed->enclave.num_immediate_downstreams; j++) {
      federate_info_t* downstream = GET_FED_INFO(my_fed->enclave.immediate_downstreams[j]);
      if (downstream->enclave.state != NOT_CONNECTED) {
        send_upstream_disconnected_locked(downstream, my_fed);
      }
    }
    send_outbound_disconnected_locked(my_fed);
```

This makes both C and Python deterministically reset the stale outbound net (the federate-side handlers are idempotent, so it's safe even if a `RESIGN` also fired).

**2. Harden the duplicate-connection guard** (`federate.c`, `lf_connect_to_federate`) so it only skips when the recorded connection is actually **open**; a stale/closed entry is discarded and replaced. This preserves the double-connect protection while ensuring a transient can always be reconnected after it rejoins:

```2090:2106:core/src/main/resources/lib/c/reactor-c/core/federated/federate.c
  LF_MUTEX_LOCK(&lf_outbound_net_mutex);
  net_abstraction_t existing = _fed.net_for_outbound_p2p_connections[remote_federate_id];
  bool existing_is_open = existing != NULL && is_net_open(existing);
  if (!existing_is_open) {
    _fed.net_for_outbound_p2p_connections[remote_federate_id] = NULL;
  }
  LF_MUTEX_UNLOCK(&lf_outbound_net_mutex);
  if (existing_is_open) {
    ...
    return;
  }
  if (existing != NULL) {
    shutdown_net(existing, false);
  }
```

With fix #1, `up` receives `DOWNSTREAM_DISCONNECTED` (net → NULL) before `mid` rejoins, so on the `DOWNSTREAM_CONNECTED` for the rejoin the guard passes and `up` reconnects to the new `mid` instance.

# Fourth batch

This fixes occasional deadlocks in `src/federated/DistributedPhysicalActionUpstreamLong.lf`.

### Root cause

1. With the **DNET optimization**, a mid-chain federate (`pt10`) stops sending NETs, so the RTI's recorded `next_event` for it goes **stale** (frozen ~7 ms) while the RTI still advances it to `(999999999, MAX)` — one microstep short of the stop tag `(1s,0)` — driven by its **upstream** `pt9`'s tag.
2. When `pt9` (the last upstream) **resigns** at shutdown, `pt10`'s grant falls into the `num_connected_upstream == 0` branch of `tag_advance_grant_if_safe`, which returned the **stale** `next_event`. That grant is behind `last_granted`, so it's redundant and suppressed — `pt10` never gets the final TAG to the stop tag and the federation hangs.

### The fix

In `tag_advance_grant_if_safe` (`rti_common.c`), when a node's immediate upstreams are all disconnected:

```1:1:core/src/main/resources/lib/c/reactor-c/core/federated/RTI/rti_common.c
if (!rti_common->has_transients) { result.tag = FOREVER_TAG; return result; }
```

With no transients, a disconnected upstream has resigned permanently and can never send another message, so the node is safely granted all the way to `FOREVER` (which exceeds `last_granted`/`last_provisionally_granted`, so it isn't suppressed) and can shut down. When transients exist, the original behavior is preserved byte-for-byte (a disconnected upstream might be a transient that reconnects). A new `rti_common_t.has_transients` flag (set from `-nt` in `main.c`) gates this.
