### PR TITLE
Retry connect() on a fresh socket instead of reusing the failed fd

### DIFF
--- a/network/impl/src/socket_common.c
+++ b/network/impl/src/socket_common.c
@@ -278,7 +278,12 @@ int connect_to_socket(int sock, const char* hostname, const struct in_addr* ip_a
       // Retry on a fresh socket, preserving the fd number that the caller
       // holds via dup2(). See #595.
       int fresh = create_real_time_tcp_socket_errexit();
-      dup2(fresh, sock);
+      if (dup2(fresh, sock) < 0) {
+        int dup_errno = errno;
+        close(fresh);
+        errno = dup_errno;
+        lf_print_error_system_failure("Failed to recreate socket with dup2() after connect() failure.");
+      }
       close(fresh);
       lf_sleep(CONNECT_RETRY_INTERVAL);
       lf_print_warning("Could not connect (errno=%d: %s). Will try again every " PRINTF_TIME

--- a/network/impl/src/socket_common.c
+++ b/network/impl/src/socket_common.c
@@ -268,9 +268,22 @@ int connect_to_socket(int sock, const char* hostname, const struct in_addr* ip_a
     }
 
     if (ret < 0) {
+      int connect_errno = errno;
+      // POSIX leaves the state of a socket unspecified after connect() fails:
+      // "If connect() fails, the state of the socket is unspecified. Conforming
+      // applications should close the file descriptor and create a new socket
+      // before attempting to reconnect." On some platforms (observed on macOS)
+      // retrying connect() on the same fd fails on every attempt, so a single
+      // transient failure otherwise becomes permanent until process restart.
+      // Retry on a fresh socket, preserving the fd number that the caller
+      // holds via dup2(). See #595.
+      int fresh = create_real_time_tcp_socket_errexit();
+      dup2(fresh, sock);
+      close(fresh);
       lf_sleep(CONNECT_RETRY_INTERVAL);
-      lf_print_warning("Could not connect. Will try again every " PRINTF_TIME " nanoseconds. Connecting to port %d.\n",
-                       CONNECT_RETRY_INTERVAL, used_port);
+      lf_print_warning("Could not connect (errno=%d: %s). Will try again every " PRINTF_TIME
+                       " nanoseconds. Connecting to port %d.\n",
+                       connect_errno, strerror(connect_errno), CONNECT_RETRY_INTERVAL, used_port);
       continue;
     } else {
       break;


### PR DESCRIPTION
Fixes #595.

`connect_to_socket()` retried `connect()` on the same file descriptor after a failure. POSIX leaves the socket's state unspecified after a failed `connect()` ("Conforming applications should close the file descriptor and create a new socket before attempting to reconnect"), and on macOS the observed consequence is that every subsequent retry on that fd fails: one transient failure makes a federate loop `"Could not connect. Will try again..."` for the entire `CONNECT_TIMEOUT` and then give up with `Failed to connect to RTI` — while the RTI is demonstrably reachable (concurrent fresh-socket connects from the same host succeed throughout; details and the evidence table are in #595). On Linux the same-fd retry happens to recover, which masks the bug in single-machine testing.

This change:
- recreates the socket on each retry via the existing `create_real_time_tcp_socket_errexit()` (so `TCP_NODELAY`, and `TCP_QUICKACK` on Linux, are preserved), using `dup2()` to keep the fd number that callers hold;
- captures `errno` before it can be clobbered and includes `errno`/`strerror` in the retry warning, which made field diagnosis of this path possible for us.

Tested on a two-machine federation (RTI + federate on Linux aarch64, federate on macOS arm64, C target, lfc v0.13.0 with this runtime via `--external-runtime-path`): with the fix, a federate whose first connect fails recovers on a subsequent retry; we also run this patch in a production federation with transient join/leave/rejoin. The late-RTI scenario (federates started before the RTI) continues to work on Linux as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
